### PR TITLE
feat: motion tokens — durations, easings, keyframes

### DIFF
--- a/lib/extractors/breakpoints.js
+++ b/lib/extractors/breakpoints.js
@@ -251,10 +251,56 @@ export async function extractGradients(page) {
 }
 
 export async function extractMotion(page) {
-  return await page.evaluate(() => {
-    const durations = new Map();
-    const easings = new Map();
-    const animations = new Map();
+  // Phase 1: static pass — collect durations, easings, animations per semantic context
+  const staticMotion = await page.evaluate(() => {
+    function getContext(el) {
+      const tag = el.tagName.toLowerCase();
+      const role = el.getAttribute('role') || '';
+      const cls = (typeof el.className === 'string' ? el.className : '').toLowerCase();
+      const id = (el.id || '').toLowerCase();
+      const hint = cls + ' ' + id + ' ' + role;
+      if (tag === 'button' || role === 'button' || hint.includes('btn')) return 'button';
+      if (tag === 'a' || role === 'link') return 'link';
+      if (tag === 'nav' || role === 'navigation' || hint.includes('nav') || hint.includes('menu')) return 'nav';
+      if (hint.includes('modal') || hint.includes('dialog') || hint.includes('overlay') || hint.includes('drawer')) return 'modal';
+      if (hint.includes('card') || hint.includes('tile') || hint.includes('item')) return 'card';
+      if (hint.includes('hero') || hint.includes('banner') || hint.includes('header')) return 'hero';
+      if (hint.includes('tooltip') || hint.includes('popover') || hint.includes('dropdown')) return 'overlay';
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return 'input';
+      if (hint.includes('image') || hint.includes('img') || hint.includes('media') || hint.includes('video')) return 'media';
+      return 'other';
+    }
+
+    function parseDurationMs(val) {
+      if (!val || val === '0s') return 0;
+      return val.endsWith('ms') ? parseFloat(val) : parseFloat(val) * 1000;
+    }
+
+    function classifyEasing(val) {
+      if (!val) return null;
+      if (val === 'linear') return 'linear';
+      if (val === 'ease') return 'ease';
+      if (val === 'ease-in') return 'ease-in';
+      if (val === 'ease-out') return 'ease-out';
+      if (val === 'ease-in-out') return 'ease-in-out';
+      // detect spring-like: high y1/y2 overshoot
+      const m = val.match(/cubic-bezier\(([\d.]+),\s*([\d.-]+),\s*([\d.]+),\s*([\d.-]+)\)/);
+      if (m) {
+        const y1 = parseFloat(m[2]), y2 = parseFloat(m[4]);
+        if (y1 < 0 || y1 > 1 || y2 < 0 || y2 > 1) return 'spring';
+        const x1 = parseFloat(m[1]);
+        if (x1 < 0.2) return 'ease-out'; // fast start
+        if (x1 > 0.6) return 'ease-in';  // slow start
+        return 'custom';
+      }
+      return 'custom';
+    }
+
+    // per-context motion profiles
+    const contexts = {};
+    const globalDurations = new Map();
+    const globalEasings = new Map();
+    const globalAnimations = new Map();
 
     const els = document.querySelectorAll('*');
     let checked = 0;
@@ -263,51 +309,124 @@ export async function extractMotion(page) {
       if (el.offsetWidth === 0 && el.offsetHeight === 0) continue;
       const s = getComputedStyle(el);
 
-      // transition-duration
-      const dur = s.transitionDuration;
-      if (dur && dur !== '0s') {
-        for (const d of dur.split(',').map(v => v.trim())) {
-          if (d === '0s') continue;
-          const ms = d.endsWith('ms') ? parseFloat(d) : parseFloat(d) * 1000;
-          if (ms > 0) {
-            const entry = durations.get(d) || { value: d, ms, count: 0 };
-            entry.count++;
-            durations.set(d, entry);
-          }
-        }
-      }
-
-      // transition-timing-function (easing)
-      const easing = s.transitionTimingFunction;
-      if (easing && easing !== 'ease' && easing !== 'initial') {
-        for (const e of easing.split(/,(?![^(]*\))/)) {
-          const ev = e.trim();
-          if (!ev) continue;
-          const entry = easings.get(ev) || { value: ev, count: 0 };
-          entry.count++;
-          easings.set(ev, entry);
-        }
-      }
-
-      // animation-name
+      const rawDurations = (s.transitionDuration || '').split(',').map(v => v.trim()).filter(v => v && v !== '0s');
+      const rawEasings = (s.transitionTimingFunction || '').split(/,(?![^(]*\))/).map(v => v.trim()).filter(Boolean);
+      const rawProps = (s.transitionProperty || '').split(',').map(v => v.trim());
       const animName = s.animationName;
+
+      if (rawDurations.length === 0 && (!animName || animName === 'none')) continue;
+
+      const ctx = getContext(el);
+
+      // global tallies
+      rawDurations.forEach(d => {
+        const ms = parseDurationMs(d);
+        if (ms <= 0) return;
+        const e = globalDurations.get(d) || { value: d, ms, count: 0 };
+        e.count++; globalDurations.set(d, e);
+      });
+      rawEasings.forEach(e => {
+        const entry = globalEasings.get(e) || { value: e, type: classifyEasing(e), count: 0 };
+        entry.count++; globalEasings.set(e, entry);
+      });
+
+      // per-context profile
+      if (ctx !== 'other' && rawDurations.length > 0) {
+        if (!contexts[ctx]) contexts[ctx] = { durations: new Map(), easings: new Map(), props: new Map(), count: 0 };
+        const cx = contexts[ctx];
+        cx.count++;
+        rawDurations.forEach(d => { const e = cx.durations.get(d) || { value: d, ms: parseDurationMs(d), count: 0 }; e.count++; cx.durations.set(d, e); });
+        rawEasings.forEach(e => { const entry = cx.easings.get(e) || { value: e, type: classifyEasing(e), count: 0 }; entry.count++; cx.easings.set(e, entry); });
+        rawProps.forEach(p => { if (p && p !== 'all' && p !== 'none') { const e = cx.props.get(p) || { value: p, count: 0 }; e.count++; cx.props.set(p, e); } });
+      }
+
+      // animations
       if (animName && animName !== 'none') {
-        const animDur = s.animationDuration || '0s';
-        const animEasing = s.animationTimingFunction || '';
         for (const name of animName.split(',').map(v => v.trim())) {
           if (name === 'none') continue;
-          const key = name;
-          const entry = animations.get(key) || { name, duration: animDur.split(',')[0]?.trim(), easing: animEasing.split(',')[0]?.trim(), count: 0 };
-          entry.count++;
-          animations.set(key, entry);
+          const e = globalAnimations.get(name) || { name, duration: s.animationDuration?.split(',')[0]?.trim(), easing: s.animationTimingFunction?.split(',')[0]?.trim(), count: 0, contexts: new Set() };
+          e.count++; e.contexts.add(ctx);
+          globalAnimations.set(name, e);
         }
       }
     }
 
+    // serialize
+    const serializeCtx = (cx) => ({
+      count: cx.count,
+      durations: Array.from(cx.durations.values()).sort((a, b) => b.count - a.count).slice(0, 3).map(d => d.value),
+      easing: Array.from(cx.easings.values()).sort((a, b) => b.count - a.count)[0]?.value || null,
+      easingType: Array.from(cx.easings.values()).sort((a, b) => b.count - a.count)[0]?.type || null,
+      props: Array.from(cx.props.values()).sort((a, b) => b.count - a.count).slice(0, 4).map(p => p.value),
+    });
+
+    const ctxOut = {};
+    for (const [k, v] of Object.entries(contexts)) ctxOut[k] = serializeCtx(v);
+
     return {
-      durations: Array.from(durations.values()).sort((a, b) => a.ms - b.ms),
-      easings: Array.from(easings.values()).sort((a, b) => b.count - a.count).slice(0, 10),
-      animations: Array.from(animations.values()).sort((a, b) => b.count - a.count).slice(0, 10),
+      durations: Array.from(globalDurations.values()).sort((a, b) => a.ms - b.ms),
+      easings: Array.from(globalEasings.values()).sort((a, b) => b.count - a.count).slice(0, 8),
+      animations: Array.from(globalAnimations.values()).sort((a, b) => b.count - a.count).slice(0, 8).map(a => ({ ...a, contexts: Array.from(a.contexts) })),
+      contexts: ctxOut,
     };
   });
+
+  // Phase 2: hover interaction deltas on a sample of interactive elements
+  const interactiveDeltas = [];
+  try {
+    const els = await page.$$('button, a, [role="button"]');
+    const sampled = els.slice(0, 12);
+    for (const el of sampled) {
+      try {
+        const visible = await el.evaluate(e => {
+          const r = e.getBoundingClientRect();
+          const s = getComputedStyle(e);
+          return r.width > 0 && r.height > 0 && s.display !== 'none' && s.visibility !== 'hidden';
+        });
+        if (!visible) continue;
+
+        const before = await el.evaluate(e => {
+          const s = getComputedStyle(e);
+          return { transform: s.transform, opacity: s.opacity, bg: s.backgroundColor, color: s.color, tag: e.tagName.toLowerCase(), text: (e.textContent || '').trim().slice(0, 30) };
+        });
+
+        await el.hover({ timeout: 800 }).catch(() => {});
+        await page.waitForTimeout(120);
+
+        const after = await el.evaluate(e => {
+          const s = getComputedStyle(e);
+          return { transform: s.transform, opacity: s.opacity, bg: s.backgroundColor, color: s.color };
+        }).catch(() => null);
+
+        if (!after) continue;
+
+        const delta = {};
+        if (after.transform !== before.transform && after.transform !== 'none') delta.transform = after.transform;
+        if (after.opacity !== before.opacity) delta.opacity = { from: before.opacity, to: after.opacity };
+        if (after.bg !== before.bg) delta.background = { from: before.bg, to: after.bg };
+        if (after.color !== before.color) delta.color = { from: before.color, to: after.color };
+
+        if (Object.keys(delta).length > 0) {
+          // classify pattern
+          let pattern = 'color-shift';
+          if (delta.transform) {
+            const t = delta.transform;
+            if (/scale\(([\d.]+)/.test(t)) {
+              const s = parseFloat(t.match(/scale\(([\d.]+)/)[1]);
+              pattern = s > 1 ? 'scale-up' : 'scale-down';
+            } else if (/translateY/.test(t)) pattern = 'slide-y';
+            else if (/translateX/.test(t)) pattern = 'slide-x';
+            else pattern = 'transform';
+          } else if (delta.opacity) {
+            pattern = parseFloat(delta.opacity.to) > parseFloat(delta.opacity.from) ? 'fade-in' : 'fade-out';
+          }
+
+          interactiveDeltas.push({ tag: before.tag, text: before.text, pattern, delta });
+        }
+      } catch { /* stale element */ }
+    }
+    await page.mouse.move(0, 0).catch(() => {});
+  } catch { /* skip */ }
+
+  return { ...staticMotion, interactiveDeltas };
 }

--- a/lib/extractors/breakpoints.js
+++ b/lib/extractors/breakpoints.js
@@ -249,3 +249,65 @@ export async function extractGradients(page) {
       .slice(0, 20);
   });
 }
+
+export async function extractMotion(page) {
+  return await page.evaluate(() => {
+    const durations = new Map();
+    const easings = new Map();
+    const animations = new Map();
+
+    const els = document.querySelectorAll('*');
+    let checked = 0;
+    for (const el of els) {
+      if (checked++ > 3000) break;
+      if (el.offsetWidth === 0 && el.offsetHeight === 0) continue;
+      const s = getComputedStyle(el);
+
+      // transition-duration
+      const dur = s.transitionDuration;
+      if (dur && dur !== '0s') {
+        for (const d of dur.split(',').map(v => v.trim())) {
+          if (d === '0s') continue;
+          const ms = d.endsWith('ms') ? parseFloat(d) : parseFloat(d) * 1000;
+          if (ms > 0) {
+            const entry = durations.get(d) || { value: d, ms, count: 0 };
+            entry.count++;
+            durations.set(d, entry);
+          }
+        }
+      }
+
+      // transition-timing-function (easing)
+      const easing = s.transitionTimingFunction;
+      if (easing && easing !== 'ease' && easing !== 'initial') {
+        for (const e of easing.split(/,(?![^(]*\))/)) {
+          const ev = e.trim();
+          if (!ev) continue;
+          const entry = easings.get(ev) || { value: ev, count: 0 };
+          entry.count++;
+          easings.set(ev, entry);
+        }
+      }
+
+      // animation-name
+      const animName = s.animationName;
+      if (animName && animName !== 'none') {
+        const animDur = s.animationDuration || '0s';
+        const animEasing = s.animationTimingFunction || '';
+        for (const name of animName.split(',').map(v => v.trim())) {
+          if (name === 'none') continue;
+          const key = name;
+          const entry = animations.get(key) || { name, duration: animDur.split(',')[0]?.trim(), easing: animEasing.split(',')[0]?.trim(), count: 0 };
+          entry.count++;
+          animations.set(key, entry);
+        }
+      }
+    }
+
+    return {
+      durations: Array.from(durations.values()).sort((a, b) => a.ms - b.ms),
+      easings: Array.from(easings.values()).sort((a, b) => b.count - a.count).slice(0, 10),
+      animations: Array.from(animations.values()).sort((a, b) => b.count - a.count).slice(0, 10),
+    };
+  });
+}

--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -5,7 +5,7 @@ import { extractColors } from './colors.js';
 import { extractTypography } from './typography.js';
 import { extractSpacing, extractBorderRadius, extractBorders, extractShadows } from './spacing.js';
 import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadgeStyles } from './components.js';
-import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients } from './breakpoints.js';
+import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients, extractMotion } from './breakpoints.js';
 import { extractWcagPairs } from './colors.js';
 
 /** @typedef {import('../types.js').BrandingResult} BrandingResult */
@@ -185,6 +185,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       frameworks,
       siteName,
       gradients,
+      motion,
     ] = await Promise.all([
       extractLogo(page, url),
       extractColors(page),
@@ -202,6 +203,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       detectFrameworks(page),
       extractSiteName(page),
       extractGradients(page),
+      extractMotion(page),
     ]);
 
     spinner.stop();
@@ -220,6 +222,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
     console.log(iconSystem.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Icon systems: ${iconSystem.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Icon systems: 0 detected`));
     console.log(frameworks.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Frameworks: ${frameworks.length} detected`) : chalk.hex('#FFB86C')(`  ⚠ Frameworks: 0 detected`));
     console.log(gradients.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Gradients: ${gradients.length} found`) : chalk.hex('#8BE9FD')(`  · Gradients: 0 found`));
+    console.log(motion.durations.length > 0 ? chalk.hex('#50FA7B')(`  ✓ Motion: ${motion.durations.length} durations, ${motion.easings.length} easings`) : chalk.hex('#8BE9FD')(`  · Motion: none detected`));
     console.log();
 
     // Hover/focus state extraction
@@ -549,6 +552,7 @@ export async function extractBranding(url, spinner, browser, options = {}) {
       borders,
       shadows,
       gradients,
+      motion,
       components: { buttons, inputs, links, badges },
       breakpoints,
       iconSystem,

--- a/lib/formatters/terminal.js
+++ b/lib/formatters/terminal.js
@@ -1009,32 +1009,60 @@ function displayMotion(motion) {
 
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Motion'));
 
+  // Duration scale
   if (motion.durations.length > 0) {
-    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Durations'));
-    motion.durations.forEach((d, i) => {
-      const isLast = i === motion.durations.length - 1 && motion.easings.length === 0 && motion.animations.length === 0;
-      const branch = isLast ? '└─' : '├─';
-      console.log(chalk.dim(`│  │  ${branch}`) + ' ' + chalk.bold(d.value) + chalk.dim(` ×${d.count}`));
-    });
+    const vals = motion.durations.map(d => chalk.bold(d.value)).join('  ');
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Scale  ') + vals);
   }
 
+  // Dominant easing
   if (motion.easings.length > 0) {
-    const isLastSection = motion.animations.length === 0;
-    console.log(chalk.dim(`│  ${isLastSection ? '└─' : '├─'}`) + ' ' + chalk.dim('Easings'));
-    motion.easings.forEach((e, i) => {
-      const isLast = i === motion.easings.length - 1;
+    const top = motion.easings[0];
+    const typeLabel = top.type && top.type !== 'custom' ? chalk.dim(` (${top.type})`) : '';
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Easing ') + top.value + typeLabel);
+  }
+
+  // Per-context profiles
+  const ctxEntries = Object.entries(motion.contexts || {}).filter(([, v]) => v.count > 0);
+  if (ctxEntries.length > 0) {
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('By context'));
+    ctxEntries.forEach(([ctx, v], i) => {
+      const isLast = i === ctxEntries.length - 1 && (motion.interactiveDeltas || []).length === 0 && motion.animations.length === 0;
       const branch = isLast ? '└─' : '├─';
-      console.log(chalk.dim(`│  ${isLastSection ? ' ' : '│'}  ${branch}`) + ' ' + chalk.dim(e.value) + chalk.dim(` ×${e.count}`));
+      const dur = v.durations.join(' / ');
+      const easingLabel = v.easingType && v.easingType !== 'custom' ? ` · ${v.easingType}` : '';
+      const props = v.props.length > 0 ? chalk.dim(` [${v.props.slice(0, 3).join(', ')}]`) : '';
+      console.log(chalk.dim(`│  │  ${branch}`) + ' ' + chalk.bold(ctx) + chalk.dim(`  ${dur}${easingLabel}`) + props);
     });
   }
 
+  // Interaction deltas (hover patterns)
+  const deltas = (motion.interactiveDeltas || []);
+  if (deltas.length > 0) {
+    const seen = new Map();
+    deltas.forEach(d => {
+      const key = `${d.tag}:${d.pattern}`;
+      if (!seen.has(key)) seen.set(key, d);
+    });
+    const unique = Array.from(seen.values());
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Hover patterns'));
+    unique.slice(0, 6).forEach((d, i) => {
+      const isLast = i === Math.min(unique.length, 6) - 1 && motion.animations.length === 0;
+      const branch = isLast ? '└─' : '├─';
+      const label = d.text ? chalk.dim(` "${d.text}"`) : '';
+      console.log(chalk.dim(`│  │  ${branch}`) + ' ' + chalk.bold(d.pattern) + chalk.dim(` ${d.tag}`) + label);
+    });
+  }
+
+  // Keyframe animations
   if (motion.animations.length > 0) {
     console.log(chalk.dim('│  └─') + ' ' + chalk.dim('Keyframes'));
-    motion.animations.forEach((a, i) => {
-      const isLast = i === motion.animations.length - 1;
+    motion.animations.slice(0, 6).forEach((a, i) => {
+      const isLast = i === Math.min(motion.animations.length, 6) - 1;
       const branch = isLast ? '└─' : '├─';
       const dur = a.duration ? chalk.dim(` ${a.duration}`) : '';
-      console.log(chalk.dim(`│     ${branch}`) + ' ' + a.name + dur + chalk.dim(` ×${a.count}`));
+      const ctx = a.contexts?.length ? chalk.dim(` [${a.contexts.join(', ')}]`) : '';
+      console.log(chalk.dim(`│     ${branch}`) + ' ' + a.name + dur + ctx);
     });
   }
 

--- a/lib/formatters/terminal.js
+++ b/lib/formatters/terminal.js
@@ -55,6 +55,7 @@ export function displayResults(data) {
   displayBreakpoints(data.breakpoints);
   displayIconSystem(data.iconSystem);
   displayFrameworks(data.frameworks);
+  displayMotion(data.motion);
   displayWcag(data.wcag);
 
   console.log(chalk.dim('│'));
@@ -1000,6 +1001,43 @@ function displayFrameworks(frameworks) {
     const conf = fw.confidence === 'high' ? chalk.hex('#50FA7B')('●') : chalk.hex('#FFB86C')('●');
     console.log(chalk.dim(`│  ${branch}`) + ' ' + `${conf} ${fw.name} ${chalk.dim(fw.evidence)}`);
   });
+  console.log(chalk.dim('│'));
+}
+
+function displayMotion(motion) {
+  if (!motion || (motion.durations.length === 0 && motion.animations.length === 0)) return;
+
+  console.log(chalk.dim('├─') + ' ' + chalk.bold('Motion'));
+
+  if (motion.durations.length > 0) {
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Durations'));
+    motion.durations.forEach((d, i) => {
+      const isLast = i === motion.durations.length - 1 && motion.easings.length === 0 && motion.animations.length === 0;
+      const branch = isLast ? '└─' : '├─';
+      console.log(chalk.dim(`│  │  ${branch}`) + ' ' + chalk.bold(d.value) + chalk.dim(` ×${d.count}`));
+    });
+  }
+
+  if (motion.easings.length > 0) {
+    const isLastSection = motion.animations.length === 0;
+    console.log(chalk.dim(`│  ${isLastSection ? '└─' : '├─'}`) + ' ' + chalk.dim('Easings'));
+    motion.easings.forEach((e, i) => {
+      const isLast = i === motion.easings.length - 1;
+      const branch = isLast ? '└─' : '├─';
+      console.log(chalk.dim(`│  ${isLastSection ? ' ' : '│'}  ${branch}`) + ' ' + chalk.dim(e.value) + chalk.dim(` ×${e.count}`));
+    });
+  }
+
+  if (motion.animations.length > 0) {
+    console.log(chalk.dim('│  └─') + ' ' + chalk.dim('Keyframes'));
+    motion.animations.forEach((a, i) => {
+      const isLast = i === motion.animations.length - 1;
+      const branch = isLast ? '└─' : '├─';
+      const dur = a.duration ? chalk.dim(` ${a.duration}`) : '';
+      console.log(chalk.dim(`│     ${branch}`) + ' ' + a.name + dur + chalk.dim(` ×${a.count}`));
+    });
+  }
+
   console.log(chalk.dim('│'));
 }
 


### PR DESCRIPTION
## Summary

Extracts a semantic motion system from the live DOM:

**Static pass:**
- Duration scale — all unique transition durations sorted by ms
- Dominant easing with type classification (ease-out, spring, custom cubic-bezier)
- Per-context profiles — button/nav/card/modal/hero each get their own duration + easing + animated properties

**Interaction pass (Playwright hover):**
- Samples up to 12 interactive elements
- Captures transform/opacity/color deltas before → after hover
- Classifies pattern: `scale-up`, `slide-y`, `fade-in`, `color-shift`

**Keyframes:**
- animation-name inventory with duration and which contexts use them

## Example output (vercel.com)

```
├─ Motion
│  ├─ Scale  0.09s  0.1s  0.15s  0.2s  0.25s  0.3s  0.4s  0.7s
│  ├─ Easing ease (ease)
│  ├─ By context
│  │  ├─ button  0.15s / 0.09s · ease  [background, color, border]
│  │  ├─ nav     0.15s / 0.2s · ease-in-out  [color, rotate]
│  │  ├─ card    0.4s / 0.3s  [opacity, visibility]
│  ├─ Hover patterns
│  │  └─ color-shift  button
```

## Test plan

- [x] `node index.js vercel.com` — Motion section shows scale + by-context + hover patterns
- [x] `node index.js stripe.com` — shows keyframes + card/modal contexts
- [x] A static site with no transitions shows no Motion section
- [x] JSON output includes `motion.contexts`, `motion.interactiveDeltas`