### PR TITLE
connect to existing browser via CDP (BROWSER_CDP_ENDPOINT)

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ program
   .description("Extract design tokens from any website")
   .version("0.11.0")
   .argument("<url>")
-  .option("--browser <type>", "Browser to use (chromium|firefox)", "chromium")
+  .option("--browser <type>", "Browser to use (chromium|firefox); set BROWSER_CDP_ENDPOINT env var to connect to an existing Chromium instance via CDP", "chromium")
   .option("--json-only", "Output raw JSON")
   .option("--save-output", "Save JSON file to output folder")
   .option("--dtcg", "Export in W3C Design Tokens (DTCG) format")
@@ -93,10 +93,18 @@ program
         if (opts.noSandbox && opts.browser === 'chromium') {
           launchArgs.push("--no-sandbox", "--disable-setuid-sandbox");
         }
-        browser = await browserType.launch({
-          headless: !useHeaded,
-          args: launchArgs,
-        });
+        if (process.env.BROWSER_CDP_ENDPOINT) {
+          if (opts.browser !== 'chromium') {
+            throw new Error("BROWSER_CDP_ENDPOINT is only supported with --browser chromium.");
+          }
+          spinner.text = "Connecting over CDP...";
+          browser = await browserType.connectOverCDP(process.env.BROWSER_CDP_ENDPOINT);
+        } else {
+          browser = await browserType.launch({
+            headless: !useHeaded,
+            args: launchArgs,
+          });
+        }
 
         try {
           const isMultiPage = opts.pages || opts.sitemap;
@@ -170,7 +178,7 @@ program
           await browser.close();
           browser = null;
 
-          if (useHeaded) throw err;
+          if (useHeaded || process.env.BROWSER_CDP_ENDPOINT) throw err;
 
           if (
             err.message.includes("Timeout") ||


### PR DESCRIPTION
## Summary

Add native support for `BROWSER_CDP_ENDPOINT`, allowing dembrandt to connect to an existing Chromium instance via Chrome DevTools Protocol instead of launching a new browser.

Originally proposed by @Saerdna in #45. This PR incorporates their implementation with fixes for the review feedback raised in that thread.

## Motivation

When running dembrandt inside a container alongside a shared browser service (e.g. a headless Chromium sidecar), launching a new browser per invocation is wasteful. CDP connection reuse is more efficient and enables tighter integration with browser-as-a-service setups.

## Changes

- `index.js`: when `BROWSER_CDP_ENDPOINT` is set, use `chromium.connectOverCDP()` instead of `browserType.launch()`
- Non-chromium browser + CDP endpoint throws a clear error instead of silently ignoring `--browser`
- Headed-retry logic is skipped in CDP mode (no headed fallback possible on a remote endpoint)
- `--help` output documents the env var on the `--browser` option

## Behavior

| `BROWSER_CDP_ENDPOINT` | Behavior |
|---|---|
| not set | unchanged — launches a new browser as before |
| set (e.g. `http://localhost:9222`) | connects to existing browser via CDP |

## Testing

```bash
# existing behavior unchanged
dembrandt https://example.com

# CDP mode
BROWSER_CDP_ENDPOINT=http://localhost:9222 dembrandt https://example.com

# non-chromium + CDP → clear error
BROWSER_CDP_ENDPOINT=http://localhost:9222 dembrandt --browser firefox https://example.com
```

Closes #45