### PR TITLE
Fix platform compatibility by using bundled Chromium browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 import { program } from "commander";
 import chalk from "chalk";
 import ora from "ora";
-import { chromium } from "playwright";
+import { chromium } from "playwright-core";
 import { extractBranding } from "./lib/extractors.js";
 import { displayResults } from "./lib/display.js";
 import { writeFileSync, mkdirSync } from "fs";

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -5,7 +5,7 @@
  * Handles bot detection, SPA hydration, and comprehensive design token extraction.
  */
 
-import { chromium } from "playwright";
+import { chromium } from "playwright-core";
 import chalk from "chalk";
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "start": "node index.js",
     "brand-challenge": "node run-no-login-challenge.mjs",
     "brand-challenge:report": "node run-no-login-challenge.mjs || true",
-    "install-browser": "npx playwright install chromium",
-    "postinstall": "npx playwright install chromium --with-deps || echo 'Playwright install failed, you may need to run: npx playwright install chromium'",
+    "install-browser": "npx playwright install chromium || echo 'Playwright browser installation failed. You may need to install system dependencies manually.'",
     "release": "./release.sh"
   },
   "keywords": [
@@ -39,10 +38,11 @@
   "author": "thevangelist <info@esajuhana.com>",
   "license": "MIT",
   "dependencies": {
+    "@playwright/browser-chromium": "^1.57.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "ora": "^7.0.1",
-    "playwright": "^1.40.0"
+    "playwright-core": "^1.57.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Based on PR #21 by @qballer, remvoing Ubunt-specific postinstall hook

What’s changed:
- Dropped the postinstall hook (was using --with-deps for apt)
- Added playwright-core ^1.57.0 (Playwright API)
- Added @playwright/browser-chromium ^1.57.0 (bundled browser)
- Updated imports: 'playwright' → 'playwright-core'
- Fixed install-browser script error handling: | → ||

Whaddayathink?