### PR TITLE
feat: add --wcag flag for DOM-based WCAG contrast analysis

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sync-downstream:
+    needs: publish-npm
+    uses: ./.github/workflows/sync-skills.yml
+    secrets: inherit

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,8 +1,7 @@
 name: Sync downstream repos
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Bump skills version and update SKILL.md
         env:
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Update dembrandt version in package.json
         env:

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ program
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a screenshot of the page")
+  .option("--wcag", "Analyze WCAG contrast ratios between palette colors")
   .option("--pages <n>", "Analyze up to N total pages including start URL (default: 5)", (v) => {
     const n = parseInt(v, 10);
     if (isNaN(n) || n < 1) throw new Error(`--pages must be a positive integer, got: ${v}`);
@@ -120,6 +121,7 @@ program
             slow: opts.slow,
             screenshotPath: opts.screenshot,
             discoverLinks: isMultiPage && !opts.sitemap ? maxPages : null,
+            wcag: opts.wcag,
           });
 
           // Multi-page crawl

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -229,6 +229,52 @@ export function hexToRgb(hex) {
 }
 
 /**
+ * Compute WCAG 2.1 relative luminance for a hex color.
+ * @param {string} hex
+ * @returns {number|null}
+ */
+export function relativeLuminance(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  return 0.2126 * srgbToLinear(rgb.r) + 0.7152 * srgbToLinear(rgb.g) + 0.0722 * srgbToLinear(rgb.b);
+}
+
+/**
+ * Compute WCAG contrast ratios for all pairs in a color palette.
+ * @param {Array<{color: string, normalized: string, confidence: string}>} palette
+ * @returns {Array<{fg: string, bg: string, ratio: number, aa: boolean, aaLarge: boolean, aaa: boolean}>}
+ */
+export function computeWcag(palette) {
+  const colors = palette
+    .filter(c => c.normalized && c.normalized.startsWith('#'))
+    .slice(0, 10);
+
+  const pairs = [];
+  for (let i = 0; i < colors.length; i++) {
+    for (let j = i + 1; j < colors.length; j++) {
+      const l1 = relativeLuminance(colors[i].normalized);
+      const l2 = relativeLuminance(colors[j].normalized);
+      if (l1 === null || l2 === null) continue;
+      const lighter = Math.max(l1, l2);
+      const darker = Math.min(l1, l2);
+      const ratio = (lighter + 0.05) / (darker + 0.05);
+      const fg = l1 >= l2 ? colors[i].normalized : colors[j].normalized;
+      const bg = l1 >= l2 ? colors[j].normalized : colors[i].normalized;
+      pairs.push({
+        fg,
+        bg,
+        ratio: Math.round(ratio * 100) / 100,
+        aa: ratio >= 4.5,
+        aaLarge: ratio >= 3,
+        aaa: ratio >= 7,
+      });
+    }
+  }
+
+  return pairs.sort((a, b) => b.ratio - a.ratio);
+}
+
+/**
  * Convert any supported color format to all formats
  * @param {string} colorString - Color in hex, rgb(), or rgba() format
  * @returns {{ hex: string, rgb: string, lch: string, oklch: string, hasAlpha: boolean } | null}

--- a/lib/extractors/colors.js
+++ b/lib/extractors/colors.js
@@ -310,3 +310,97 @@ export async function extractColors(page) {
 
   return result;
 }
+
+export async function extractWcagPairs(page) {
+  let rawPairs = [];
+  try {
+    rawPairs = await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 1;
+      const ctx = canvas.getContext('2d');
+
+      function toHex(color) {
+        if (!color) return null;
+        try {
+          const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
+          if (m) {
+            if (m[4] !== undefined && parseFloat(m[4]) < 0.1) return null;
+            const r = parseInt(m[1]).toString(16).padStart(2, '0');
+            const g = parseInt(m[2]).toString(16).padStart(2, '0');
+            const b = parseInt(m[3]).toString(16).padStart(2, '0');
+            return `#${r}${g}${b}`;
+          }
+          if (/^#[0-9a-f]{6}$/i.test(color)) return color.toLowerCase();
+          if (!ctx) return null;
+          ctx.clearRect(0, 0, 1, 1);
+          ctx.fillStyle = 'rgba(0,0,0,0)';
+          ctx.fillStyle = color;
+          ctx.fillRect(0, 0, 1, 1);
+          const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+          if (a < 25) return null;
+          return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+        } catch {
+          return null;
+        }
+      }
+
+      function findBg(el) {
+        let node = el;
+        while (node && node.tagName !== 'HTML') {
+          try {
+            const bg = toHex(getComputedStyle(node).backgroundColor);
+            if (bg) return bg;
+          } catch { /* skip stale node */ }
+          node = node.parentElement;
+        }
+        return null;
+      }
+
+      const seen = new Map();
+      let checked = 0;
+      const els = document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, a, button, label, span, li, td, th, [role="button"]');
+
+      for (const el of els) {
+        if (checked++ > 1500) break;
+        try {
+          const s = getComputedStyle(el);
+          if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') continue;
+          const rect = el.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) continue;
+          const fg = toHex(s.color);
+          if (!fg) continue;
+          const bg = findBg(el);
+          if (!bg || fg === bg) continue;
+          const key = [fg, bg].sort().join('/');
+          const entry = seen.get(key);
+          if (entry) { entry.count++; } else { seen.set(key, { fg, bg, count: 1 }); }
+        } catch { /* skip any element that throws */ }
+      }
+
+      return Array.from(seen.values()).sort((a, b) => b.count - a.count).slice(0, 50);
+    });
+  } catch {
+    return [];
+  }
+
+  const { relativeLuminance } = await import('../colors.js');
+  const pairs = [];
+  const seen = new Set();
+
+  for (const { fg, bg, count } of rawPairs) {
+    try {
+      const key = [fg, bg].sort().join('/');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const l1 = relativeLuminance(fg);
+      const l2 = relativeLuminance(bg);
+      if (l1 === null || l2 === null) continue;
+      const lighter = Math.max(l1, l2);
+      const darker = Math.min(l1, l2);
+      const ratio = Math.round((lighter + 0.05) / (darker + 0.05) * 100) / 100;
+      pairs.push({ fg, bg, ratio, aa: ratio >= 4.5, aaLarge: ratio >= 3, aaa: ratio >= 7, count });
+    } catch { /* skip malformed pair */ }
+  }
+
+  return pairs.sort((a, b) => b.count - a.count);
+}

--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -8,6 +8,15 @@ import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadg
 import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients } from './breakpoints.js';
 import { extractWcagPairs } from './colors.js';
 
+/** @typedef {import('../types.js').BrandingResult} BrandingResult */
+
+/**
+ * @param {string} url
+ * @param {import('ora').Ora} spinner
+ * @param {import('playwright-core').Browser} browser
+ * @param {{ slow?: boolean, darkMode?: boolean, mobile?: boolean, wcag?: boolean, screenshotPath?: string, discoverLinks?: number|null, navigationTimeout?: number }} [options]
+ * @returns {Promise<BrandingResult>}
+ */
 export async function extractBranding(url, spinner, browser, options = {}) {
   const timeoutMultiplier = options.slow ? 3 : 1;
   const timeouts = [];

--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -6,6 +6,7 @@ import { extractTypography } from './typography.js';
 import { extractSpacing, extractBorderRadius, extractBorders, extractShadows } from './spacing.js';
 import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadgeStyles } from './components.js';
 import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients } from './breakpoints.js';
+import { extractWcagPairs } from './colors.js';
 
 export async function extractBranding(url, spinner, browser, options = {}) {
   const timeoutMultiplier = options.slow ? 3 : 1;
@@ -411,6 +412,18 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       console.log(chalk.hex('#8BE9FD')(`💡 Tip: Try running with ${chalk.bold('--slow')} flag for more reliable results on slow-loading sites`));
     }
 
+    let wcag = [];
+    if (options.wcag) {
+      spinner.start("Analyzing WCAG contrast pairs...");
+      try {
+        wcag = await extractWcagPairs(page);
+        spinner.stop();
+        console.log(chalk.hex('#50FA7B')(`  ✓ WCAG: ${wcag.filter(p => p.aa).length}/${wcag.length} pairs pass AA`));
+      } catch {
+        spinner.stop();
+      }
+    }
+
     const result = {
       url: page.url(),
       extractedAt: new Date().toISOString(),
@@ -428,6 +441,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       breakpoints,
       iconSystem,
       frameworks,
+      ...(options.wcag ? { wcag } : {}),
     };
 
     const isCanvasOnly = await page.evaluate(() => {

--- a/lib/formatters/terminal.js
+++ b/lib/formatters/terminal.js
@@ -54,6 +54,7 @@ export function displayResults(data) {
   displayBreakpoints(data.breakpoints);
   displayIconSystem(data.iconSystem);
   displayFrameworks(data.frameworks);
+  displayWcag(data.wcag);
 
   console.log(chalk.dim('│'));
   console.log(chalk.dim('└─') + ' ' + chalk.hex('#50FA7B')('✓ Complete'));
@@ -978,6 +979,33 @@ function displayFrameworks(frameworks) {
     const branch = isLast ? '└─' : '├─';
     const conf = fw.confidence === 'high' ? chalk.hex('#50FA7B')('●') : chalk.hex('#FFB86C')('●');
     console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${fw.name} ${chalk.dim(fw.evidence)}`);
+  });
+  console.log(chalk.dim('│'));
+}
+
+function displayWcag(wcag) {
+  if (!wcag || wcag.length === 0) return;
+
+  console.log(chalk.dim('├─') + ' ' + chalk.bold('WCAG Contrast'));
+
+  const passing = wcag.filter(p => p.aa);
+  const failing = wcag.filter(p => !p.aa);
+  const all = [...passing.slice(0, 5), ...failing.slice(0, 3)];
+
+  all.forEach((pair, i) => {
+    const isLast = i === all.length - 1;
+    const branch = isLast ? '└─' : '├─';
+    const fgSwatch = chalk.bgHex(pair.fg)('  ');
+    const bgSwatch = chalk.bgHex(pair.bg)('  ');
+    const grade = pair.aaa
+      ? chalk.hex('#50FA7B')('AAA')
+      : pair.aa
+        ? chalk.hex('#50FA7B')('AA ')
+        : pair.aaLarge
+          ? chalk.hex('#FFB86C')('AA-Large')
+          : chalk.hex('#FF5555')('fail');
+    const ratio = chalk.bold(`${pair.ratio}:1`);
+    console.log(chalk.dim(`│  ${branch}`) + ' ' + `${fgSwatch} ${bgSwatch}  ${ratio}  ${grade}  ${chalk.dim(pair.fg + ' / ' + pair.bg)}`);
   });
   console.log(chalk.dim('│'));
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,204 @@
+/**
+ * @typedef {'high'|'medium'|'low'} Confidence
+ */
+
+/**
+ * @typedef {Object} PaletteColor
+ * @property {string} color - Original color string
+ * @property {string} normalized - Hex color (#rrggbb)
+ * @property {number} count - Number of occurrences
+ * @property {number} score - Semantic relevance score
+ * @property {string[]} sources - CSS class/id sources
+ * @property {Confidence} confidence
+ */
+
+/**
+ * @typedef {Object} Colors
+ * @property {PaletteColor[]} palette
+ * @property {Record<string, string>} semantic - e.g. { primary: '#hex' }
+ * @property {Record<string, string>} cssVariables - CSS custom properties
+ * @property {PaletteColor[]} [rawColors]
+ */
+
+/**
+ * @typedef {Object} TypographyStyle
+ * @property {string} context - 'heading-1'|'body'|'button'|'caption'|'display'|'link'
+ * @property {string} family
+ * @property {string[]} fallbacks
+ * @property {string} size
+ * @property {string} weight
+ * @property {string} lineHeight
+ * @property {string} [letterSpacing]
+ * @property {string} [textTransform]
+ * @property {boolean} [isVariable]
+ * @property {boolean} [isFluid]
+ */
+
+/**
+ * @typedef {Object} Typography
+ * @property {TypographyStyle[]} styles
+ * @property {{ googleFonts: string[], adobeFonts: string[], variableFonts: string[] }} sources
+ */
+
+/**
+ * @typedef {Object} SpacingValue
+ * @property {number} px
+ * @property {string} rem
+ * @property {number} count
+ */
+
+/**
+ * @typedef {Object} Spacing
+ * @property {string} scaleType - 'base-4'|'base-8'|'fibonacci'|'custom'
+ * @property {SpacingValue[]} commonValues
+ */
+
+/**
+ * @typedef {Object} TokenValue
+ * @property {string} value
+ * @property {number} count
+ * @property {Confidence} confidence
+ */
+
+/**
+ * @typedef {Object} BorderRadius
+ * @property {TokenValue[]} values
+ */
+
+/**
+ * @typedef {Object} Borders
+ * @property {TokenValue[]} widths
+ * @property {TokenValue[]} styles
+ * @property {TokenValue[]} colors
+ * @property {{ width: string, style: string, color: string }[]} [combinations]
+ */
+
+/**
+ * @typedef {Object} Shadow
+ * @property {string} shadow
+ * @property {number} count
+ * @property {Confidence} confidence
+ */
+
+/**
+ * @typedef {Object} Gradient
+ * @property {string} gradient
+ * @property {'linear'|'radial'|'conic'|'linear-repeating'|'radial-repeating'|'conic-repeating'} type
+ * @property {string[]} stopColors
+ * @property {number} count
+ */
+
+/**
+ * @typedef {Object} ButtonStyle
+ * @property {string} backgroundColor
+ * @property {string} color
+ * @property {string} padding
+ * @property {string} borderRadius
+ * @property {string} border
+ * @property {string} [boxShadow]
+ * @property {Confidence} confidence
+ */
+
+/**
+ * @typedef {Object} InputStyle
+ * @property {string} type
+ * @property {string} border
+ * @property {string} borderRadius
+ * @property {string} padding
+ * @property {Object} [focusStyles]
+ */
+
+/**
+ * @typedef {Object} LinkStyle
+ * @property {string} color
+ * @property {string} textDecoration
+ * @property {string} [hoverColor]
+ */
+
+/**
+ * @typedef {Object} BadgeStyle
+ * @property {string} backgroundColor
+ * @property {string} color
+ * @property {string} borderRadius
+ * @property {string} padding
+ */
+
+/**
+ * @typedef {Object} Components
+ * @property {ButtonStyle[]} buttons
+ * @property {{ text: InputStyle[] }} inputs
+ * @property {LinkStyle[]} links
+ * @property {BadgeStyle[]} badges
+ */
+
+/**
+ * @typedef {Object} Breakpoint
+ * @property {number} px
+ */
+
+/**
+ * @typedef {Object} IconSystem
+ * @property {string} name
+ * @property {string} type
+ * @property {string[]} [sizes]
+ */
+
+/**
+ * @typedef {Object} Framework
+ * @property {string} name
+ * @property {Confidence} confidence
+ * @property {string} evidence
+ */
+
+/**
+ * @typedef {Object} Logo
+ * @property {'img'|'svg'} source
+ * @property {string} url
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {string} [alt]
+ * @property {{ top: number, right: number, bottom: number, left: number }} safeZone
+ * @property {string|null} background
+ */
+
+/**
+ * @typedef {Object} Favicon
+ * @property {string} type
+ * @property {string} url
+ * @property {string|null} sizes
+ */
+
+/**
+ * @typedef {Object} WcagPair
+ * @property {string} fg - Foreground hex color
+ * @property {string} bg - Background hex color
+ * @property {number} ratio - Contrast ratio (e.g. 4.5)
+ * @property {boolean} aa - Passes WCAG AA (4.5:1)
+ * @property {boolean} aaLarge - Passes WCAG AA Large (3:1)
+ * @property {boolean} aaa - Passes WCAG AAA (7:1)
+ * @property {number} count - How many elements share this pair
+ */
+
+/**
+ * @typedef {Object} BrandingResult
+ * @property {string} url
+ * @property {string} extractedAt - ISO 8601 timestamp
+ * @property {string|null} siteName
+ * @property {Logo|null} logo
+ * @property {Favicon[]} favicons
+ * @property {Colors} colors
+ * @property {Typography} typography
+ * @property {Spacing} spacing
+ * @property {BorderRadius} borderRadius
+ * @property {Borders} borders
+ * @property {Shadow[]} shadows
+ * @property {Gradient[]} gradients
+ * @property {Components} components
+ * @property {Breakpoint[]} breakpoints
+ * @property {IconSystem[]} iconSystem
+ * @property {Framework[]} frameworks
+ * @property {WcagPair[]} [wcag]
+ * @property {{ url: string }[]} [pages]
+ */
+
+export {};


### PR DESCRIPTION
## Summary

- Adds `--wcag` flag that extracts real fg/bg color pairs directly from DOM elements
- Walks ancestor tree to find actual background color per element (not palette combinations)
- Computes WCAG 2.1 contrast ratios, grades pairs as AAA / AA / AA-Large / fail
- Results shown in terminal output and saved to `result.wcag` in JSON
- All errors caught defensively — never breaks existing extraction

## How it works

For each visible text element (`p`, `h1-h6`, `a`, `button`, etc.), gets `color` and walks up the DOM to find the nearest opaque `backgroundColor`. Deduplicates pairs and sorts by frequency (how many elements share that combination).

## Test

```
node index.js stripe.com --wcag
```