### PR TITLE
fix: rewrite button extractor

### DIFF
--- a/lib/extractors/components.js
+++ b/lib/extractors/components.js
@@ -1,137 +1,96 @@
 export async function extractButtonStyles(page) {
   return await page.evaluate(() => {
-    const buttons = Array.from(
-      document.querySelectorAll(`
-        button,
-        a[type="button"],
-        [role="button"],
-        [role="tab"],
-        [role="menuitem"],
-        [role="switch"],
-        [aria-pressed],
-        [aria-expanded],
-        .btn,
-        [class*="btn"],
-        [class*="button"],
-        [class*="cta"],
-        [data-cta]
-      `)
-    );
+    // Only real interactive buttons — not tabs, menus, dropdowns
+    const candidates = Array.from(document.querySelectorAll(
+      'button, a[href], [role="button"]'
+    ));
 
-    const extractState = (btn) => {
-      const computed = getComputedStyle(btn);
-      return {
-        backgroundColor: computed.backgroundColor,
-        color: computed.color,
-        padding: computed.padding,
-        borderRadius: computed.borderRadius,
-        border: computed.border || `${computed.borderWidth} ${computed.borderStyle} ${computed.borderColor}`,
-        boxShadow: computed.boxShadow,
-        outline: computed.outline,
-        transform: computed.transform,
-        opacity: computed.opacity,
-      };
-    };
+    const isTransparent = (color) =>
+      !color || color === 'transparent' || color === 'rgba(0, 0, 0, 0)';
 
-    const buttonStyles = [];
+    const results = [];
 
-    buttons.forEach((btn) => {
-      const computed = getComputedStyle(btn);
-      const rect = btn.getBoundingClientRect();
-      if (rect.width === 0 || rect.height === 0 || computed.display === 'none' || computed.visibility === 'hidden') return;
-
-      const bg = computed.backgroundColor;
-      const border = computed.border;
-      const borderWidth = computed.borderWidth;
-      const borderColor = computed.borderColor;
-      const boxShadow = computed.boxShadow;
-
-      const hasBorder = borderWidth && parseFloat(borderWidth) > 0 && border !== 'none' && borderColor !== 'rgba(0, 0, 0, 0)' && borderColor !== 'transparent';
-      const hasBackground = bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent';
-      const hasShadow = boxShadow && boxShadow !== 'none' && boxShadow !== 'rgba(0, 0, 0, 0)';
-
-      if (!hasBackground && !hasBorder && !hasShadow) return;
-
-      const role = btn.getAttribute('role');
-      const isNativeButton = btn.tagName === "BUTTON";
-      const isButtonRole = ['button', 'tab', 'menuitem', 'switch'].includes(role);
-      const hasAriaPressed = btn.hasAttribute('aria-pressed');
-      const hasAriaExpanded = btn.hasAttribute('aria-expanded');
-      const isHighConfidence = isNativeButton || isButtonRole || hasAriaPressed || hasAriaExpanded;
-
-      const className = typeof btn.className === 'string' ? btn.className : btn.className.baseVal || '';
-
-      const defaultState = extractState(btn);
-      const states = { default: defaultState, hover: null, active: null, focus: null };
-
+    for (const el of candidates) {
       try {
-        const sheets = Array.from(document.styleSheets);
-        for (const sheet of sheets) {
-          try {
-            const rules = Array.from(sheet.cssRules || []);
-            for (const rule of rules) {
-              if (rule.selectorText) {
-                const btnClasses = className.split(' ').filter(c => c);
-                const matchesButton = btnClasses.some(cls => rule.selectorText.includes(`.${cls}`));
-                if (matchesButton || rule.selectorText.includes(btn.tagName.toLowerCase())) {
-                  if (rule.selectorText.includes(':hover')) {
-                    if (!states.hover) states.hover = {};
-                    if (rule.style.backgroundColor) states.hover.backgroundColor = rule.style.backgroundColor;
-                    if (rule.style.color) states.hover.color = rule.style.color;
-                    if (rule.style.boxShadow) states.hover.boxShadow = rule.style.boxShadow;
-                    if (rule.style.outline) states.hover.outline = rule.style.outline;
-                    if (rule.style.border) states.hover.border = rule.style.border;
-                    if (rule.style.transform) states.hover.transform = rule.style.transform;
-                    if (rule.style.opacity) states.hover.opacity = rule.style.opacity;
-                  }
-                  if (rule.selectorText.includes(':active')) {
-                    if (!states.active) states.active = {};
-                    if (rule.style.backgroundColor) states.active.backgroundColor = rule.style.backgroundColor;
-                    if (rule.style.color) states.active.color = rule.style.color;
-                    if (rule.style.boxShadow) states.active.boxShadow = rule.style.boxShadow;
-                    if (rule.style.outline) states.active.outline = rule.style.outline;
-                    if (rule.style.border) states.active.border = rule.style.border;
-                    if (rule.style.transform) states.active.transform = rule.style.transform;
-                    if (rule.style.opacity) states.active.opacity = rule.style.opacity;
-                  }
-                  if (rule.selectorText.includes(':focus')) {
-                    if (!states.focus) states.focus = {};
-                    if (rule.style.backgroundColor) states.focus.backgroundColor = rule.style.backgroundColor;
-                    if (rule.style.color) states.focus.color = rule.style.color;
-                    if (rule.style.boxShadow) states.focus.boxShadow = rule.style.boxShadow;
-                    if (rule.style.outline) states.focus.outline = rule.style.outline;
-                    if (rule.style.border) states.focus.border = rule.style.border;
-                    if (rule.style.transform) states.focus.transform = rule.style.transform;
-                    if (rule.style.opacity) states.focus.opacity = rule.style.opacity;
-                  }
-                }
-              }
-            }
-          } catch (e) {}
-        }
-      } catch (e) {}
+        const computed = getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
 
-      buttonStyles.push({
-        states,
-        fontWeight: computed.fontWeight,
-        fontSize: computed.fontSize,
-        classes: className.substring(0, 50),
-        confidence: isHighConfidence ? "high" : "medium",
-      });
-    });
+        if (rect.width === 0 || rect.height === 0) continue;
+        if (computed.display === 'none' || computed.visibility === 'hidden') continue;
 
-    const uniqueButtons = [];
-    const seen = new Set();
-    for (const btn of buttonStyles) {
-      const s = btn.states.default;
-      const key = `${s.backgroundColor}|${s.border}|${s.boxShadow}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        uniqueButtons.push(btn);
-      }
+        // Skip nav/menu context elements
+        const role = el.getAttribute('role');
+        if (['tab', 'menuitem', 'option', 'switch', 'treeitem'].includes(role)) continue;
+        if (el.closest('[role="tablist"], [role="menu"], [role="menubar"], nav, footer')) continue;
+
+        // Must have a visible background or border — not just inherited
+        const bg = computed.backgroundColor;
+        const borderWidth = parseFloat(computed.borderWidth);
+        const hasBackground = !isTransparent(bg);
+        const hasBorder = borderWidth > 0 && !isTransparent(computed.borderColor);
+
+        if (!hasBackground && !hasBorder) continue;
+
+        // Size sanity: real buttons aren't huge or tiny
+        if (rect.height < 24 || rect.height > 100) continue;
+        if (rect.width < 40 || rect.width > 600) continue;
+
+        // Prefer above-the-fold
+        const aboveFold = rect.top < window.innerHeight;
+
+        // Score by prominence
+        let score = 0;
+        if (el.tagName === 'BUTTON') score += 30;
+        if (role === 'button') score += 20;
+        if (hasBackground) score += 20;
+        if (hasBorder && !hasBackground) score += 10;
+        if (aboveFold) score += 15;
+        if (rect.top < 300) score += 10;
+
+        // Deprioritize tiny text-only links styled as buttons
+        const text = el.textContent?.trim() || '';
+        if (text.length === 0) score -= 20;
+
+        results.push({
+          el,
+          score,
+          state: {
+            backgroundColor: bg,
+            color: computed.color,
+            padding: computed.padding,
+            borderRadius: computed.borderRadius,
+            border: `${computed.borderWidth} ${computed.borderStyle} ${computed.borderColor}`,
+            boxShadow: computed.boxShadow !== 'none' ? computed.boxShadow : undefined,
+            fontSize: computed.fontSize,
+            fontWeight: computed.fontWeight,
+          },
+          text: text.slice(0, 40),
+        });
+      } catch {}
     }
 
-    return uniqueButtons.slice(0, 15);
+    // Sort by score, deduplicate by visual fingerprint
+    results.sort((a, b) => b.score - a.score);
+
+    const seen = new Set();
+    const unique = [];
+    for (const r of results) {
+      const s = r.state;
+      const key = `${s.backgroundColor}|${s.color}|${s.borderRadius}|${s.border}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push({
+          states: { default: s },
+          fontWeight: s.fontWeight,
+          fontSize: s.fontSize,
+          text: r.text,
+          confidence: r.score >= 40 ? 'high' : 'medium',
+        });
+      }
+      if (unique.length >= 8) break;
+    }
+
+    return unique;
   });
 }
 


### PR DESCRIPTION
## Summary
- Selektori karsittu: ei enää tab/menuitem/nav/footer-kontekstissa olevia elementtejä
- Pisteytys position (above-fold), elementin tyyppi ja visuaalinen paino mukaan
- Dedup avain: `bg|color|borderRadius|border` aiemman pelkän `bg|border|shadow` sijaan
- Max 8 nappia, oikea teksti mukana datassa

## Test plan
- [ ] Aja `node index.js stripe.com --json-only` ja tarkista `components.buttons` — pitäisi olla CTA-nappeja ei nav-itemejä
- [ ] Aja samoin `apple.com`, `nike.com`