### PR TITLE
feat: rewrite logo extractor

### DIFF
--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -169,7 +169,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
 
     spinner.start("Analyzing design system (16 parallel tasks)...");
     const [
-      { logo, favicons },
+      { logo, instances: logoInstances, favicons },
       colors,
       typography,
       spacing,
@@ -438,6 +438,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       extractedAt: new Date().toISOString(),
       siteName,
       logo,
+      logoInstances,
       favicons,
       colors,
       typography,

--- a/lib/extractors/logo.js
+++ b/lib/extractors/logo.js
@@ -32,216 +32,363 @@ export async function extractSiteName(page) {
 }
 
 export async function extractLogo(page, url) {
-  return await page.evaluate((baseUrl) => {
-    const candidates = Array.from(document.querySelectorAll("img, svg")).filter(
-      (el) => {
-        const className =
-          typeof el.className === "string"
-            ? el.className
-            : el.className.baseVal || "";
-        const attrs = (
-          className +
-          " " +
-          (el.id || "") +
-          " " +
-          (el.getAttribute("alt") || "")
-        ).toLowerCase();
+  // Extract manifest.json for PWA icons
+  const manifestIcons = await page.evaluate((baseUrl) => {
+    try {
+      const manifestLink = document.querySelector('link[rel="manifest"]');
+      if (!manifestLink) return [];
+      return [{ manifestUrl: new URL(manifestLink.getAttribute('href'), baseUrl).href }];
+    } catch {
+      return [];
+    }
+  }, url);
 
-        if (attrs.includes("logo") || attrs.includes("brand")) return true;
+  let pwaIcons = [];
+  if (manifestIcons.length > 0) {
+    try {
+      const manifestUrl = manifestIcons[0].manifestUrl;
+      const response = await page.evaluate(async (mUrl) => {
+        try {
+          const r = await fetch(mUrl);
+          if (!r.ok) return null;
+          return await r.json();
+        } catch { return null; }
+      }, manifestUrl);
 
-        if (el.tagName === "svg" || el.tagName === "SVG") {
-          const useElements = el.querySelectorAll("use");
-          for (const use of useElements) {
-            const href =
-              use.getAttribute("href") || use.getAttribute("xlink:href") || "";
-            if (
-              href.toLowerCase().includes("logo") ||
-              href.toLowerCase().includes("brand")
-            ) {
-              return true;
-            }
-          }
-        }
-
-        const inHeader = el.closest('header, nav, [role="banner"], [class*="header"], [class*="Header"], [id*="header"]');
-        if (inHeader) {
-          const parentLink = el.closest('a');
-          if (parentLink) {
-            const href = parentLink.getAttribute('href') || '';
-            const ariaLabel = (parentLink.getAttribute('aria-label') || '').toLowerCase();
-            if (href === '/' || href === baseUrl || href === baseUrl + '/' ||
-                href.match(/^https?:\/\/[^/]+\/?$/) ||
-                href.match(/^https?:\/\/[^/]+\/[a-z]{2}(-[a-z]{2})?\/?$/) ||
-                ariaLabel.includes('homepage') || ariaLabel.includes('home page')) {
-              return true;
-            }
-          }
-        }
-
-        return false;
+      if (response?.icons) {
+        pwaIcons = response.icons.map(icon => ({
+          type: 'pwa',
+          url: new URL(icon.src, url).href,
+          sizes: icon.sizes || null,
+          purpose: icon.purpose || 'any',
+        }));
       }
-    );
+    } catch {}
+  }
 
-    let logoData = null;
-    if (candidates.length > 0) {
-      const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();
+  const result = await page.evaluate((baseUrl) => {
+    const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();
 
-      const scored = candidates.map(el => {
-        let score = 0;
-        const rect = el.getBoundingClientRect();
-        const parentLink = el.closest('a');
-        const linkHref = parentLink?.getAttribute('href') || '';
-        const imgSrc = el.tagName === 'IMG' ? (el.src || '') : '';
-        const altText = (el.getAttribute('alt') || '').toLowerCase();
-        const className = (typeof el.className === 'string' ? el.className : el.className.baseVal || '').toLowerCase();
+    // Canvas for background color detection
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext('2d');
 
-        const inHeader = el.closest('header, nav, [role="banner"], [class*="header"], [class*="nav"], [id*="header"], [id*="nav"]');
-        if (inHeader) score += 50;
-
-        if (imgSrc.toLowerCase().includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) {
-          score += 40;
+    function toHex(color) {
+      if (!color || color === 'transparent') return null;
+      try {
+        const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
+        if (m) {
+          if (m[4] !== undefined && parseFloat(m[4]) < 0.1) return null;
+          return `#${parseInt(m[1]).toString(16).padStart(2,'0')}${parseInt(m[2]).toString(16).padStart(2,'0')}${parseInt(m[3]).toString(16).padStart(2,'0')}`;
         }
+        if (/^#[0-9a-f]{6}$/i.test(color)) return color.toLowerCase();
+        if (!ctx) return null;
+        ctx.clearRect(0, 0, 1, 1);
+        ctx.fillStyle = 'rgba(0,0,0,0)';
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 1, 1);
+        const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+        if (a < 25) return null;
+        return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+      } catch { return null; }
+    }
 
-        if (parentLink) {
-          const href = linkHref.toLowerCase();
-          if (href === '/' || href === baseUrl || href === baseUrl + '/' || href.endsWith('://' + new URL(baseUrl).hostname + '/') || href.endsWith('://' + new URL(baseUrl).hostname)) {
-            score += 30;
-          }
+    function findBgColor(el) {
+      let node = el;
+      while (node && node.tagName !== 'HTML') {
+        try {
+          const bg = toHex(getComputedStyle(node).backgroundColor);
+          if (bg) return bg;
+        } catch {}
+        node = node.parentElement;
+      }
+      return null;
+    }
+
+    function isLight(hex) {
+      if (!hex) return true;
+      const r = parseInt(hex.slice(1,3), 16);
+      const g = parseInt(hex.slice(3,5), 16);
+      const b = parseInt(hex.slice(5,7), 16);
+      return (0.299*r + 0.587*g + 0.114*b) / 255 > 0.5;
+    }
+
+    function detectLogoType(el, altText) {
+      const text = (altText || '').toLowerCase().trim();
+      const hasText = text.length > 0 && !/^logo$|^brand$|^icon$/i.test(text);
+      const rect = el.getBoundingClientRect();
+      const ratio = rect.width / (rect.height || 1);
+
+      // Wide element with text in alt = wordmark
+      if (hasText && ratio > 3) return 'wordmark';
+      // Squarish = logomark/icon
+      if (ratio < 1.5 && ratio > 0.5) return 'logomark';
+      // Wide with no meaningful alt = likely combination or wordmark
+      if (ratio > 2) return 'wordmark';
+      return 'combination';
+    }
+
+    function scoreLogo(el, context) {
+      let score = 0;
+      const rect = el.getBoundingClientRect();
+      const s = getComputedStyle(el);
+      const parentLink = el.closest('a');
+      const linkHref = parentLink?.getAttribute('href') || '';
+      const imgSrc = el.tagName === 'IMG' ? (el.getAttribute('src') || '') : '';
+      const altText = (el.getAttribute('alt') || '').toLowerCase();
+      const className = (typeof el.className === 'string' ? el.className : el.className.baseVal || '').toLowerCase();
+
+      if (context === 'header') score += 50;
+      if (context === 'footer') score += 20;
+      if (context === 'hero') score += 15;
+
+      if (imgSrc.toLowerCase().includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
+      if (className.includes('logo') || el.id?.toLowerCase().includes('logo')) score += 30;
+
+      if (parentLink) {
+        const href = linkHref.toLowerCase();
+        if (href === '/' || href === baseUrl || href.endsWith('://' + new URL(baseUrl).hostname + '/') || href.endsWith('://' + new URL(baseUrl).hostname)) {
+          score += 30;
         }
+      }
 
-        if (rect.top < 200) score += 10;
-        if (rect.left < 400) score += 10;
-        if (rect.top > 600) score -= 20;
+      if (rect.top < 200) score += 10;
+      if (rect.left < 400) score += 10;
 
-        const width = el.naturalWidth || el.width?.baseVal?.value || rect.width;
-        const height = el.naturalHeight || el.height?.baseVal?.value || rect.height;
-        if (width < 20 || height < 20) score -= 30;
-        if (width > 500 || height > 300) score -= 40;
+      const width = el.naturalWidth || el.width?.baseVal?.value || rect.width;
+      const height = el.naturalHeight || el.height?.baseVal?.value || rect.height;
+      if (width < 20 || height < 20) score -= 30;
+      if (width > 600 || height > 400) score -= 40;
+      if (altText.length > 50) score -= 30;
+      if (width > height && width < 400 && width > 40 && height > 10 && height < 120) score += 15;
 
-        if (altText.length > 50) score -= 30;
-        if (altText.includes(' the ') || altText.includes(' a ') || altText.includes(' of ')) score -= 20;
+      return score;
+    }
 
-        if (width > height && width < 300 && width > 40 && height > 15 && height < 100) score += 15;
-
-        if (!inHeader && !imgSrc.toLowerCase().includes(siteDomain) && !altText.includes(siteDomain)) {
-          score -= 30;
-        }
-
-        return { el, score };
-      });
-
-      scored.sort((a, b) => b.score - a.score);
-      const logo = scored[0].el;
-      const computed = window.getComputedStyle(logo);
-      const parent = logo.parentElement;
-      const parentComputed = parent ? window.getComputedStyle(parent) : null;
+    function extractLogoFromEl(el, context, baseUrl) {
+      const rect = el.getBoundingClientRect();
+      const computed = getComputedStyle(el);
+      const parent = el.parentElement;
+      const parentComputed = parent ? getComputedStyle(parent) : null;
+      const parentLink = el.closest('a');
+      const bg = findBgColor(el);
+      const altText = el.getAttribute('alt') || '';
 
       const safeZone = {
-        top:
-          parseFloat(computed.marginTop) +
-          (parentComputed ? parseFloat(parentComputed.paddingTop) : 0),
-        right:
-          parseFloat(computed.marginRight) +
-          (parentComputed ? parseFloat(parentComputed.paddingRight) : 0),
-        bottom:
-          parseFloat(computed.marginBottom) +
-          (parentComputed ? parseFloat(parentComputed.paddingBottom) : 0),
-        left:
-          parseFloat(computed.marginLeft) +
-          (parentComputed ? parseFloat(parentComputed.paddingLeft) : 0),
+        top: parseFloat(computed.marginTop) + (parentComputed ? parseFloat(parentComputed.paddingTop) : 0),
+        right: parseFloat(computed.marginRight) + (parentComputed ? parseFloat(parentComputed.paddingRight) : 0),
+        bottom: parseFloat(computed.marginBottom) + (parentComputed ? parseFloat(parentComputed.paddingBottom) : 0),
+        left: parseFloat(computed.marginLeft) + (parentComputed ? parseFloat(parentComputed.paddingLeft) : 0),
       };
 
-      let logoBg = null;
-      let walker = logo;
-      while (walker) {
-        const bg = window.getComputedStyle(walker).backgroundColor;
-        if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
-          logoBg = bg;
-          break;
-        }
-        walker = walker.parentElement;
-      }
+      const logoType = detectLogoType(el, altText);
+      const reversed = bg ? !isLight(bg) : false;
 
-      if (logo.tagName === "IMG") {
-        logoData = {
-          source: "img",
-          url: new URL(logo.src, baseUrl).href,
-          width: logo.naturalWidth || logo.width,
-          height: logo.naturalHeight || logo.height,
-          alt: logo.alt,
+      if (el.tagName === 'IMG') {
+        // Handle picture element -- prefer highest-res source
+        const picture = el.closest('picture');
+        let src = el.src;
+        if (picture) {
+          const sources = picture.querySelectorAll('source');
+          for (const source of sources) {
+            const srcset = source.getAttribute('srcset');
+            if (srcset) {
+              const best = srcset.split(',').map(s => s.trim().split(/\s+/)).sort((a, b) => {
+                const wa = parseFloat(a[1]) || 0;
+                const wb = parseFloat(b[1]) || 0;
+                return wb - wa;
+              })[0];
+              if (best?.[0]) { src = new URL(best[0], baseUrl).href; break; }
+            }
+          }
+        }
+
+        return {
+          source: 'img',
+          context,
+          url: new URL(src, baseUrl).href,
+          width: el.naturalWidth || rect.width,
+          height: el.naturalHeight || rect.height,
+          alt: altText,
+          type: logoType,
+          reversed,
+          background: bg,
           safeZone,
-          background: logoBg,
+          position: { top: rect.top, left: rect.left },
         };
-      } else {
-        const parentLink = logo.closest("a");
-        logoData = {
-          source: "svg",
-          url: parentLink ? parentLink.href : window.location.href,
-          width: logo.width?.baseVal?.value,
-          height: logo.height?.baseVal?.value,
+      } else if (el.tagName === 'SVG' || el.tagName === 'svg') {
+        return {
+          source: 'svg',
+          context,
+          url: parentLink ? parentLink.href : baseUrl,
+          width: el.width?.baseVal?.value || rect.width,
+          height: el.height?.baseVal?.value || rect.height,
+          type: logoType,
+          reversed,
+          background: bg,
           safeZone,
-          background: logoBg,
+          position: { top: rect.top, left: rect.left },
         };
+      }
+      return null;
+    }
+
+    function findLogosInZone(container, context) {
+      if (!container) return [];
+      const candidates = [];
+
+      // img and svg
+      container.querySelectorAll('img, svg').forEach(el => {
+        try {
+          const s = getComputedStyle(el);
+          if (s.display === 'none' || s.visibility === 'hidden') return;
+          const rect = el.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return;
+
+          const className = (typeof el.className === 'string' ? el.className : el.className.baseVal || '').toLowerCase();
+          const attrs = (className + ' ' + (el.id || '') + ' ' + (el.getAttribute('alt') || '')).toLowerCase();
+
+          let qualifies = attrs.includes('logo') || attrs.includes('brand');
+
+          if (!qualifies && el.tagName === 'svg') {
+            const useEls = el.querySelectorAll('use');
+            for (const use of useEls) {
+              const href = use.getAttribute('href') || use.getAttribute('xlink:href') || '';
+              if (href.toLowerCase().includes('logo') || href.toLowerCase().includes('brand')) { qualifies = true; break; }
+            }
+          }
+
+          if (!qualifies) {
+            const parentLink = el.closest('a');
+            if (parentLink) {
+              const href = (parentLink.getAttribute('href') || '').toLowerCase();
+              const ariaLabel = (parentLink.getAttribute('aria-label') || '').toLowerCase();
+              if (href === '/' || href.match(/^https?:\/\/[^/]+\/?$/) || ariaLabel.includes('home')) qualifies = true;
+            }
+          }
+
+          if (qualifies) {
+            const score = scoreLogo(el, context);
+            candidates.push({ el, score, context });
+          }
+        } catch {}
+      });
+
+      // CSS background-image logos
+      container.querySelectorAll('a, [class*="logo"], [id*="logo"], header > *, nav > *').forEach(el => {
+        try {
+          const s = getComputedStyle(el);
+          const bg = s.backgroundImage;
+          if (!bg || bg === 'none') return;
+          const urlMatch = bg.match(/url\(["']?([^"')]+)["']?\)/);
+          if (!urlMatch) return;
+          const imgUrl = urlMatch[1];
+          if (!/\.(svg|png|webp|gif)(\?|$)/i.test(imgUrl) && !imgUrl.includes('logo') && !imgUrl.includes('brand')) return;
+          const rect = el.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return;
+
+          candidates.push({
+            el: null,
+            score: scoreLogo(el, context) + 10,
+            context,
+            cssBackground: {
+              source: 'css-background',
+              context,
+              url: new URL(imgUrl, window.location.href).href,
+              width: rect.width,
+              height: rect.height,
+              type: rect.width / rect.height > 2 ? 'wordmark' : 'logomark',
+              reversed: !isLight(toHex(s.backgroundColor)),
+              background: toHex(s.backgroundColor),
+              safeZone: { top: parseFloat(s.paddingTop), right: parseFloat(s.paddingRight), bottom: parseFloat(s.paddingBottom), left: parseFloat(s.paddingLeft) },
+              position: { top: rect.top, left: rect.left },
+            }
+          });
+        } catch {}
+      });
+
+      return candidates;
+    }
+
+    const headerEl = document.querySelector('header, [role="banner"], [class*="header"], [id*="header"], nav');
+    const footerEl = document.querySelector('footer, [role="contentinfo"], [class*="footer"], [id*="footer"]');
+
+    // Hero: first large section that's not header/footer
+    const heroEl = (() => {
+      const sections = document.querySelectorAll('main > *:first-child, [class*="hero"], [class*="Hero"], [class*="banner"]:not([role="banner"])');
+      for (const s of sections) {
+        const rect = s.getBoundingClientRect();
+        if (rect.height > 200) return s;
+      }
+      return null;
+    })();
+
+    const allCandidates = [
+      ...findLogosInZone(headerEl, 'header'),
+      ...findLogosInZone(footerEl, 'footer'),
+      ...findLogosInZone(heroEl, 'hero'),
+    ];
+
+    allCandidates.sort((a, b) => b.score - a.score);
+
+    // Primary logo = highest scoring
+    const primary = allCandidates[0];
+    let primaryLogo = null;
+    if (primary) {
+      if (primary.cssBackground) {
+        primaryLogo = primary.cssBackground;
+      } else if (primary.el) {
+        primaryLogo = extractLogoFromEl(primary.el, primary.context, baseUrl);
       }
     }
 
+    // Collect all unique instances (header, footer, hero)
+    const instances = [];
+    const seenContexts = new Set();
+    for (const c of allCandidates) {
+      if (seenContexts.has(c.context)) continue;
+      seenContexts.add(c.context);
+      let inst = null;
+      if (c.cssBackground) inst = c.cssBackground;
+      else if (c.el) inst = extractLogoFromEl(c.el, c.context, baseUrl);
+      if (inst) instances.push(inst);
+    }
+
+    // Favicons
     const favicons = [];
-
-    document.querySelectorAll('link[rel*="icon"]').forEach((link) => {
-      const href = link.getAttribute("href");
+    document.querySelectorAll('link[rel*="icon"], link[rel="apple-touch-icon"]').forEach(link => {
+      const href = link.getAttribute('href');
       if (href) {
-        favicons.push({
-          type: link.getAttribute("rel"),
-          url: new URL(href, baseUrl).href,
-          sizes: link.getAttribute("sizes") || null,
-        });
-      }
-    });
-
-    document.querySelectorAll('link[rel="apple-touch-icon"]').forEach((link) => {
-      const href = link.getAttribute("href");
-      if (href) {
-        favicons.push({
-          type: "apple-touch-icon",
-          url: new URL(href, baseUrl).href,
-          sizes: link.getAttribute("sizes") || null,
-        });
+        try {
+          favicons.push({
+            type: link.getAttribute('rel'),
+            url: new URL(href, baseUrl).href,
+            sizes: link.getAttribute('sizes') || null,
+          });
+        } catch {}
       }
     });
 
     const ogImage = document.querySelector('meta[property="og:image"]');
-    if (ogImage) {
-      const content = ogImage.getAttribute("content");
-      if (content) {
-        favicons.push({
-          type: "og:image",
-          url: new URL(content, baseUrl).href,
-          sizes: null,
-        });
-      }
+    if (ogImage?.getAttribute('content')) {
+      try { favicons.push({ type: 'og:image', url: new URL(ogImage.getAttribute('content'), baseUrl).href, sizes: null }); } catch {}
     }
 
     const twitterImage = document.querySelector('meta[name="twitter:image"]');
-    if (twitterImage) {
-      const content = twitterImage.getAttribute("content");
-      if (content) {
-        favicons.push({
-          type: "twitter:image",
-          url: new URL(content, baseUrl).href,
-          sizes: null,
-        });
-      }
+    if (twitterImage?.getAttribute('content')) {
+      try { favicons.push({ type: 'twitter:image', url: new URL(twitterImage.getAttribute('content'), baseUrl).href, sizes: null }); } catch {}
     }
 
-    const hasFaviconIco = favicons.some((f) => f.url.endsWith("/favicon.ico"));
-    if (!hasFaviconIco) {
-      favicons.push({
-        type: "favicon.ico",
-        url: new URL("/favicon.ico", baseUrl).href,
-        sizes: null,
-      });
+    if (!favicons.some(f => f.url.endsWith('/favicon.ico'))) {
+      favicons.push({ type: 'favicon.ico', url: new URL('/favicon.ico', baseUrl).href, sizes: null });
     }
 
-    return { logo: logoData, favicons };
+    return { logo: primaryLogo, instances, favicons };
   }, url);
+
+  // Merge PWA icons into favicons
+  result.favicons = [...result.favicons, ...pwaIcons];
+
+  return result;
 }


### PR DESCRIPTION
## Summary
- Löytää logot erikseen header/footer/hero-zoneista, palauttaa kaikki instanssit
- Tunnistaa logo-tyypin: wordmark/logomark/combination kuvasuhteen perusteella
- Tunnistaa reversed-variantin taustan luminanssin mukaan
- CSS background-image -logot header/nav-kontekstissa
- picture/srcset: valitsee korkeimman resoluution
- PWA manifest.json -ikonit liitetään faviconeihin
- Kontekstipisteytys: header=+50, footer=+20, hero=+15

## Test plan
- [ ] `node index.js apple.com --json-only | jq '.logo, .logoInstances'`
- [ ] `node index.js stripe.com --json-only | jq '.logo.type'` — pitäisi olla "wordmark"
- [ ] `node index.js instagram.com --json-only | jq '.logo.type'` — pitäisi olla "logomark"