### PR TITLE
Fix scroll loop missing lazy-loaded content

### DIFF
--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -161,12 +161,16 @@ export async function extractBranding(
         await page.evaluate(async () => {
           const delay = (ms) => new Promise(r => setTimeout(r, ms));
           const scrollStep = 600;
-          const maxHeight = Math.min(document.body.scrollHeight, 30000);
+          const maxScrolls = 200; // safety cap (~120000px)
           let y = 0;
-          while (y < maxHeight) {
-            y = Math.min(y + scrollStep, maxHeight);
+          let scrolls = 0;
+          while (scrolls < maxScrolls) {
+            const currentHeight = document.body.scrollHeight;
+            if (y >= currentHeight) break;
+            y = Math.min(y + scrollStep, currentHeight);
             window.scrollTo(0, y);
             await delay(150 + Math.random() * 100);
+            scrolls++;
           }
           // Scroll back to top
           window.scrollTo(0, 0);


### PR DESCRIPTION
## Summary
- Re-read `document.body.scrollHeight` each scroll iteration instead of capturing it once upfront
- Removes arbitrary 30000px cap; uses iteration cap (200) as safety limit instead

## Test plan
- [ ] Run against a long page with lazy-loaded content (e.g. `node index.js dribbble.com`)
- [ ] Verify "Full page scrolled" message appears and extraction includes below-fold content

🤖 Generated with [Claude Code](https://claude.com/claude-code)