### PR TITLE
feat: emit typography fontFeature in DESIGN.md front matter

### DIFF
--- a/lib/formatters/markdown.js
+++ b/lib/formatters/markdown.js
@@ -157,6 +157,7 @@ function buildTypographyTokens(result) {
       fontWeight: normalizeFontWeight(style.fontWeight ?? style.weight),
       lineHeight: normalizeLineHeight(style.lineHeight),
       letterSpacing: normalizeDimension(style.letterSpacing),
+      fontFeature: normalizeFontFeature(style.fontFeatures ?? style.fontFeature),
     });
 
     if (!token || !token.fontFamily && !token.fontSize) continue;
@@ -406,6 +407,12 @@ function sanitizeTokenName(name) {
 function normalizeFontFamily(value) {
   if (!value) return null;
   return String(value).trim().replace(/\s+/g, ' ');
+}
+
+function normalizeFontFeature(value) {
+  if (!value) return null;
+  const raw = String(value).trim();
+  return raw && raw !== 'normal' ? raw : null;
 }
 
 function normalizeFontWeight(value) {

--- a/test/markdown.test.mjs
+++ b/test/markdown.test.mjs
@@ -25,6 +25,7 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
           fontWeight: '600',
           lineHeight: '1.1',
           letterSpacing: '-0.02em',
+          fontFeatures: '"liga" 1, "kern" 1',
           contexts: ['h1'],
         },
         {
@@ -67,7 +68,7 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
 
   assert.match(output, /^---\nname: "Example Product"\n/);
   assert.match(output, /colors:\n  primary: "#1A1C1E"/);
-  assert.match(output, /typography:\n  headline-display:\n    fontFamily: "Public Sans"\n    fontSize: "48px"\n    fontWeight: 600\n    lineHeight: 1.1\n    letterSpacing: "-0.02em"/);
+  assert.match(output, /typography:\n  headline-display:\n    fontFamily: "Public Sans"\n    fontSize: "48px"\n    fontWeight: 600\n    lineHeight: 1.1\n    letterSpacing: "-0.02em"\n    fontFeature: "\\"liga\\" 1, \\"kern\\" 1"/);
   assert.match(output, /spacing:\n  base: "8px"/);
   assert.match(output, /rounded:\n  sm: "4px"\n  md: "8px"\n  full: "9999px"/);
   assert.match(output, /components:\n  button-observed:\n    backgroundColor: "\{colors.primary\}"/);
@@ -78,7 +79,6 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
     '## Colors',
     '## Typography',
     '## Layout',
-    '## Elevation & Depth',
     '## Shapes',
     '## Components',
   ];


### PR DESCRIPTION
## What

Adds the `fontFeature` sub-key to each `typography` token in the DESIGN.md front matter, sourced from the `font-feature-settings` Dembrandt already observes per type style but currently discards.

```yaml
typography:
  body-md:
    fontFamily: "Inter"
    fontSize: "16px"
    fontWeight: 400
    fontFeature: "\"ss01\" 1, \"cv11\" 1"
```

## Standards conformance

`fontFeature` is a key the [DESIGN.md spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) defines under `typography` (alongside `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`). This PR introduces **no new or non-standard keys** — it fills in the one spec-defined typography field Dembrandt extracts but wasn't writing. The value is the observed `font-feature-settings` string verbatim; the key is omitted when a style uses the default (`normal`), consistent with the existing "report only what was observed" behavior.

## Tests

- Asserts `fontFeature` is emitted for a style that declares feature settings.
- Fixes a **pre-existing** failure in `test/markdown.test.mjs`: the section-order test asserted an `## Elevation & Depth` section while passing `shadows: []`, so that section never rendered. Removed it from the expected order.
- `node --test test/markdown.test.mjs` → 4/4.

> Note: no workflow currently runs these unit tests (`nightly.yml`/`smoke.yml` only run `test/qa.mjs` against live sites), which is why the test break landed silently. Wiring `node --test` into CI would be a worthwhile follow-up.