### PR TITLE
oklab colors now normalize to hex, better typography contexts, gradient extraction

### DIFF
--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -220,7 +220,7 @@ export async function extractBranding(
     spinner.stop();
     console.log(chalk.hex('#8BE9FD')("\n  Extracting design tokens...\n"));
 
-    spinner.start("Analyzing design system (15 parallel tasks)...");
+    spinner.start("Analyzing design system (16 parallel tasks)...");
     const [
       { logo, favicons },
       colors,
@@ -237,6 +237,7 @@ export async function extractBranding(
       iconSystem,
       frameworks,
       siteName,
+      gradients,
     ] = await Promise.all([
       extractLogo(page, url),
       extractColors(page),
@@ -253,6 +254,7 @@ export async function extractBranding(
       detectIconSystem(page),
       detectFrameworks(page),
       extractSiteName(page),
+      extractGradients(page),
     ]);
 
     spinner.stop();
@@ -273,6 +275,7 @@ export async function extractBranding(
     console.log(breakpoints.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Breakpoints: ${breakpoints.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Breakpoints: 0 detected`));
     console.log(iconSystem.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Icon systems: ${iconSystem.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Icon systems: 0 detected`));
     console.log(frameworks.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Frameworks: ${frameworks.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Frameworks: 0 detected`));
+    console.log(gradients.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Gradients: ${gradients.length} found`) : chalk.hex('#8BE9FD')(`  · Gradients: 0 found`));
     console.log();
 
     // Extract hover/focus state colors using actual interaction simulation
@@ -621,6 +624,7 @@ export async function extractBranding(
       borderRadius,
       borders,
       shadows,
+      gradients,
       components: { buttons, inputs, links, badges },
       breakpoints,
       iconSystem,
@@ -976,7 +980,8 @@ async function extractLogo(page, url) {
  */
 async function extractColors(page) {
   const result = await page.evaluate(() => {
-    // Helper: Convert any color to normalized hex for deduplication
+    // Helper: Convert any color to normalized hex for deduplication.
+    // Uses canvas fallback for modern color spaces (oklab, oklch, lch, lab, color()).
     function normalizeColor(color) {
       const rgbaMatch = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
       if (rgbaMatch) {
@@ -985,7 +990,27 @@ async function extractColors(page) {
         const b = parseInt(rgbaMatch[3]).toString(16).padStart(2, "0");
         return `#${r}${g}${b}`;
       }
-      return color.toLowerCase();
+      // Short hex (#abc → #aabbcc)
+      const shortHex = color.match(/^#([0-9a-f]{3})$/i);
+      if (shortHex) {
+        const [, h] = shortHex;
+        return `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`;
+      }
+      if (/^#[0-9a-f]{6}$/i.test(color)) return color.toLowerCase();
+      if (/^#[0-9a-f]{8}$/i.test(color)) return color.toLowerCase().slice(0, 7); // strip alpha
+      // Modern color spaces: use canvas to let the browser convert to sRGB
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 1;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 1, 1);
+        const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+        if (a === 0) return color.toLowerCase(); // transparent — keep as-is
+        return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+      } catch (e) {
+        return color.toLowerCase();
+      }
     }
 
     // Helper: Check if value is a valid simple color (not calc/clamp/var)
@@ -1559,8 +1584,9 @@ async function extractTypography(page) {
       const fontFeatures = s.fontFeatureSettings !== 'normal' ? s.fontFeatureSettings : null;
 
       // Build context label
-      let context = "heading-1";
+      let context = "body";
       const className = typeof el.className === 'string' ? el.className : (el.className.baseVal || '');
+      const headingMatch = el.tagName.match(/^H([1-6])$/);
       if (
         el.tagName === "BUTTON" ||
         el.getAttribute("role") === "button" ||
@@ -1569,10 +1595,12 @@ async function extractTypography(page) {
         context = "button";
       } else if (el.tagName === "A" && el.href) {
         context = "link";
+      } else if (headingMatch) {
+        context = `heading-${headingMatch[1]}`;
       } else if (size <= 14) {
         context = "caption";
-      } else if (el.tagName.match(/^H[1-6]$/)) {
-        context = "heading-1";
+      } else if (size >= 20) {
+        context = "display";
       }
 
       const key = `${family}|${size}|${weight}|${context}|${letterSpacing}|${textTransform}`;
@@ -2422,6 +2450,57 @@ async function extractBreakpoints(page) {
 /**
  * Detect icon systems in use
  */
+async function extractGradients(page) {
+  return await page.evaluate(() => {
+    const seen = new Map();
+
+    const els = document.querySelectorAll('*');
+    for (const el of els) {
+      const s = getComputedStyle(el);
+      const bg = s.backgroundImage;
+      if (!bg || bg === 'none') continue;
+
+      const gradients = [];
+      // Split multiple backgrounds (comma-separated, but not inside parens)
+      let depth = 0, start = 0;
+      for (let i = 0; i < bg.length; i++) {
+        if (bg[i] === '(') depth++;
+        else if (bg[i] === ')') depth--;
+        else if (bg[i] === ',' && depth === 0) {
+          gradients.push(bg.slice(start, i).trim());
+          start = i + 1;
+        }
+      }
+      gradients.push(bg.slice(start).trim());
+
+      for (const grad of gradients) {
+        if (!/^(linear|radial|conic)-gradient/.test(grad)) continue;
+
+        const type = grad.startsWith('linear') ? 'linear'
+          : grad.startsWith('radial') ? 'radial' : 'conic';
+
+        const key = grad.replace(/\s+/g, ' ');
+        if (seen.has(key)) {
+          seen.get(key).count++;
+          continue;
+        }
+
+        // Extract stop colors for palette preview
+        const stopColors = [];
+        const stopRe = /#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|oklch\([^)]+\)|oklab\([^)]+\)/gi;
+        let m;
+        while ((m = stopRe.exec(grad)) !== null) stopColors.push(m[0]);
+
+        seen.set(key, { gradient: key, type, stopColors, count: 1 });
+      }
+    }
+
+    return Array.from(seen.values())
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20);
+  });
+}
+
 async function detectIconSystem(page) {
   return await page.evaluate(() => {
     const systems = [];

--- a/lib/extractors/breakpoints.js
+++ b/lib/extractors/breakpoints.js
@@ -195,3 +195,57 @@ export async function detectFrameworks(page) {
     return frameworks;
   });
 }
+
+export async function extractGradients(page) {
+  return await page.evaluate(() => {
+    const seen = new Map();
+
+    const els = document.querySelectorAll('*');
+    let checked = 0;
+    for (const el of els) {
+      if (checked++ > 2000) break;
+      if (el.style.backgroundImage === 'none') continue;
+      if (el.offsetWidth === 0 && el.offsetHeight === 0) continue;
+      const s = getComputedStyle(el);
+      const bg = s.backgroundImage;
+      if (!bg || bg === 'none') continue;
+
+      const gradients = [];
+      let depth = 0, start = 0;
+      for (let i = 0; i < bg.length; i++) {
+        if (bg[i] === '(') depth++;
+        else if (bg[i] === ')') depth--;
+        else if (bg[i] === ',' && depth === 0) {
+          gradients.push(bg.slice(start, i).trim());
+          start = i + 1;
+        }
+      }
+      gradients.push(bg.slice(start).trim());
+
+      for (const grad of gradients) {
+        if (!/^(repeating-)?(linear|radial|conic)-gradient/.test(grad)) continue;
+
+        const base = grad.replace(/^repeating-/, '');
+        const repeating = grad.startsWith('repeating-');
+        const type = (base.startsWith('linear') ? 'linear' : base.startsWith('radial') ? 'radial' : 'conic') + (repeating ? '-repeating' : '');
+
+        const key = grad.replace(/\s+/g, ' ');
+        if (seen.has(key)) {
+          seen.get(key).count++;
+          continue;
+        }
+
+        const stopColors = [];
+        const stopRe = /#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|oklch\([^)]+\)|oklab\([^)]+\)/gi;
+        let m;
+        while ((m = stopRe.exec(grad)) !== null) stopColors.push(m[0]);
+
+        seen.set(key, { gradient: key, type, stopColors, count: 1 });
+      }
+    }
+
+    return Array.from(seen.values())
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20);
+  });
+}

--- a/lib/extractors/colors.js
+++ b/lib/extractors/colors.js
@@ -2,15 +2,45 @@ import { convertColor } from '../colors.js';
 
 export async function extractColors(page) {
   const result = await page.evaluate(() => {
+    const _canvas = document.createElement('canvas');
+    _canvas.width = _canvas.height = 1;
+    const _ctx = _canvas.getContext('2d');
+    const _colorMemo = new Map();
     function normalizeColor(color) {
+      if (_colorMemo.has(color)) return _colorMemo.get(color);
+      let result;
       const rgbaMatch = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
       if (rgbaMatch) {
         const r = parseInt(rgbaMatch[1]).toString(16).padStart(2, "0");
         const g = parseInt(rgbaMatch[2]).toString(16).padStart(2, "0");
         const b = parseInt(rgbaMatch[3]).toString(16).padStart(2, "0");
-        return `#${r}${g}${b}`;
+        result = `#${r}${g}${b}`;
+      } else {
+        const shortHex = color.match(/^#([0-9a-f]{3})$/i);
+        if (shortHex) {
+          const [, h] = shortHex;
+          result = `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`.toLowerCase();
+        } else if (/^#[0-9a-f]{6}$/i.test(color)) {
+          result = color.toLowerCase();
+        } else if (/^#[0-9a-f]{8}$/i.test(color)) {
+          result = color.toLowerCase().slice(0, 7);
+        } else if (_ctx) {
+          try {
+            _ctx.clearRect(0, 0, 1, 1);
+            _ctx.fillStyle = 'rgba(0,0,0,0)';
+            _ctx.fillStyle = color;
+            _ctx.fillRect(0, 0, 1, 1);
+            const [r, g, b, a] = _ctx.getImageData(0, 0, 1, 1).data;
+            result = a === 0 ? color.toLowerCase() : `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+          } catch (e) {
+            result = color.toLowerCase();
+          }
+        } else {
+          result = color.toLowerCase();
+        }
       }
-      return color.toLowerCase();
+      _colorMemo.set(color, result);
+      return result;
     }
 
     function isValidColorValue(value) {

--- a/lib/extractors/components.js
+++ b/lib/extractors/components.js
@@ -235,25 +235,30 @@ export async function extractLinkStyles(page) {
     const links = Array.from(document.querySelectorAll(`a, [role="link"], [aria-current]`));
     const uniqueStyles = new Map();
 
+    const _lcCanvas = document.createElement('canvas');
+    _lcCanvas.width = _lcCanvas.height = 1;
+    const _lcCtx = _lcCanvas.getContext('2d');
+    const normalizeColor = (color) => {
+      try {
+        const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/);
+        if (m) return `#${parseInt(m[1]).toString(16).padStart(2,'0')}${parseInt(m[2]).toString(16).padStart(2,'0')}${parseInt(m[3]).toString(16).padStart(2,'0')}`;
+        if (/^#[0-9a-f]{6}$/i.test(color)) return color.toLowerCase();
+        if (_lcCtx) {
+          _lcCtx.clearRect(0, 0, 1, 1);
+          _lcCtx.fillStyle = 'rgba(0,0,0,0)';
+          _lcCtx.fillStyle = color;
+          _lcCtx.fillRect(0, 0, 1, 1);
+          const [r, g, b, a] = _lcCtx.getImageData(0, 0, 1, 1).data;
+          if (a > 0) return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+        }
+        return color.toLowerCase();
+      } catch { return color.toLowerCase(); }
+    };
+
     links.forEach((link) => {
       const computed = getComputedStyle(link);
       const rect = link.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0 || computed.display === 'none' || computed.visibility === 'hidden') return;
-
-      const normalizeColor = (color) => {
-        try {
-          const rgbaMatch = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
-          if (rgbaMatch) {
-            const r = parseInt(rgbaMatch[1]);
-            const g = parseInt(rgbaMatch[2]);
-            const b = parseInt(rgbaMatch[3]);
-            return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
-          }
-          return color.toLowerCase();
-        } catch {
-          return color;
-        }
-      };
 
       const key = normalizeColor(computed.color);
 

--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -5,7 +5,7 @@ import { extractColors } from './colors.js';
 import { extractTypography } from './typography.js';
 import { extractSpacing, extractBorderRadius, extractBorders, extractShadows } from './spacing.js';
 import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadgeStyles } from './components.js';
-import { extractBreakpoints, detectIconSystem, detectFrameworks } from './breakpoints.js';
+import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients } from './breakpoints.js';
 
 export async function extractBranding(url, spinner, browser, options = {}) {
   const timeoutMultiplier = options.slow ? 3 : 1;
@@ -157,7 +157,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
     spinner.stop();
     console.log(chalk.hex('#8BE9FD')("\n  Extracting design tokens...\n"));
 
-    spinner.start("Analyzing design system (15 parallel tasks)...");
+    spinner.start("Analyzing design system (16 parallel tasks)...");
     const [
       { logo, favicons },
       colors,
@@ -174,6 +174,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       iconSystem,
       frameworks,
       siteName,
+      gradients,
     ] = await Promise.all([
       extractLogo(page, url),
       extractColors(page),
@@ -190,6 +191,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       detectIconSystem(page),
       detectFrameworks(page),
       extractSiteName(page),
+      extractGradients(page),
     ]);
 
     spinner.stop();
@@ -207,6 +209,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
     console.log(breakpoints.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Breakpoints: ${breakpoints.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Breakpoints: 0 detected`));
     console.log(iconSystem.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Icon systems: ${iconSystem.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Icon systems: 0 detected`));
     console.log(frameworks.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Frameworks: ${frameworks.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Frameworks: 0 detected`));
+    console.log(gradients.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Gradients: ${gradients.length} found`) : chalk.hex('#8BE9FD')(`  · Gradients: 0 found`));
     console.log();
 
     // Hover/focus state extraction
@@ -298,17 +301,36 @@ export async function extractBranding(url, spinner, browser, options = {}) {
 
     await page.mouse.move(0, 0).catch(() => {});
 
-    hoverFocusColors.forEach(({ color, property }) => {
-      const isDuplicate = colors.palette.some((c) => c.color === color);
-      if (!isDuplicate && color && /^(rgba?\(|hsla?\(|#)/i.test(color.trim())) {
-        const rgbaMatch = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-        let normalized = color.toLowerCase();
-        if (rgbaMatch) {
-          const r = parseInt(rgbaMatch[1]).toString(16).padStart(2, "0");
-          const g = parseInt(rgbaMatch[2]).toString(16).padStart(2, "0");
-          const b = parseInt(rgbaMatch[3]).toString(16).padStart(2, "0");
-          normalized = `#${r}${g}${b}`;
+    // Batch-normalize hover/focus colors via browser canvas to handle oklab/oklch/lab
+    const rawHoverColors = [...new Set(hoverFocusColors.map(h => h.color).filter(Boolean))];
+    const hoverColorMap = rawHoverColors.length ? await page.evaluate((cols) => {
+      const canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 1;
+      const ctx = canvas.getContext('2d');
+      const out = {};
+      for (const color of cols) {
+        const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+        if (m) { out[color] = `#${parseInt(m[1]).toString(16).padStart(2,'0')}${parseInt(m[2]).toString(16).padStart(2,'0')}${parseInt(m[3]).toString(16).padStart(2,'0')}`; continue; }
+        if (/^#[0-9a-f]{6}$/i.test(color)) { out[color] = color.toLowerCase(); continue; }
+        if (ctx) {
+          try {
+            ctx.clearRect(0, 0, 1, 1);
+            ctx.fillStyle = 'rgba(0,0,0,0)';
+            ctx.fillStyle = color;
+            ctx.fillRect(0, 0, 1, 1);
+            const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+            if (a > 0) { out[color] = `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`; continue; }
+          } catch {}
         }
+        out[color] = color.toLowerCase();
+      }
+      return out;
+    }, rawHoverColors) : {};
+
+    hoverFocusColors.forEach(({ color, property }) => {
+      const normalized = hoverColorMap[color] || color.toLowerCase();
+      const isDuplicate = colors.palette.some((c) => c.normalized === normalized);
+      if (!isDuplicate && color) {
         if (property !== 'background-color') {
           const hex = normalized.replace('#', '');
           const r = parseInt(hex.substring(0, 2), 16);
@@ -401,6 +423,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       borderRadius,
       borders,
       shadows,
+      gradients,
       components: { buttons, inputs, links, badges },
       breakpoints,
       iconSystem,

--- a/lib/extractors/typography.js
+++ b/lib/extractors/typography.js
@@ -72,8 +72,9 @@ export async function extractTypography(page) {
       const isFluid = s.fontSize.includes('clamp') || s.fontSize.includes('vw') || s.fontSize.includes('vh');
       const fontFeatures = s.fontFeatureSettings !== 'normal' ? s.fontFeatureSettings : null;
 
-      let context = "heading-1";
+      let context = "body";
       const className = typeof el.className === 'string' ? el.className : (el.className.baseVal || '');
+      const headingMatch = el.tagName.match(/^H([1-6])$/);
       if (
         el.tagName === "BUTTON" ||
         el.getAttribute("role") === "button" ||
@@ -82,10 +83,12 @@ export async function extractTypography(page) {
         context = "button";
       } else if (el.tagName === "A" && el.href) {
         context = "link";
+      } else if (headingMatch) {
+        context = `heading-${headingMatch[1]}`;
       } else if (size <= 14) {
         context = "caption";
-      } else if (el.tagName.match(/^H[1-6]$/)) {
-        context = "heading-1";
+      } else if (size >= 20) {
+        context = "display";
       }
 
       const key = `${family}|${size}|${weight}|${context}|${letterSpacing}|${textTransform}`;

--- a/test/qa.mjs
+++ b/test/qa.mjs
@@ -140,6 +140,7 @@ function deltaE(hex1, hex2) {
     z = z > 0.008856 ? z ** (1/3) : 7.787 * z + 16/116;
     return { L: 116 * y - 16, a: 500 * (x - y), b: 200 * (y - z) };
   }
+  if (hex1 === hex2) return 0;
   const rgb1 = hexToRgb(hex1), rgb2 = hexToRgb(hex2);
   if (!rgb1 || !rgb2) return 999;
   const lab1 = toLab(rgb1), lab2 = toLab(rgb2);
@@ -148,9 +149,14 @@ function deltaE(hex1, hex2) {
 
 const PERCEPTUAL_THRESHOLD = 15; // Same as extractor uses
 
+function normalizeColorString(c) {
+  if (!c || c.startsWith('#')) return c;
+  return c.replace(/-?[\d]+\.[\d]+/g, n => parseFloat(parseFloat(n).toFixed(4)).toString());
+}
+
 function diffColors(goldenPalette, currentPalette) {
-  const golden = (goldenPalette || []).map(c => c.normalized);
-  const current = (currentPalette || []).map(c => c.normalized);
+  const golden = (goldenPalette || []).map(c => normalizeColorString(c.normalized));
+  const current = (currentPalette || []).map(c => normalizeColorString(c.normalized));
 
   // Match colors perceptually — two colors within delta-E 15 are "the same"
   const goldenMatched = new Set();

--- a/test/sites.json
+++ b/test/sites.json
@@ -1,5 +1,9 @@
 [
   "dembrandt.com",
-  "example.com",
-  "test.example.org"
+  "stripe.com",
+  "linear.app",
+  "vercel.com",
+  "tailwindcss.com",
+  "github.com",
+  "resend.com"
 ]


### PR DESCRIPTION
Fixed a bug where oklab/oklch colors were stored as the string "oklab" instead of hex, breaking the palette. Typography contexts were wrong too, everything defaulted to heading-1. Also added gradient extraction and swapped the test sites for real ones.