### PR TITLE
Add multi-page extraction (--pages, --sitemap)

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ program
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a screenshot of the page")
-  .option("--pages <n>", "Crawl up to N internal pages (default: 5)", (v) => parseInt(v, 10))
+  .option("--pages <n>", "Crawl up to N internal pages (default: 5)", (v) => {
+    const n = parseInt(v, 10);
+    if (isNaN(n) || n < 1) throw new Error(`--pages must be a positive integer, got: ${v}`);
+    return n;
+  })
   .option("--sitemap", "Discover pages from sitemap.xml instead of DOM links")
   .action(async (input, opts) => {
     let url = input;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ import { extractBranding } from "./lib/extractors.js";
 import { displayResults } from "./lib/display.js";
 import { toW3CFormat } from "./lib/w3c-exporter.js";
 import { generatePDF } from "./lib/pdf.js";
+import { discoverLinks, parseSitemap } from "./lib/discovery.js";
+import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 
@@ -34,6 +36,8 @@ program
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a screenshot of the page")
+  .option("--pages <n>", "Crawl up to N internal pages (default: 5)", (v) => parseInt(v, 10))
+  .option("--sitemap", "Discover pages from sitemap.xml instead of DOM links")
   .action(async (input, opts) => {
     let url = input;
     if (!url.startsWith("http://") && !url.startsWith("https://")) {
@@ -67,13 +71,85 @@ program
         });
 
         try {
+          const isMultiPage = opts.pages || opts.sitemap;
           result = await extractBranding(url, spinner, browser, {
             navigationTimeout: 90000,
             darkMode: opts.darkMode,
             mobile: opts.mobile,
             slow: opts.slow,
             screenshotPath: opts.screenshot,
+            discoverLinks: isMultiPage && !opts.sitemap,
           });
+
+          // Multi-page crawl
+          if (isMultiPage) {
+            const maxPages = opts.pages || 5;
+            spinner.start("Discovering pages...");
+
+            let additionalUrls;
+            if (opts.sitemap) {
+              additionalUrls = await parseSitemap(url, maxPages);
+            } else {
+              // _internalLinks was collected during extraction — score and rank them
+              const rawLinks = result._internalLinks || [];
+              const homepagePath = new URL(url).pathname.replace(/\/$/, '') || '/';
+              const { scoreUrl } = await import('./lib/discovery.js');
+              const seen = new Set([homepagePath]);
+              additionalUrls = rawLinks
+                .filter(href => {
+                  try {
+                    const p = new URL(href).pathname.replace(/\/$/, '') || '/';
+                    if (seen.has(p)) return false;
+                    seen.add(p);
+                    return true;
+                  } catch { return false; }
+                })
+                .map(href => ({ href, score: scoreUrl(new URL(href).pathname) }))
+                .filter(l => l.score >= 0)
+                .sort((a, b) => b.score - a.score)
+                .slice(0, maxPages)
+                .map(l => l.href);
+            }
+
+            delete result._internalLinks;
+
+            if (additionalUrls.length === 0) {
+              spinner.warn("No additional pages discovered");
+            } else {
+              spinner.stop();
+              console.log(chalk.dim(`  Found ${additionalUrls.length} page(s) to analyze`));
+
+              const allResults = [result];
+              for (let i = 0; i < additionalUrls.length; i++) {
+                const pageUrl = additionalUrls[i];
+                const pageNum = i + 2;
+                const total = additionalUrls.length + 1;
+                spinner.start(`Extracting page ${pageNum}/${total}: ${new URL(pageUrl).pathname}`);
+
+                // Polite delay between pages
+                await new Promise(r => setTimeout(r, 2000 + Math.random() * 3000));
+
+                try {
+                  const pageResult = await extractBranding(pageUrl, spinner, browser, {
+                    navigationTimeout: 90000,
+                    darkMode: opts.darkMode,
+                    mobile: opts.mobile,
+                    slow: opts.slow,
+                  });
+                  delete pageResult._internalLinks;
+                  allResults.push(pageResult);
+                } catch (err) {
+                  spinner.warn(`Skipping ${pageUrl}: ${err.message.slice(0, 80)}`);
+                }
+              }
+
+              spinner.stop();
+              result = mergeResults(allResults);
+            }
+          } else {
+            delete result._internalLinks;
+          }
+
           break;
         } catch (err) {
           await browser.close();

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ program
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a screenshot of the page")
-  .option("--pages <n>", "Crawl up to N internal pages (default: 5)", (v) => {
+  .option("--pages <n>", "Analyze up to N total pages including start URL (default: 5)", (v) => {
     const n = parseInt(v, 10);
     if (isNaN(n) || n < 1) throw new Error(`--pages must be a positive integer, got: ${v}`);
     return n;
@@ -76,7 +76,7 @@ program
 
         try {
           const isMultiPage = opts.pages || opts.sitemap;
-          const maxPages = opts.pages || 5;
+          const maxPages = (opts.pages || 5) - 1; // -1 because homepage counts
           result = await extractBranding(url, spinner, browser, {
             navigationTimeout: 90000,
             darkMode: opts.darkMode,
@@ -87,12 +87,18 @@ program
           });
 
           // Multi-page crawl
-          if (isMultiPage) {
+          if (isMultiPage && maxPages > 0) {
             spinner.start("Discovering pages...");
 
             let additionalUrls;
             if (opts.sitemap) {
+              // Try post-redirect URL first, fall back to user-provided URL
+              // (sites like spotify.com redirect browser to open.spotify.com
+              // but sitemap lives at www.spotify.com)
               additionalUrls = await parseSitemap(result.url, maxPages);
+              if (additionalUrls.length === 0 && result.url !== url) {
+                additionalUrls = await parseSitemap(url, maxPages);
+              }
             } else {
               additionalUrls = result._discoveredLinks || [];
             }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import { extractBranding } from "./lib/extractors.js";
 import { displayResults } from "./lib/display.js";
 import { toW3CFormat } from "./lib/w3c-exporter.js";
 import { generatePDF } from "./lib/pdf.js";
-import { scoreUrl, parseSitemap } from "./lib/discovery.js";
+import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
@@ -76,45 +76,28 @@ program
 
         try {
           const isMultiPage = opts.pages || opts.sitemap;
+          const maxPages = opts.pages || 5;
           result = await extractBranding(url, spinner, browser, {
             navigationTimeout: 90000,
             darkMode: opts.darkMode,
             mobile: opts.mobile,
             slow: opts.slow,
             screenshotPath: opts.screenshot,
-            discoverLinks: isMultiPage && !opts.sitemap,
+            discoverLinks: isMultiPage && !opts.sitemap ? maxPages : null,
           });
 
           // Multi-page crawl
           if (isMultiPage) {
-            const maxPages = opts.pages || 5;
             spinner.start("Discovering pages...");
 
             let additionalUrls;
             if (opts.sitemap) {
               additionalUrls = await parseSitemap(url, maxPages);
             } else {
-              // _internalLinks was collected during extraction — score and rank them
-              const rawLinks = result._internalLinks || [];
-              const homepagePath = new URL(url).pathname.replace(/\/$/, '') || '/';
-              const seen = new Set([homepagePath]);
-              additionalUrls = rawLinks
-                .filter(href => {
-                  try {
-                    const p = new URL(href).pathname.replace(/\/$/, '') || '/';
-                    if (seen.has(p)) return false;
-                    seen.add(p);
-                    return true;
-                  } catch { return false; }
-                })
-                .map(href => ({ href, score: scoreUrl(new URL(href).pathname) }))
-                .filter(l => l.score >= 0)
-                .sort((a, b) => b.score - a.score)
-                .slice(0, maxPages)
-                .map(l => l.href);
+              additionalUrls = result._discoveredLinks || [];
             }
 
-            delete result._internalLinks;
+            delete result._discoveredLinks;
 
             if (additionalUrls.length === 0) {
               spinner.warn("No additional pages discovered");
@@ -139,10 +122,10 @@ program
                     mobile: opts.mobile,
                     slow: opts.slow,
                   });
-                  delete pageResult._internalLinks;
+                  delete pageResult._discoveredLinks;
                   allResults.push(pageResult);
                 } catch (err) {
-                  spinner.warn(`Skipping ${pageUrl}: ${err.message.slice(0, 80)}`);
+                  spinner.warn(`Skipping ${pageUrl}: ${String(err?.message || err).slice(0, 80)}`);
                 }
               }
 
@@ -150,7 +133,7 @@ program
               result = mergeResults(allResults);
             }
           } else {
-            delete result._internalLinks;
+            delete result._discoveredLinks;
           }
 
           break;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import { extractBranding } from "./lib/extractors.js";
 import { displayResults } from "./lib/display.js";
 import { toW3CFormat } from "./lib/w3c-exporter.js";
 import { generatePDF } from "./lib/pdf.js";
-import { discoverLinks, parseSitemap } from "./lib/discovery.js";
+import { scoreUrl, parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
@@ -93,7 +93,6 @@ program
               // _internalLinks was collected during extraction — score and rank them
               const rawLinks = result._internalLinks || [];
               const homepagePath = new URL(url).pathname.replace(/\/$/, '') || '/';
-              const { scoreUrl } = await import('./lib/discovery.js');
               const seen = new Set([homepagePath]);
               additionalUrls = rawLinks
                 .filter(href => {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ program
 
             let additionalUrls;
             if (opts.sitemap) {
-              additionalUrls = await parseSitemap(url, maxPages);
+              additionalUrls = await parseSitemap(result.url, maxPages);
             } else {
               additionalUrls = result._discoveredLinks || [];
             }

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -167,6 +167,7 @@ export function formatOklch(oklch, alpha) {
  * @returns {number}
  */
 export function deltaE(hex1, hex2) {
+  if (!hex1 || !hex2) return 999;
   function hexToRgbLocal(hex) {
     hex = hex.replace('#', '');
     if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -160,6 +160,40 @@ export function formatOklch(oklch, alpha) {
 }
 
 /**
+ * Compute CIE76 delta-E perceptual distance between two hex colors.
+ * Returns 0 for identical colors, ~100 for maximally different.
+ * @param {string} hex1 - Hex color string (e.g. "#ff0000")
+ * @param {string} hex2 - Hex color string
+ * @returns {number}
+ */
+export function deltaE(hex1, hex2) {
+  function hexToRgbLocal(hex) {
+    hex = hex.replace('#', '');
+    if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+    return {
+      r: parseInt(hex.slice(0,2), 16),
+      g: parseInt(hex.slice(2,4), 16),
+      b: parseInt(hex.slice(4,6), 16)
+    };
+  }
+  function toLab(hex) {
+    const { r, g, b } = hexToRgbLocal(hex);
+    const lr = srgbToLinear(r);
+    const lg = srgbToLinear(g);
+    const lb = srgbToLinear(b);
+    const xyz = linearRgbToXyz(lr, lg, lb);
+    return xyzToLab(xyz.x, xyz.y, xyz.z);
+  }
+  const lab1 = toLab(hex1);
+  const lab2 = toLab(hex2);
+  return Math.sqrt(
+    Math.pow(lab1.l - lab2.l, 2) +
+    Math.pow(lab1.a - lab2.a, 2) +
+    Math.pow(lab1.b - lab2.b, 2)
+  );
+}
+
+/**
  * Parse a hex color string and return RGB values
  * @param {string} hex - Hex color (#fff, #ffffff, #ffffffaa)
  * @returns {{ r: number, g: number, b: number, a?: number } | null}

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -167,26 +167,18 @@ export function formatOklch(oklch, alpha) {
  * @returns {number}
  */
 export function deltaE(hex1, hex2) {
-  if (!hex1 || !hex2) return 999;
-  function hexToRgbLocal(hex) {
-    hex = hex.replace('#', '');
-    if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
-    return {
-      r: parseInt(hex.slice(0,2), 16),
-      g: parseInt(hex.slice(2,4), 16),
-      b: parseInt(hex.slice(4,6), 16)
-    };
-  }
   function toLab(hex) {
-    const { r, g, b } = hexToRgbLocal(hex);
-    const lr = srgbToLinear(r);
-    const lg = srgbToLinear(g);
-    const lb = srgbToLinear(b);
+    const rgb = hexToRgb(hex);
+    if (!rgb) return null;
+    const lr = srgbToLinear(rgb.r);
+    const lg = srgbToLinear(rgb.g);
+    const lb = srgbToLinear(rgb.b);
     const xyz = linearRgbToXyz(lr, lg, lb);
     return xyzToLab(xyz.x, xyz.y, xyz.z);
   }
   const lab1 = toLab(hex1);
   const lab2 = toLab(hex2);
+  if (!lab1 || !lab2) return 999;
   return Math.sqrt(
     Math.pow(lab1.l - lab2.l, 2) +
     Math.pow(lab1.a - lab2.a, 2) +

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -1,0 +1,186 @@
+/**
+ * Page Discovery
+ *
+ * Discovers internal pages from a starting URL via DOM link extraction
+ * or sitemap.xml parsing.
+ */
+
+/**
+ * Score a URL path for importance (higher = more important).
+ * Prioritizes shallow, navigational paths over blog posts / legal pages.
+ */
+export function scoreUrl(pathname) {
+  const lc = pathname.toLowerCase();
+
+  // Exclude noise
+  const exclude = [
+    /\/(login|signin|sign-in|signup|sign-up|register|auth)/,
+    /\/(terms|privacy|legal|cookie|gdpr|tos)/,
+    /\/(cdn-cgi|wp-admin|wp-content|wp-json)/,
+    /\.(pdf|jpg|jpeg|png|gif|svg|webp|zip|tar|gz|mp4|mp3)$/,
+    /\/tag\//,
+    /\/author\//,
+    /\/page\/\d+/,
+    /\?/,  // query strings (shouldn't appear here but safety)
+  ];
+  if (exclude.some(r => r.test(lc))) return -1;
+
+  let score = 100;
+
+  // Prefer shallow paths
+  const depth = (pathname.match(/\//g) || []).length;
+  score -= depth * 10;
+
+  // Boost key navigational pages
+  const boosts = [
+    [/^\/(pricing|plans?|cost)/, 30],
+    [/^\/(about|company|team|story)/, 25],
+    [/^\/(product|features?|solutions?)/, 25],
+    [/^\/(enterprise|business|platform)/, 20],
+    [/^\/(contact|demo|trial|start)/, 20],
+    [/^\/(docs|documentation|developers?|api)/, 15],
+    [/^\/(blog|resources|insights|news)/, 10],
+  ];
+  for (const [re, boost] of boosts) {
+    if (re.test(lc)) { score += boost; break; }
+  }
+
+  return score;
+}
+
+/**
+ * Discover internal links from an already-loaded Playwright page.
+ * Call after extractBranding() has loaded and scrolled the page.
+ *
+ * @param {import('playwright-core').Page} page
+ * @param {string} baseUrl - The starting URL (used to determine same-origin)
+ * @param {number} maxPages - Maximum number of URLs to return
+ * @returns {Promise<string[]>} Ordered list of URLs to crawl (excluding homepage)
+ */
+export async function discoverLinks(page, baseUrl, maxPages) {
+  const origin = new URL(baseUrl).origin;
+
+  const links = await page.evaluate((origin) => {
+    const results = [];
+    const navSelectors = [
+      'nav a', 'header a', 'footer a',
+      '[role="navigation"] a', '[aria-label*="nav"] a',
+      '[data-nav] a', '.nav a', '.navbar a', '.header a', '.menu a',
+    ];
+
+    // Score links by location: nav/header/footer = 2, elsewhere = 1
+    const scored = new Map(); // pathname → { href, locationScore }
+
+    function addLinks(selector, locationScore) {
+      document.querySelectorAll(selector).forEach(a => {
+        try {
+          const url = new URL(a.href);
+          if (url.origin !== origin) return;
+          const pathname = url.pathname.replace(/\/$/, '') || '/';
+          if (!scored.has(pathname) || scored.get(pathname).locationScore < locationScore) {
+            scored.set(pathname, { href: url.origin + pathname, locationScore });
+          }
+        } catch {}
+      });
+    }
+
+    navSelectors.forEach(sel => addLinks(sel, 2));
+    addLinks('a[href]', 1);
+
+    scored.forEach(({ href, locationScore }, pathname) => {
+      results.push({ href, pathname, locationScore });
+    });
+
+    return results;
+  }, origin);
+
+  // Remove homepage itself
+  const homepagePath = new URL(baseUrl).pathname.replace(/\/$/, '') || '/';
+
+  const scored = links
+    .filter(l => l.pathname !== homepagePath)
+    .map(l => ({ ...l, score: scoreUrl(l.pathname) + (l.locationScore * 5) }))
+    .filter(l => l.score >= 0)
+    .sort((a, b) => b.score - a.score);
+
+  return scored.slice(0, maxPages).map(l => l.href);
+}
+
+/**
+ * Discover pages from a site's sitemap.xml.
+ *
+ * @param {string} baseUrl - The starting URL
+ * @param {number} maxPages - Maximum number of URLs to return
+ * @returns {Promise<string[]>} List of URLs from sitemap (excluding homepage)
+ */
+export async function parseSitemap(baseUrl, maxPages) {
+  const base = new URL(baseUrl);
+  const sitemapUrl = `${base.origin}/sitemap.xml`;
+
+  let xml;
+  try {
+    const res = await fetch(sitemapUrl, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Dembrandt/1.0)' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) return [];
+    xml = await res.text();
+  } catch {
+    return [];
+  }
+
+  // If it's a sitemap index, fetch child sitemaps
+  const isSitemapIndex = xml.includes('<sitemapindex');
+  let allXml = xml;
+
+  if (isSitemapIndex) {
+    const childUrls = [...xml.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
+      .map(m => m[1].trim())
+      .filter(u => u.includes(base.hostname))
+      .slice(0, 3); // only first 3 child sitemaps
+
+    const childXmls = await Promise.all(
+      childUrls.map(u =>
+        fetch(u, { signal: AbortSignal.timeout(8000) })
+          .then(r => r.text())
+          .catch(() => '')
+      )
+    );
+    allXml = childXmls.join('\n');
+  }
+
+  const homepagePath = base.pathname.replace(/\/$/, '') || '/';
+
+  const urls = [...allXml.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
+    .map(m => m[1].trim())
+    .filter(u => {
+      try {
+        const parsed = new URL(u);
+        return parsed.hostname === base.hostname;
+      } catch { return false; }
+    })
+    .map(u => {
+      // Normalize: strip trailing slash, query, hash
+      const p = new URL(u);
+      return p.origin + (p.pathname.replace(/\/$/, '') || '/');
+    });
+
+  // Deduplicate
+  const seen = new Set();
+  const deduped = [];
+  for (const u of urls) {
+    const path = new URL(u).pathname;
+    if (path === homepagePath) continue;
+    if (seen.has(u)) continue;
+    seen.add(u);
+    deduped.push(u);
+  }
+
+  // Score and sort
+  const scored = deduped
+    .map(u => ({ href: u, score: scoreUrl(new URL(u).pathname) }))
+    .filter(l => l.score >= 0)
+    .sort((a, b) => b.score - a.score);
+
+  return scored.slice(0, maxPages).map(l => l.href);
+}

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -136,7 +136,9 @@ export async function parseSitemap(baseUrl, maxPages) {
   if (isSitemapIndex) {
     const childUrls = [...xml.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
       .map(m => m[1].trim())
-      .filter(u => u.includes(base.hostname))
+      .filter(u => {
+        try { return new URL(u).hostname === base.hostname; } catch { return false; }
+      })
       .slice(0, 3); // only first 3 child sitemaps
 
     const childXmls = await Promise.all(

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -106,49 +106,111 @@ export async function discoverLinks(page, baseUrl, maxPages) {
   return scored.slice(0, maxPages).map(l => l.href);
 }
 
+const FETCH_OPTS = {
+  headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Dembrandt/1.0)' },
+};
+
+/**
+ * Discover sitemap URLs by checking robots.txt first, then common paths.
+ * Returns the first sitemap XML that responds successfully.
+ */
+async function findSitemapUrls(origin) {
+  // 1. Check robots.txt for Sitemap: directives
+  try {
+    const res = await fetch(`${origin}/robots.txt`, {
+      ...FETCH_OPTS,
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.ok) {
+      const text = await res.text();
+      const sitemaps = [...text.matchAll(/^Sitemap:\s*(.+)$/gmi)]
+        .map(m => m[1].trim())
+        .filter(u => u.startsWith('http'));
+      if (sitemaps.length > 0) return sitemaps;
+    }
+  } catch {}
+
+  // 2. Fall back to common sitemap locations
+  return [
+    `${origin}/sitemap.xml`,
+    `${origin}/sitemap_index.xml`,
+    `${origin}/sitemap/sitemap-index.xml`,
+  ];
+}
+
+/**
+ * Fetch a single sitemap URL, returning its XML text or empty string.
+ */
+async function fetchSitemap(url) {
+  try {
+    const res = await fetch(url, {
+      ...FETCH_OPTS,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) return '';
+    const text = await res.text();
+    return text.includes('<') ? text : ''; // sanity check for XML
+  } catch {
+    return '';
+  }
+}
+
 /**
  * Discover pages from a site's sitemap.xml.
+ * Checks robots.txt for Sitemap directives, then tries common paths.
+ * Follows sitemapindex references one level deep.
  *
- * @param {string} baseUrl - The starting URL
+ * @param {string} baseUrl - The starting URL (should be post-redirect)
  * @param {number} maxPages - Maximum number of URLs to return
  * @returns {Promise<string[]>} List of URLs from sitemap (excluding homepage)
  */
 export async function parseSitemap(baseUrl, maxPages) {
   const base = new URL(baseUrl);
-  const sitemapUrl = `${base.origin}/sitemap.xml`;
 
-  let xml;
-  try {
-    const res = await fetch(sitemapUrl, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Dembrandt/1.0)' },
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!res.ok) return [];
-    xml = await res.text();
-  } catch {
-    return [];
+  // Find and fetch sitemap(s)
+  const candidates = await findSitemapUrls(base.origin);
+  let xml = '';
+  for (const candidate of candidates) {
+    xml = await fetchSitemap(candidate);
+    if (xml) break;
+  }
+  if (!xml) return [];
+
+  // Also accept www/non-www variants of the same domain
+  const acceptedHostnames = new Set([base.hostname]);
+  if (base.hostname.startsWith('www.')) {
+    acceptedHostnames.add(base.hostname.slice(4));
+  } else {
+    acceptedHostnames.add('www.' + base.hostname);
   }
 
-  // If it's a sitemap index, fetch child sitemaps
-  const isSitemapIndex = xml.includes('<sitemapindex');
+  // Expand sitemapindex references up to two levels deep
   let allXml = xml;
-
-  if (isSitemapIndex) {
-    const childUrls = [...xml.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
+  if (xml.includes('<sitemapindex')) {
+    const extractLocs = (text) => [...text.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
       .map(m => m[1].trim())
-      .filter(u => {
-        try { return new URL(u).hostname === base.hostname; } catch { return false; }
-      })
-      .slice(0, 3); // only first 3 child sitemaps
+      .filter(u => { try { return acceptedHostnames.has(new URL(u).hostname); } catch { return false; } });
 
-    const childXmls = await Promise.all(
-      childUrls.map(u =>
-        fetch(u, { signal: AbortSignal.timeout(8000) })
-          .then(r => r.text())
-          .catch(() => '')
-      )
-    );
-    allXml = childXmls.join('\n');
+    const childUrls = extractLocs(xml).slice(0, 10);
+    const childXmls = await Promise.all(childUrls.map(u => fetchSitemap(u)));
+
+    // Check if children are also sitemapindex (e.g. Spotify's 3-level hierarchy)
+    const grandchildFetches = [];
+    const pageXmls = [];
+    for (const childXml of childXmls) {
+      if (!childXml) continue;
+      if (childXml.includes('<sitemapindex')) {
+        const gcUrls = extractLocs(childXml).slice(0, 3);
+        grandchildFetches.push(...gcUrls.map(u => fetchSitemap(u)));
+      } else {
+        pageXmls.push(childXml);
+      }
+    }
+    if (grandchildFetches.length > 0) {
+      const gcXmls = await Promise.all(grandchildFetches);
+      pageXmls.push(...gcXmls);
+    }
+    allXml = pageXmls.join('\n');
   }
 
   const homepagePath = base.pathname.replace(/\/$/, '') || '/';
@@ -156,13 +218,10 @@ export async function parseSitemap(baseUrl, maxPages) {
   const urls = [...allXml.matchAll(/<loc>\s*(https?:\/\/[^<]+)\s*<\/loc>/g)]
     .map(m => m[1].trim())
     .filter(u => {
-      try {
-        const parsed = new URL(u);
-        return parsed.hostname === base.hostname;
-      } catch { return false; }
+      try { return acceptedHostnames.has(new URL(u).hostname); }
+      catch { return false; }
     })
     .map(u => {
-      // Normalize: strip trailing slash, query, hash
       const p = new URL(u);
       return p.origin + (p.pathname.replace(/\/$/, '') || '/');
     });

--- a/lib/display.js
+++ b/lib/display.js
@@ -33,6 +33,10 @@ export function displayResults(data) {
     second: '2-digit'
   });
   console.log(chalk.dim('├─') + ' ' + chalk.dim(timeString));
+  if (data.pages && data.pages.length > 1) {
+    const paths = data.pages.map(p => new URL(p.url).pathname || '/').join(', ');
+    console.log(chalk.dim('├─') + ' ' + chalk.dim(`${data.pages.length} pages: ${paths}`));
+  }
   console.log(chalk.dim('│'));
 
   displayLogo(data.logo);
@@ -210,32 +214,23 @@ function displayColors(colors) {
 
   const uniqueColors = Array.from(colorMap.values());
 
-  // Display all colors with hex, RGB, LCH, and OKLCH formats
+  // Display all colors — one line per color with all formats inline
   uniqueColors.forEach(({ hex, rgb, lch, oklch, label, confidence }, index) => {
     const isLast = index === uniqueColors.length - 1;
     const branch = isLast ? '└─' : '├─';
-    const indent = isLast ? '   ' : '│  ';
 
     try {
       const colorBlock = chalk.bgHex(hex)('  ');
       let conf;
       if (confidence === 'high') conf = chalk.hex('#50FA7B')('●');
       else if (confidence === 'medium') conf = chalk.hex('#FFB86C')('●');
-      else conf = chalk.gray('●'); // low confidence
+      else conf = chalk.gray('●');
 
       const labelText = label ? chalk.dim(` ${label}`) : '';
-
-      // First line: color swatch, hex, and label
-      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${colorBlock} ${hex}${labelText}`);
-      // Second line: RGB and LCH
-      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('rgb:   ') + rgb);
-      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('lch:   ') + lch);
-      console.log(chalk.dim(`│  ${indent}└─`) + ' ' + chalk.dim('oklch: ') + oklch);
+      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${colorBlock} ${hex}  ${chalk.dim(rgb)}  ${chalk.dim(oklch)}${labelText}`);
     } catch {
-      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${hex} ${label ? chalk.dim(label) : ''}`);
-      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('rgb:   ') + rgb);
-      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('lch:   ') + lch);
-      console.log(chalk.dim(`│  ${indent}└─`) + ' ' + chalk.dim('oklch: ') + oklch);
+      const labelText = label ? chalk.dim(` ${label}`) : '';
+      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${hex}  ${chalk.dim(rgb)}  ${chalk.dim(oklch)}${labelText}`);
     }
   });
 
@@ -321,43 +316,18 @@ function displayTypography(typography) {
           const styleBranch = isStyleLast ? '└─' : '├─';
           const propIndent = isStyleLast ? '   ' : '│  ';
 
-          // Main size line
-          console.log(chalk.dim(`│  ${styleIndent}${contextIndent}${styleBranch}`) + ' ' + `${style.size}`);
+          // Size line with all properties inline
+          const parts = [style.size];
+          if (style.weight && style.weight !== 400) parts.push(`w:${style.weight}`);
+          if (style.lineHeight) parts.push(`lh:${style.lineHeight}`);
+          if (style.transform) parts.push(style.transform);
+          if (style.spacing) parts.push(`ls:${style.spacing}`);
+          if (style.isFluid) parts.push('fluid');
+          if (style.fontFeatures) parts.push(`feat:${style.fontFeatures}`);
 
-          // Collect properties
-          const props = [];
-          if (style.weight && style.weight !== 400) {
-            props.push({ key: 'weight', value: style.weight });
-          }
-          if (style.lineHeight) {
-            const lh = parseFloat(style.lineHeight);
-            let lhLabel = '';
-            if (lh <= 1.3) lhLabel = ' (tight)';
-            else if (lh >= 1.6) lhLabel = ' (relaxed)';
-            props.push({ key: 'line-height', value: `${style.lineHeight}${lhLabel}` });
-          }
-          if (style.transform) {
-            props.push({ key: 'transform', value: style.transform });
-          }
-          if (style.spacing) {
-            props.push({ key: 'letter-spacing', value: style.spacing });
-          }
-          if (style.isFluid) {
-            props.push({ key: 'fluid', value: 'yes' });
-          }
-          if (style.fontFeatures) {
-            props.push({ key: 'features', value: style.fontFeatures });
-          }
-
-          // Display properties
-          props.forEach((prop, propIndex) => {
-            const isLastProp = propIndex === props.length - 1;
-            const propBranch = isLastProp ? '└─' : '├─';
-            console.log(
-              chalk.dim(`│  ${styleIndent}${contextIndent}${propIndent}${propBranch}`) + ' ' +
-              chalk.dim(`${prop.key}: `) + `${prop.value}`
-            );
-          });
+          const sizeText = parts[0];
+          const propsText = parts.slice(1).length > 0 ? '  ' + chalk.dim(parts.slice(1).join('  ')) : '';
+          console.log(chalk.dim(`│  ${styleIndent}${contextIndent}${styleBranch}`) + ' ' + sizeText + propsText);
         });
       }
     }
@@ -517,18 +487,16 @@ function displayButtons(buttons) {
       const stateBranch = isLastState ? '└─' : '├─';
       const stateIndent = isLastState ? '   ' : '│  ';
 
-      console.log(chalk.dim(`│  ${btnIndent}${stateBranch}`) + ' ' + chalk.hex('#8BE9FD')(stateInfo.label));
+      // Collect all properties inline
+      const parts = [];
 
-      const props = [];
-
-      // Only show properties that exist and are meaningful
       if (state.backgroundColor && state.backgroundColor !== 'rgba(0, 0, 0, 0)' && state.backgroundColor !== 'transparent') {
         try {
           const formats = normalizeColorFormat(state.backgroundColor);
           const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
+          parts.push(`bg:${colorBlock} ${formats.hex}`);
         } catch {
-          props.push({ key: 'bg', value: state.backgroundColor });
+          parts.push(`bg:${state.backgroundColor}`);
         }
       }
 
@@ -536,53 +504,31 @@ function displayButtons(buttons) {
         try {
           const formats = normalizeColorFormat(state.color);
           const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'text', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
+          parts.push(`text:${colorBlock} ${formats.hex}`);
         } catch {
-          props.push({ key: 'text', value: state.color });
+          parts.push(`text:${state.color}`);
         }
       }
 
       if (stateInfo.key === 'default') {
-        if (state.padding && state.padding !== '0px') {
-          props.push({ key: 'padding', value: state.padding });
-        }
-        if (state.borderRadius && state.borderRadius !== '0px') {
-          props.push({ key: 'radius', value: state.borderRadius });
-        }
+        if (state.padding && state.padding !== '0px') parts.push(`pad:${state.padding}`);
+        if (state.borderRadius && state.borderRadius !== '0px') parts.push(`r:${state.borderRadius}`);
       }
 
       if (state.border && state.border !== 'none' && !state.border.includes('0px')) {
-        props.push({ key: 'border', value: state.border });
+        parts.push(`border:${state.border}`);
       }
 
       if (state.boxShadow && state.boxShadow !== 'none') {
-        const shortShadow = state.boxShadow.length > 40
-          ? state.boxShadow.substring(0, 37) + '...'
-          : state.boxShadow;
-        props.push({ key: 'shadow', value: shortShadow });
+        const short = state.boxShadow.length > 30 ? state.boxShadow.substring(0, 27) + '...' : state.boxShadow;
+        parts.push(`shadow:${short}`);
       }
 
-      if (state.outline && state.outline !== 'none') {
-        props.push({ key: 'outline', value: state.outline });
-      }
+      if (state.outline && state.outline !== 'none') parts.push(`outline:${state.outline}`);
+      if (state.transform && state.transform !== 'none') parts.push(`transform:${state.transform}`);
+      if (state.opacity && state.opacity !== '1') parts.push(`opacity:${state.opacity}`);
 
-      if (state.transform && state.transform !== 'none') {
-        props.push({ key: 'transform', value: state.transform });
-      }
-
-      if (state.opacity && state.opacity !== '1') {
-        props.push({ key: 'opacity', value: state.opacity });
-      }
-
-      // Display properties
-      props.forEach((prop, propIndex) => {
-        const isLastProp = propIndex === props.length - 1;
-        const propBranch = isLastProp ? '└─' : '├─';
-        console.log(
-          chalk.dim(`│  ${btnIndent}${stateIndent}${propBranch}`) + ' ' +
-          chalk.dim(`${prop.key}: `) + `${prop.value}`
-        );
-      });
+      console.log(chalk.dim(`│  ${btnIndent}${stateBranch}`) + ' ' + chalk.hex('#8BE9FD')(stateInfo.label) + '  ' + parts.join('  '));
     });
   });
 
@@ -891,57 +837,27 @@ function displayLinks(links) {
       console.log(chalk.dim(`│  ${linkBranch}`) + ' ' + `${link.color}`);
     }
 
-    // Display default state
-    if (link.states && link.states.default) {
-      const defaultState = link.states.default;
-      const hasHover = link.states.hover;
-      const hasDecoration = defaultState.textDecoration && defaultState.textDecoration !== 'none';
-
-      // Only show default state if there's decoration or hover state
-      if (hasDecoration || hasHover) {
-        console.log(chalk.dim(`│  ${linkIndent}├─`) + ' ' + chalk.hex('#8BE9FD')('Default'));
-
-        if (hasDecoration) {
-          const decorBranch = hasHover ? '├─' : '└─';
-          console.log(chalk.dim(`│  ${linkIndent}│  ${decorBranch}`) + ' ' + chalk.dim(`decoration: ${defaultState.textDecoration}`));
+    // Inline default and hover info
+    const infoParts = [];
+    if (link.states?.default?.textDecoration && link.states.default.textDecoration !== 'none') {
+      infoParts.push(chalk.dim(`decoration:${link.states.default.textDecoration}`));
+    }
+    if (link.states?.hover) {
+      const hover = link.states.hover;
+      if (hover.color) {
+        try {
+          const hf = normalizeColorFormat(hover.color);
+          infoParts.push(chalk.dim(`hover:`) + chalk.bgHex(hf.hex)('  ') + ` ${hf.hex}`);
+        } catch {
+          infoParts.push(chalk.dim(`hover:${hover.color}`));
         }
       }
-
-      // Display hover state if available
-      if (hasHover) {
-        const hoverState = link.states.hover;
-        console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + chalk.hex('#8BE9FD')('Hover'));
-
-        const hoverProps = [];
-
-        if (hoverState.color) {
-          try {
-            const formats = normalizeColorFormat(hoverState.color);
-            const colorBlock = chalk.bgHex(formats.hex)('  ');
-            hoverProps.push({ key: 'color', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-          } catch {
-            hoverProps.push({ key: 'color', value: hoverState.color });
-          }
-        }
-
-        if (hoverState.textDecoration) {
-          hoverProps.push({ key: 'decoration', value: hoverState.textDecoration });
-        }
-
-        hoverProps.forEach((prop, propIndex) => {
-          const isLastProp = propIndex === hoverProps.length - 1;
-          const propBranch = isLastProp ? '└─' : '├─';
-          console.log(
-            chalk.dim(`│  ${linkIndent}   ${propBranch}`) + ' ' +
-            chalk.dim(`${prop.key}: `) + `${prop.value}`
-          );
-        });
-      }
-    } else {
-      // Fallback for old format
-      if (link.textDecoration && link.textDecoration !== 'none') {
-        console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + chalk.dim(`decoration: ${link.textDecoration}`));
-      }
+      if (hover.textDecoration) infoParts.push(chalk.dim(`hover-decoration:${hover.textDecoration}`));
+    } else if (link.textDecoration && link.textDecoration !== 'none') {
+      infoParts.push(chalk.dim(`decoration:${link.textDecoration}`));
+    }
+    if (infoParts.length > 0) {
+      console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + infoParts.join('  '));
     }
   });
 

--- a/lib/display.js
+++ b/lib/display.js
@@ -214,23 +214,32 @@ function displayColors(colors) {
 
   const uniqueColors = Array.from(colorMap.values());
 
-  // Display all colors — one line per color with all formats inline
+  // Display all colors with hex, RGB, LCH, and OKLCH formats
   uniqueColors.forEach(({ hex, rgb, lch, oklch, label, confidence }, index) => {
     const isLast = index === uniqueColors.length - 1;
     const branch = isLast ? '└─' : '├─';
+    const indent = isLast ? '   ' : '│  ';
 
     try {
       const colorBlock = chalk.bgHex(hex)('  ');
       let conf;
       if (confidence === 'high') conf = chalk.hex('#50FA7B')('●');
       else if (confidence === 'medium') conf = chalk.hex('#FFB86C')('●');
-      else conf = chalk.gray('●');
+      else conf = chalk.gray('●'); // low confidence
 
       const labelText = label ? chalk.dim(` ${label}`) : '';
-      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${colorBlock} ${hex}  ${chalk.dim(rgb)}  ${chalk.dim(oklch)}${labelText}`);
+
+      // First line: color swatch, hex, and label
+      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${colorBlock} ${hex}${labelText}`);
+      // Second line: RGB and LCH
+      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('rgb:   ') + rgb);
+      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('lch:   ') + lch);
+      console.log(chalk.dim(`│  ${indent}└─`) + ' ' + chalk.dim('oklch: ') + oklch);
     } catch {
-      const labelText = label ? chalk.dim(` ${label}`) : '';
-      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${hex}  ${chalk.dim(rgb)}  ${chalk.dim(oklch)}${labelText}`);
+      console.log(chalk.dim(`│  ${branch}`) + ' ' + `${hex} ${label ? chalk.dim(label) : ''}`);
+      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('rgb:   ') + rgb);
+      console.log(chalk.dim(`│  ${indent}├─`) + ' ' + chalk.dim('lch:   ') + lch);
+      console.log(chalk.dim(`│  ${indent}└─`) + ' ' + chalk.dim('oklch: ') + oklch);
     }
   });
 
@@ -316,18 +325,43 @@ function displayTypography(typography) {
           const styleBranch = isStyleLast ? '└─' : '├─';
           const propIndent = isStyleLast ? '   ' : '│  ';
 
-          // Size line with all properties inline
-          const parts = [style.size];
-          if (style.weight && style.weight !== 400) parts.push(`w:${style.weight}`);
-          if (style.lineHeight) parts.push(`lh:${style.lineHeight}`);
-          if (style.transform) parts.push(style.transform);
-          if (style.spacing) parts.push(`ls:${style.spacing}`);
-          if (style.isFluid) parts.push('fluid');
-          if (style.fontFeatures) parts.push(`feat:${style.fontFeatures}`);
+          // Main size line
+          console.log(chalk.dim(`│  ${styleIndent}${contextIndent}${styleBranch}`) + ' ' + `${style.size}`);
 
-          const sizeText = parts[0];
-          const propsText = parts.slice(1).length > 0 ? '  ' + chalk.dim(parts.slice(1).join('  ')) : '';
-          console.log(chalk.dim(`│  ${styleIndent}${contextIndent}${styleBranch}`) + ' ' + sizeText + propsText);
+          // Collect properties
+          const props = [];
+          if (style.weight && style.weight !== 400) {
+            props.push({ key: 'weight', value: style.weight });
+          }
+          if (style.lineHeight) {
+            const lh = parseFloat(style.lineHeight);
+            let lhLabel = '';
+            if (lh <= 1.3) lhLabel = ' (tight)';
+            else if (lh >= 1.6) lhLabel = ' (relaxed)';
+            props.push({ key: 'line-height', value: `${style.lineHeight}${lhLabel}` });
+          }
+          if (style.transform) {
+            props.push({ key: 'transform', value: style.transform });
+          }
+          if (style.spacing) {
+            props.push({ key: 'letter-spacing', value: style.spacing });
+          }
+          if (style.isFluid) {
+            props.push({ key: 'fluid', value: 'yes' });
+          }
+          if (style.fontFeatures) {
+            props.push({ key: 'features', value: style.fontFeatures });
+          }
+
+          // Display properties
+          props.forEach((prop, propIndex) => {
+            const isLastProp = propIndex === props.length - 1;
+            const propBranch = isLastProp ? '└─' : '├─';
+            console.log(
+              chalk.dim(`│  ${styleIndent}${contextIndent}${propIndent}${propBranch}`) + ' ' +
+              chalk.dim(`${prop.key}: `) + `${prop.value}`
+            );
+          });
         });
       }
     }
@@ -487,16 +521,18 @@ function displayButtons(buttons) {
       const stateBranch = isLastState ? '└─' : '├─';
       const stateIndent = isLastState ? '   ' : '│  ';
 
-      // Collect all properties inline
-      const parts = [];
+      console.log(chalk.dim(`│  ${btnIndent}${stateBranch}`) + ' ' + chalk.hex('#8BE9FD')(stateInfo.label));
 
+      const props = [];
+
+      // Only show properties that exist and are meaningful
       if (state.backgroundColor && state.backgroundColor !== 'rgba(0, 0, 0, 0)' && state.backgroundColor !== 'transparent') {
         try {
           const formats = normalizeColorFormat(state.backgroundColor);
           const colorBlock = chalk.bgHex(formats.hex)('  ');
-          parts.push(`bg:${colorBlock} ${formats.hex}`);
+          props.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
         } catch {
-          parts.push(`bg:${state.backgroundColor}`);
+          props.push({ key: 'bg', value: state.backgroundColor });
         }
       }
 
@@ -504,31 +540,53 @@ function displayButtons(buttons) {
         try {
           const formats = normalizeColorFormat(state.color);
           const colorBlock = chalk.bgHex(formats.hex)('  ');
-          parts.push(`text:${colorBlock} ${formats.hex}`);
+          props.push({ key: 'text', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
         } catch {
-          parts.push(`text:${state.color}`);
+          props.push({ key: 'text', value: state.color });
         }
       }
 
       if (stateInfo.key === 'default') {
-        if (state.padding && state.padding !== '0px') parts.push(`pad:${state.padding}`);
-        if (state.borderRadius && state.borderRadius !== '0px') parts.push(`r:${state.borderRadius}`);
+        if (state.padding && state.padding !== '0px') {
+          props.push({ key: 'padding', value: state.padding });
+        }
+        if (state.borderRadius && state.borderRadius !== '0px') {
+          props.push({ key: 'radius', value: state.borderRadius });
+        }
       }
 
       if (state.border && state.border !== 'none' && !state.border.includes('0px')) {
-        parts.push(`border:${state.border}`);
+        props.push({ key: 'border', value: state.border });
       }
 
       if (state.boxShadow && state.boxShadow !== 'none') {
-        const short = state.boxShadow.length > 30 ? state.boxShadow.substring(0, 27) + '...' : state.boxShadow;
-        parts.push(`shadow:${short}`);
+        const shortShadow = state.boxShadow.length > 40
+          ? state.boxShadow.substring(0, 37) + '...'
+          : state.boxShadow;
+        props.push({ key: 'shadow', value: shortShadow });
       }
 
-      if (state.outline && state.outline !== 'none') parts.push(`outline:${state.outline}`);
-      if (state.transform && state.transform !== 'none') parts.push(`transform:${state.transform}`);
-      if (state.opacity && state.opacity !== '1') parts.push(`opacity:${state.opacity}`);
+      if (state.outline && state.outline !== 'none') {
+        props.push({ key: 'outline', value: state.outline });
+      }
 
-      console.log(chalk.dim(`│  ${btnIndent}${stateBranch}`) + ' ' + chalk.hex('#8BE9FD')(stateInfo.label) + '  ' + parts.join('  '));
+      if (state.transform && state.transform !== 'none') {
+        props.push({ key: 'transform', value: state.transform });
+      }
+
+      if (state.opacity && state.opacity !== '1') {
+        props.push({ key: 'opacity', value: state.opacity });
+      }
+
+      // Display properties
+      props.forEach((prop, propIndex) => {
+        const isLastProp = propIndex === props.length - 1;
+        const propBranch = isLastProp ? '└─' : '├─';
+        console.log(
+          chalk.dim(`│  ${btnIndent}${stateIndent}${propBranch}`) + ' ' +
+          chalk.dim(`${prop.key}: `) + `${prop.value}`
+        );
+      });
     });
   });
 
@@ -837,27 +895,57 @@ function displayLinks(links) {
       console.log(chalk.dim(`│  ${linkBranch}`) + ' ' + `${link.color}`);
     }
 
-    // Inline default and hover info
-    const infoParts = [];
-    if (link.states?.default?.textDecoration && link.states.default.textDecoration !== 'none') {
-      infoParts.push(chalk.dim(`decoration:${link.states.default.textDecoration}`));
-    }
-    if (link.states?.hover) {
-      const hover = link.states.hover;
-      if (hover.color) {
-        try {
-          const hf = normalizeColorFormat(hover.color);
-          infoParts.push(chalk.dim(`hover:`) + chalk.bgHex(hf.hex)('  ') + ` ${hf.hex}`);
-        } catch {
-          infoParts.push(chalk.dim(`hover:${hover.color}`));
+    // Display default state
+    if (link.states && link.states.default) {
+      const defaultState = link.states.default;
+      const hasHover = link.states.hover;
+      const hasDecoration = defaultState.textDecoration && defaultState.textDecoration !== 'none';
+
+      // Only show default state if there's decoration or hover state
+      if (hasDecoration || hasHover) {
+        console.log(chalk.dim(`│  ${linkIndent}├─`) + ' ' + chalk.hex('#8BE9FD')('Default'));
+
+        if (hasDecoration) {
+          const decorBranch = hasHover ? '├─' : '└─';
+          console.log(chalk.dim(`│  ${linkIndent}│  ${decorBranch}`) + ' ' + chalk.dim(`decoration: ${defaultState.textDecoration}`));
         }
       }
-      if (hover.textDecoration) infoParts.push(chalk.dim(`hover-decoration:${hover.textDecoration}`));
-    } else if (link.textDecoration && link.textDecoration !== 'none') {
-      infoParts.push(chalk.dim(`decoration:${link.textDecoration}`));
-    }
-    if (infoParts.length > 0) {
-      console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + infoParts.join('  '));
+
+      // Display hover state if available
+      if (hasHover) {
+        const hoverState = link.states.hover;
+        console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + chalk.hex('#8BE9FD')('Hover'));
+
+        const hoverProps = [];
+
+        if (hoverState.color) {
+          try {
+            const formats = normalizeColorFormat(hoverState.color);
+            const colorBlock = chalk.bgHex(formats.hex)('  ');
+            hoverProps.push({ key: 'color', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
+          } catch {
+            hoverProps.push({ key: 'color', value: hoverState.color });
+          }
+        }
+
+        if (hoverState.textDecoration) {
+          hoverProps.push({ key: 'decoration', value: hoverState.textDecoration });
+        }
+
+        hoverProps.forEach((prop, propIndex) => {
+          const isLastProp = propIndex === hoverProps.length - 1;
+          const propBranch = isLastProp ? '└─' : '├─';
+          console.log(
+            chalk.dim(`│  ${linkIndent}   ${propBranch}`) + ' ' +
+            chalk.dim(`${prop.key}: `) + `${prop.value}`
+          );
+        });
+      }
+    } else {
+      // Fallback for old format
+      if (link.textDecoration && link.textDecoration !== 'none') {
+        console.log(chalk.dim(`│  ${linkIndent}└─`) + ' ' + chalk.dim(`decoration: ${link.textDecoration}`));
+      }
     }
   });
 

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -657,7 +657,7 @@ export async function extractBranding(
 
     // Discover internal links for multi-page extraction
     if (options.discoverLinks) {
-      result._discoveredLinks = await discoverLinks(page, url, options.discoverLinks);
+      result._discoveredLinks = await discoverLinks(page, page.url(), options.discoverLinks);
     }
 
     return result;

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -7,6 +7,7 @@
 
 import chalk from "chalk";
 import { convertColor } from "./colors.js";
+import { discoverLinks } from "./discovery.js";
 
 /**
  * Main extraction function - orchestrates the entire brand analysis process
@@ -656,18 +657,7 @@ export async function extractBranding(
 
     // Discover internal links for multi-page extraction
     if (options.discoverLinks) {
-      result._internalLinks = await page.evaluate(() => {
-        const links = new Set();
-        document.querySelectorAll('a[href]').forEach(a => {
-          try {
-            const u = new URL(a.href);
-            if (u.origin === location.origin) {
-              links.add(u.origin + (u.pathname.replace(/\/$/, '') || '/'));
-            }
-          } catch {}
-        });
-        return [...links];
-      });
+      result._discoveredLinks = await discoverLinks(page, url, options.discoverLinks);
     }
 
     return result;

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -654,6 +654,22 @@ export async function extractBranding(
       result.colors.rawColors = colors._raw || [];
     }
 
+    // Discover internal links for multi-page extraction
+    if (options.discoverLinks) {
+      result._internalLinks = await page.evaluate(() => {
+        const links = new Set();
+        document.querySelectorAll('a[href]').forEach(a => {
+          try {
+            const u = new URL(a.href);
+            if (u.origin === location.origin) {
+              links.add(u.origin + (u.pathname.replace(/\/$/, '') || '/'));
+            }
+          } catch {}
+        });
+        return [...links];
+      });
+    }
+
     return result;
   } catch (error) {
     spinner.fail("Extraction failed");

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -657,7 +657,11 @@ export async function extractBranding(
 
     // Discover internal links for multi-page extraction
     if (options.discoverLinks) {
-      result._discoveredLinks = await discoverLinks(page, page.url(), options.discoverLinks);
+      try {
+        result._discoveredLinks = await discoverLinks(page, page.url(), options.discoverLinks);
+      } catch {
+        result._discoveredLinks = [];
+      }
     }
 
     return result;

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -87,10 +87,9 @@ function mergeTypography(results) {
     (r.typography?.styles || []).forEach(s => {
       const key = `${s.family}|${s.size}|${s.weight}`;
       if (!styleMap.has(key)) {
-        styleMap.set(key, { ...s });
+        styleMap.set(key, { ...s, count: 1 });
       } else {
-        const existing = styleMap.get(key);
-        existing.count = (existing.count || 1) + (s.count || 1);
+        styleMap.get(key).count++;
       }
     });
   });
@@ -111,10 +110,15 @@ function mergeTypography(results) {
   return { ...base, styles: [...styleMap.values()], sources };
 }
 
+/**
+ * Fingerprint a component by its visual properties.
+ * Buttons and links have states.default; badges have top-level props.
+ */
 function fingerprintComponent(c) {
+  const base = c.states?.default || c;
   return [
-    c.backgroundColor || '', c.color || '', c.borderRadius || '',
-    c.fontSize || '', c.fontWeight || '', c.border || ''
+    base.backgroundColor || '', base.color || '', base.borderRadius || '',
+    base.fontSize || '', base.fontWeight || '', base.border || ''
   ].join('|');
 }
 
@@ -131,12 +135,52 @@ function mergeComponentArray(arrays) {
   return [...map.values()].sort((a, b) => b.count - a.count);
 }
 
+/**
+ * Merge grouped component objects (inputs: {text,checkbox,...}, badges: {all,byVariant}).
+ * Preserves the grouping keys and merges each sub-array independently.
+ */
+function mergeComponentGroups(groupObjects) {
+  const grouped = {};
+  groupObjects.forEach(obj => {
+    if (!obj) return;
+    for (const [key, val] of Object.entries(obj)) {
+      if (Array.isArray(val)) {
+        if (!grouped[key]) grouped[key] = [];
+        grouped[key].push(val);
+      } else if (typeof val === 'object' && val !== null) {
+        // Nested groups like byVariant: { error: [], warning: [], ... }
+        if (!grouped[key]) grouped[key] = {};
+        for (const [subKey, subArr] of Object.entries(val)) {
+          if (Array.isArray(subArr)) {
+            if (!grouped[key][subKey]) grouped[key][subKey] = [];
+            grouped[key][subKey].push(subArr);
+          }
+        }
+      }
+    }
+  });
+
+  const merged = {};
+  for (const [key, val] of Object.entries(grouped)) {
+    if (Array.isArray(val)) {
+      merged[key] = mergeComponentArray(val);
+    } else {
+      // Nested groups
+      merged[key] = {};
+      for (const [subKey, subArrays] of Object.entries(val)) {
+        merged[key][subKey] = mergeComponentArray(subArrays);
+      }
+    }
+  }
+  return merged;
+}
+
 function mergeComponents(results) {
   return {
     buttons: mergeComponentArray(results.map(r => r.components?.buttons || [])),
-    inputs:  mergeComponentArray(results.map(r => r.components?.inputs  || [])),
-    links:   mergeComponentArray(results.map(r => r.components?.links   || [])),
-    badges:  mergeComponentArray(results.map(r => r.components?.badges  || [])),
+    inputs:  mergeComponentGroups(results.map(r => r.components?.inputs).filter(Boolean)),
+    links:   mergeComponentArray(results.map(r => r.components?.links || [])),
+    badges:  mergeComponentGroups(results.map(r => r.components?.badges).filter(Boolean)),
   };
 }
 
@@ -179,7 +223,6 @@ function mergeBorders(results) {
       } else {
         const e = map.get(key);
         e.count += (item.count || 1);
-        // Merge element contexts
         const elementSet = new Set([...(e.elements || []), ...(item.elements || [])]);
         e.elements = [...elementSet].slice(0, 5);
         if (e.count > 10) e.confidence = 'high';
@@ -247,7 +290,7 @@ export function mergeResults(results) {
       ...new Map(
         results.flatMap(r => r.breakpoints || []).map(b => [b.px, b])
       ).values()
-    ].sort((a, b) => b.px - a.px),
+    ].sort((a, b) => parseInt(b.px) - parseInt(a.px)),
     iconSystem: mergeByName(results, r => r.iconSystem),
     frameworks: mergeByName(results, r => r.frameworks),
     pages: results.map(r => ({ url: r.url, extractedAt: r.extractedAt })),

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -212,6 +212,11 @@ function mergeSpacing(results) {
 function mergeBorderRadius(results) {
   const base = results[0].borderRadius || {};
   const values = mergeValueArrays(results, r => r.borderRadius?.values);
+  // Recompute confidence from aggregated count
+  for (const v of values) {
+    if (v.count > 10) v.confidence = 'high';
+    else if (v.count > 3) v.confidence = 'medium';
+  }
   return { ...base, values };
 }
 
@@ -249,6 +254,11 @@ function mergeShadows(results) {
       }
     });
   });
+  // Recompute confidence from aggregated count
+  for (const s of map.values()) {
+    if (s.count > 10) s.confidence = 'high';
+    else if (s.count > 3) s.confidence = 'medium';
+  }
   return [...map.values()].sort((a, b) => b.count - a.count);
 }
 

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -2,7 +2,9 @@
  * Multi-Page Result Merger
  *
  * Merges extraction results from multiple pages into a single
- * unified result with the same shape as a single-page result.
+ * unified result that is a superset of the single-page result: all single-page
+ * fields are preserved, with additional multi-page metadata (pages array,
+ * pageCount on palette entries) added.
  */
 
 import { deltaE } from './colors.js';

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -1,0 +1,242 @@
+/**
+ * Multi-Page Result Merger
+ *
+ * Merges extraction results from multiple pages into a single
+ * unified result with the same shape as a single-page result.
+ */
+
+import { deltaE } from './colors.js';
+
+const DELTA_E_THRESHOLD = 15;
+
+function mergeColors(results) {
+  const base = results[0].colors;
+
+  // Pool all palette entries with their source page index
+  const allColors = [];
+  results.forEach((r, pageIdx) => {
+    (r.colors?.palette || []).forEach(c => {
+      allColors.push({ ...c, _pageIdx: pageIdx });
+    });
+  });
+
+  // Perceptual dedup across all pages
+  const merged = [];
+  const used = new Set();
+
+  for (let i = 0; i < allColors.length; i++) {
+    if (used.has(i)) continue;
+
+    const c = allColors[i];
+    const similar = [c];
+    const pagesSeen = new Set([c._pageIdx]);
+
+    for (let j = i + 1; j < allColors.length; j++) {
+      if (used.has(j)) continue;
+      try {
+        if (deltaE(c.normalized, allColors[j].normalized) < DELTA_E_THRESHOLD) {
+          similar.push(allColors[j]);
+          pagesSeen.add(allColors[j]._pageIdx);
+          used.add(j);
+        }
+      } catch { /* skip unparseable colors */ }
+    }
+    used.add(i);
+
+    // Keep variant with highest count as canonical
+    const best = similar.sort((a, b) => b.count - a.count)[0];
+    const totalCount = similar.reduce((s, x) => s + (x.count || 0), 0);
+    const pageCount = pagesSeen.size;
+
+    // Boost confidence when color appears on multiple pages
+    let confidence = best.confidence;
+    if (pageCount > 1 && confidence === 'low') confidence = 'medium';
+    if (pageCount > 2 && confidence === 'medium') confidence = 'high';
+
+    const { _pageIdx, ...clean } = best;
+    merged.push({ ...clean, count: totalCount, confidence, pageCount });
+  }
+
+  // Semantic: homepage wins, fill missing from other pages
+  const semantic = { ...base.semantic };
+  for (let i = 1; i < results.length; i++) {
+    const s = results[i].colors?.semantic || {};
+    for (const [k, v] of Object.entries(s)) {
+      if (!semantic[k] && v) semantic[k] = v;
+    }
+  }
+
+  // CSS variables: union, first occurrence wins
+  const cssVariables = {};
+  results.forEach(r => {
+    const vars = r.colors?.cssVariables || {};
+    for (const [k, v] of Object.entries(vars)) {
+      if (!(k in cssVariables)) cssVariables[k] = v;
+    }
+  });
+
+  return { ...base, semantic, palette: merged, cssVariables };
+}
+
+function mergeTypography(results) {
+  const base = results[0].typography || {};
+
+  // Dedup styles by (family, size, weight) tuple, sum counts
+  const styleMap = new Map();
+  results.forEach(r => {
+    (r.typography?.styles || []).forEach(s => {
+      const key = `${s.family}|${s.size}|${s.weight}`;
+      if (!styleMap.has(key)) {
+        styleMap.set(key, { ...s });
+      } else {
+        const existing = styleMap.get(key);
+        existing.count = (existing.count || 1) + (s.count || 1);
+      }
+    });
+  });
+
+  // Merge sources
+  const sources = { ...(base.sources || {}) };
+  results.slice(1).forEach(r => {
+    const s = r.typography?.sources || {};
+    for (const [k, v] of Object.entries(s)) {
+      if (Array.isArray(v)) {
+        sources[k] = [...new Set([...(sources[k] || []), ...v])];
+      } else if (v && !sources[k]) {
+        sources[k] = v;
+      }
+    }
+  });
+
+  return { ...base, styles: [...styleMap.values()], sources };
+}
+
+function fingerprintComponent(c) {
+  return [
+    c.backgroundColor, c.color, c.borderRadius,
+    c.fontSize, c.fontWeight, c.border
+  ].join('|');
+}
+
+function mergeComponentArray(arrays) {
+  const map = new Map();
+  arrays.flat().forEach(item => {
+    const key = fingerprintComponent(item);
+    if (!map.has(key)) {
+      map.set(key, { ...item, count: item.count || 1 });
+    } else {
+      map.get(key).count += (item.count || 1);
+    }
+  });
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+function mergeComponents(results) {
+  return {
+    buttons: mergeComponentArray(results.map(r => r.components?.buttons || [])),
+    inputs:  mergeComponentArray(results.map(r => r.components?.inputs  || [])),
+    links:   mergeComponentArray(results.map(r => r.components?.links   || [])),
+    badges:  mergeComponentArray(results.map(r => r.components?.badges  || [])),
+  };
+}
+
+function mergeValueArrays(results, getter, valueKey = 'value') {
+  const map = new Map();
+  results.forEach(r => {
+    (getter(r) || []).forEach(item => {
+      const key = item[valueKey];
+      if (!map.has(key)) {
+        map.set(key, { ...item });
+      } else {
+        const e = map.get(key);
+        e.count = (e.count || 0) + (item.count || 1);
+        e.frequency = (e.frequency || 0) + (item.frequency || 0);
+      }
+    });
+  });
+  return [...map.values()].sort((a, b) => (b.count || b.frequency || 0) - (a.count || a.frequency || 0));
+}
+
+function mergeSpacing(results) {
+  const base = results[0].spacing || {};
+  const values = mergeValueArrays(results, r => r.spacing?.commonValues, 'px');
+  return { ...base, commonValues: values };
+}
+
+function mergeBorderRadius(results) {
+  const base = results[0].borderRadius || {};
+  const values = mergeValueArrays(results, r => r.borderRadius?.values);
+  return { ...base, values };
+}
+
+function mergeBorders(results) {
+  const base = results[0].borders || {};
+  return {
+    ...base,
+    widths: mergeValueArrays(results, r => r.borders?.widths),
+    styles: mergeValueArrays(results, r => r.borders?.styles),
+    colors: mergeValueArrays(results, r => r.borders?.colors, 'color'),
+  };
+}
+
+function mergeShadows(results) {
+  const map = new Map();
+  results.forEach(r => {
+    (r.shadows || []).forEach(s => {
+      const key = s.shadow || s.value || JSON.stringify(s);
+      if (!map.has(key)) {
+        map.set(key, { ...s, count: s.count || 1 });
+      } else {
+        map.get(key).count += (s.count || 1);
+      }
+    });
+  });
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+function mergeByName(results, getter) {
+  const seen = new Set();
+  const out = [];
+  results.forEach(r => {
+    (getter(r) || []).forEach(item => {
+      const key = item.name || item.library || JSON.stringify(item);
+      if (!seen.has(key)) { seen.add(key); out.push(item); }
+    });
+  });
+  return out;
+}
+
+/**
+ * Merge an array of per-page result objects into a single unified result.
+ * @param {Object[]} results - Array of extractBranding() result objects
+ * @returns {Object} Merged result with same shape as single-page result
+ */
+export function mergeResults(results) {
+  if (results.length === 0) throw new Error('No results to merge');
+  if (results.length === 1) return results[0];
+
+  const home = results[0];
+
+  return {
+    url: home.url,
+    extractedAt: home.extractedAt,
+    siteName: home.siteName,
+    logo: home.logo,
+    favicons: home.favicons,
+    colors: mergeColors(results),
+    typography: mergeTypography(results),
+    spacing: mergeSpacing(results),
+    borderRadius: mergeBorderRadius(results),
+    borders: mergeBorders(results),
+    shadows: mergeShadows(results),
+    components: mergeComponents(results),
+    breakpoints: [
+      ...new Map(
+        results.flatMap(r => r.breakpoints || []).map(b => [b.px, b])
+      ).values()
+    ].sort((a, b) => b.px - a.px),
+    iconSystem: mergeByName(results, r => r.iconSystem),
+    frameworks: mergeByName(results, r => r.frameworks),
+    pages: results.map(r => ({ url: r.url, extractedAt: r.extractedAt })),
+  };
+}

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -113,8 +113,8 @@ function mergeTypography(results) {
 
 function fingerprintComponent(c) {
   return [
-    c.backgroundColor, c.color, c.borderRadius,
-    c.fontSize, c.fontWeight, c.border
+    c.backgroundColor || '', c.color || '', c.borderRadius || '',
+    c.fontSize || '', c.fontWeight || '', c.border || ''
   ].join('|');
 }
 
@@ -170,12 +170,25 @@ function mergeBorderRadius(results) {
 }
 
 function mergeBorders(results) {
-  const base = results[0].borders || {};
+  const map = new Map();
+  results.forEach(r => {
+    (r.borders?.combinations || []).forEach(item => {
+      const key = `${item.width}|${item.style}|${item.color}`;
+      if (!map.has(key)) {
+        map.set(key, { ...item, elements: [...(item.elements || [])] });
+      } else {
+        const e = map.get(key);
+        e.count += (item.count || 1);
+        // Merge element contexts
+        const elementSet = new Set([...(e.elements || []), ...(item.elements || [])]);
+        e.elements = [...elementSet].slice(0, 5);
+        if (e.count > 10) e.confidence = 'high';
+        else if (e.count > 3) e.confidence = 'medium';
+      }
+    });
+  });
   return {
-    ...base,
-    widths: mergeValueArrays(results, r => r.borders?.widths),
-    styles: mergeValueArrays(results, r => r.borders?.styles),
-    colors: mergeValueArrays(results, r => r.borders?.colors, 'color'),
+    combinations: [...map.values()].sort((a, b) => b.count - a.count),
   };
 }
 

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -109,7 +109,8 @@ function mergeTypography(results) {
     }
   });
 
-  return { ...base, styles: [...styleMap.values()], sources };
+  const styles = [...styleMap.values()].sort((a, b) => parseFloat(b.size) - parseFloat(a.size));
+  return { ...base, styles, sources };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #20

Adds `--pages` and `--sitemap` flags so the CLI can crawl and merge multiple pages into one unified design token result. Colors, typography, and components that only appear on subpages are now captured.

```bash
node index.js stripe.com --pages 5          # crawl up to 5 internal pages
node index.js stripe.com --sitemap          # discover pages from sitemap.xml
node index.js stripe.com --sitemap --pages 10
```

No flags = current single-page behavior, no breaking changes.

## New files

**`lib/discovery.js`** — two discovery strategies:
- `discoverLinks(page, baseUrl, maxPages)` — evaluates the already-loaded page DOM, weights links by location (nav/header/footer score higher), boosts key pages (pricing, about, product), filters out noise (login, terms, assets). Single source of truth for all DOM link discovery.
- `parseSitemap(baseUrl, maxPages)` — fetches `/sitemap.xml`, follows `<sitemapindex>` one level deep, normalizes and scores URLs the same way

**`lib/merger.js`** — merges N per-page result objects into one. Output is a superset of the single-page shape (adds `pages` metadata array and `pageCount` on palette entries).

- **Colors**: perceptual dedup across pages using delta-E (CIE76, threshold 15). Confidence boosted for colors that appear on multiple pages.
- **Typography**: dedup by `(family, size, weight)` with consistent count tracking
- **Buttons/links**: fingerprinted via `states.default` (correct shape)
- **Inputs/badges**: merged with `mergeComponentGroups` to preserve their object structure (`{text, checkbox, ...}` / `{all, byVariant}`)
- **Borders**: merged via `combinations` array (correct extractor shape)
- **Breakpoints**: sorted correctly with `parseInt()` (value is a string like `"768px"`)

## How it works

Homepage loads normally. `discoverLinks()` runs on the loaded page and returns ranked URLs. Sub-pages are extracted sequentially with a 2–5s polite delay between requests. Results are merged into a single JSON object and passed to the existing display/PDF/DTCG pipeline unchanged.

## Tested

Tested against `gunsnroses.com --pages 5` — found colors, fonts, and button variants not visible on the homepage. Brand guide generation works correctly on the merged result.

## Review fixes (two rounds)

- `discoverLinks()` consolidated as the single DOM discovery path (no more duplicate inline logic in index.js)
- `deltaE()` uses `hexToRgb()` for parsing — malformed hex returns 999 instead of NaN
- `--pages` validates positive integer, throws a clear Commander error on bad input
- `mergeBorders` uses correct `combinations` shape
- `mergeComponents` handles inputs/badges as grouped objects, not flat arrays
- `fingerprintComponent` reads from `states.default`
- Breakpoint sort uses `parseInt()`
- Sitemap child URL filter uses `hostname ===` instead of `.includes()`
- Per-page error catch uses `String(err?.message || err)` defensively

🤖 Generated with [Claude Code](https://claude.com/claude-code)