### PR TITLE
feat: assets and meta blocks in DESIGN.md front matter

### DIFF
--- a/lib/formatters/markdown.js
+++ b/lib/formatters/markdown.js
@@ -17,6 +17,11 @@ export function generateDesignMd(result) {
   const typographyTokens = buildTypographyTokens(result);
   const spacingTokens = buildSpacingTokens(result);
   const roundedTokens = buildRoundedTokens(result);
+  const elevationTokens = buildElevationTokens(result);
+  const borderTokens = buildBorderTokens(result);
+  const gradientTokens = buildGradientTokens(result);
+  const motionTokens = buildMotionTokens(result);
+  const breakpointTokens = buildBreakpointTokens(result);
   const componentTokens = buildComponentTokens(result, colorRoles, roundedTokens);
 
   const frontMatter = compactObject({
@@ -26,6 +31,11 @@ export function generateDesignMd(result) {
     typography: hasKeys(typographyTokens) ? typographyTokens : null,
     spacing: hasKeys(spacingTokens) ? spacingTokens : null,
     rounded: hasKeys(roundedTokens) ? roundedTokens : null,
+    elevation: hasKeys(elevationTokens) ? elevationTokens : null,
+    borders: hasKeys(borderTokens) ? borderTokens : null,
+    gradients: hasKeys(gradientTokens) ? gradientTokens : null,
+    motion: hasKeys(motionTokens) ? motionTokens : null,
+    breakpoints: hasKeys(breakpointTokens) ? breakpointTokens : null,
     components: hasKeys(componentTokens) ? componentTokens : null,
   });
 
@@ -34,9 +44,11 @@ export function generateDesignMd(result) {
     buildOverviewSection(domain),
     hasKeys(colorRoles) ? buildColorsSection(colorRoles) : null,
     hasKeys(typographyTokens) ? buildTypographySection(result, typographyTokens) : null,
-    hasLayoutEvidence(result, spacingTokens) ? buildLayoutSection(result, spacingTokens) : null,
-    hasElevationEvidence(result) ? buildElevationSection(result) : null,
-    hasKeys(roundedTokens) ? buildShapesSection(roundedTokens) : null,
+    hasLayoutEvidence(spacingTokens, breakpointTokens) ? buildLayoutSection(result, spacingTokens, breakpointTokens) : null,
+    hasKeys(elevationTokens) ? buildElevationSection(elevationTokens) : null,
+    (hasKeys(roundedTokens) || hasKeys(borderTokens)) ? buildShapesSection(roundedTokens, borderTokens) : null,
+    hasKeys(gradientTokens) ? buildGradientsSection(gradientTokens) : null,
+    hasKeys(motionTokens) ? buildMotionSection(motionTokens) : null,
     hasComponentEvidence(result) ? buildComponentsSection(result) : null,
   ].filter(Boolean);
 
@@ -210,6 +222,88 @@ function buildRoundedTokens(result) {
   return tokens;
 }
 
+function buildElevationTokens(result) {
+  const distinct = [...new Set((result.shadows ?? [])
+    .map(entry => entry.shadow)
+    .filter(shadow => shadow && shadow !== 'none'))];
+
+  const ordered = distinct
+    .map(shadow => ({ shadow, depth: shadowDepth(shadow) }))
+    .sort((a, b) => a.depth - b.depth)
+    .slice(0, 4);
+
+  return scaleTokens(ordered.map(entry => entry.shadow), ['sm', 'md', 'lg', 'xl'], 'elevation');
+}
+
+function buildBorderTokens(result) {
+  const seen = new Set();
+  const distinct = [];
+  for (const combo of result.borders?.combinations ?? []) {
+    if (!combo.width || !combo.style || combo.style === 'none') continue;
+    const token = compactObject({
+      width: normalizeDimension(combo.width) ?? String(combo.width),
+      style: combo.style,
+      color: toHex(combo.color),
+    });
+    if (!token || !token.color) continue;
+    const key = `${token.width}|${token.style}|${token.color}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    distinct.push(token);
+  }
+
+  const top = distinct
+    .slice(0, 3)
+    .sort((a, b) => parseFloat(a.width) - parseFloat(b.width));
+  return scaleTokens(top, ['sm', 'md', 'lg'], 'border');
+}
+
+function buildGradientTokens(result) {
+  const tokens = {};
+  const usedNames = new Set();
+  for (const entry of (result.gradients ?? []).slice(0, 4)) {
+    if (!entry.gradient) continue;
+    const baseName = (entry.type ?? 'gradient').split('-')[0];
+    tokens[uniqueTokenName(baseName, usedNames)] = entry.gradient;
+  }
+  return tokens;
+}
+
+function buildMotionTokens(result) {
+  const motion = result.motion ?? {};
+
+  const durationValues = [...new Set((motion.durations ?? []).map(d => d.value).filter(Boolean))].slice(0, 5);
+  const durations = scaleTokens(durationValues, ['fast', 'base', 'slow', 'slower', 'slowest'], 'duration');
+
+  const easing = {};
+  const usedNames = new Set();
+  for (const entry of (motion.easings ?? []).slice(0, 5)) {
+    if (!entry.value) continue;
+    const baseName = entry.type && entry.type !== 'custom' ? entry.type : 'custom';
+    easing[uniqueTokenName(baseName, usedNames)] = entry.value;
+  }
+
+  return compactObject({
+    duration: hasKeys(durations) ? durations : null,
+    easing: hasKeys(easing) ? easing : null,
+  }) ?? {};
+}
+
+function buildBreakpointTokens(result) {
+  const values = [...new Set((result.breakpoints ?? [])
+    .map(bp => normalizeDimension(bp.px))
+    .filter(Boolean))]
+    .sort((a, b) => parseFloat(a) - parseFloat(b))
+    .slice(0, 6);
+
+  return scaleTokens(values, ['sm', 'md', 'lg', 'xl', 'xxl', 'xxxl'], 'breakpoint');
+}
+
+function shadowDepth(shadow) {
+  const lengths = String(shadow).match(/-?\d*\.?\d+px/g) ?? [];
+  return lengths.reduce((sum, length) => sum + Math.abs(parseFloat(length)), 0);
+}
+
 function buildComponentTokens(result, colorRoles, roundedTokens) {
   const components = {};
   const button = (result.components?.buttons ?? [])
@@ -271,37 +365,70 @@ function buildTypographySection(result, typographyTokens) {
   return lines.join('\n');
 }
 
-function buildLayoutSection(result, spacingTokens) {
+function buildLayoutSection(result, spacingTokens, breakpointTokens) {
   const scale = result.spacing?.scaleType ? `${result.spacing.scaleType} spacing scale` : null;
-  const breakpoints = (result.breakpoints ?? []).map(bp => bp.px).filter(Boolean).slice(0, 6);
   const lines = ['## Layout'];
 
   if (scale) {
     lines.push(`Observed spacing scale: ${scale}.`);
   }
 
-  if (Object.keys(spacingTokens).length) {
-    lines.push(`- **Spacing tokens**: ${Object.entries(spacingTokens).map(([name, value]) => `${name} ${value}`).join(', ')}`);
+  if (hasKeys(spacingTokens)) {
+    lines.push(`- **Spacing tokens**: ${tokenList(spacingTokens)}`);
   }
 
-  if (breakpoints.length) {
-    lines.push(`- **Responsive breakpoints**: ${breakpoints.join(', ')}`);
+  if (hasKeys(breakpointTokens)) {
+    lines.push(`- **Responsive breakpoints**: ${tokenList(breakpointTokens)}`);
   }
 
   return lines.join('\n');
 }
 
-function buildElevationSection(result) {
-  const shadows = result.shadows ?? [];
+function buildElevationSection(elevationTokens) {
   const lines = ['## Elevation & Depth'];
-  lines.push(`Observed box-shadow styles: ${shadows.slice(0, 3).map(s => s.shadow).join('; ')}`);
+  lines.push(`Observed box-shadow tokens: ${tokenList(elevationTokens)}.`);
   return lines.join('\n');
 }
 
-function buildShapesSection(roundedTokens) {
+function buildShapesSection(roundedTokens, borderTokens) {
   const lines = ['## Shapes'];
-  const rounded = Object.entries(roundedTokens).map(([name, value]) => `${name} ${value}`).join(', ');
-  lines.push(`Observed rounded-corner tokens: ${rounded}.`);
+
+  if (hasKeys(roundedTokens)) {
+    lines.push(`Observed rounded-corner tokens: ${tokenList(roundedTokens)}.`);
+  }
+
+  if (hasKeys(borderTokens)) {
+    const borders = Object.entries(borderTokens)
+      .map(([name, token]) => `${name} ${token.width} ${token.style} ${token.color}`)
+      .join(', ');
+    lines.push(`Observed border tokens: ${borders}.`);
+  }
+
+  return lines.join('\n');
+}
+
+function buildGradientsSection(gradientTokens) {
+  const lines = ['## Gradients'];
+  for (const [name, value] of Object.entries(gradientTokens)) {
+    lines.push(`- **${titleize(name)}**: ${value}`);
+  }
+  return lines.join('\n');
+}
+
+function buildMotionSection(motionTokens) {
+  const lines = ['## Motion'];
+
+  if (hasKeys(motionTokens.duration)) {
+    lines.push(`- **Durations**: ${tokenList(motionTokens.duration)}`);
+  }
+
+  if (hasKeys(motionTokens.easing)) {
+    const easings = Object.entries(motionTokens.easing)
+      .map(([name, value]) => (name === value ? value : `${name} ${value}`))
+      .join(', ');
+    lines.push(`- **Easings**: ${easings}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -465,12 +592,18 @@ function hasKeys(object) {
   return Boolean(object && Object.keys(object).length);
 }
 
-function hasLayoutEvidence(result, spacingTokens) {
-  return hasKeys(spacingTokens) || (result.breakpoints ?? []).some(bp => bp.px);
+function hasLayoutEvidence(spacingTokens, breakpointTokens) {
+  return hasKeys(spacingTokens) || hasKeys(breakpointTokens);
 }
 
-function hasElevationEvidence(result) {
-  return result.shadows?.length > 0;
+function tokenList(tokens) {
+  return Object.entries(tokens).map(([name, value]) => `${name} ${value}`).join(', ');
+}
+
+function scaleTokens(values, names, prefix) {
+  const tokens = {};
+  values.forEach((value, i) => { tokens[names[i] ?? `${prefix}-${i + 1}`] = value; });
+  return tokens;
 }
 
 function hasComponentEvidence(result) {

--- a/lib/formatters/markdown.js
+++ b/lib/formatters/markdown.js
@@ -23,6 +23,8 @@ export function generateDesignMd(result) {
   const motionTokens = buildMotionTokens(result);
   const breakpointTokens = buildBreakpointTokens(result);
   const componentTokens = buildComponentTokens(result, colorRoles, roundedTokens);
+  const assetTokens = buildAssetTokens(result);
+  const metaTokens = buildMetaTokens(result);
 
   const frontMatter = compactObject({
     name,
@@ -37,6 +39,8 @@ export function generateDesignMd(result) {
     motion: hasKeys(motionTokens) ? motionTokens : null,
     breakpoints: hasKeys(breakpointTokens) ? breakpointTokens : null,
     components: hasKeys(componentTokens) ? componentTokens : null,
+    assets: hasKeys(assetTokens) ? assetTokens : null,
+    meta: hasKeys(metaTokens) ? metaTokens : null,
   });
 
   const sections = [
@@ -50,6 +54,7 @@ export function generateDesignMd(result) {
     hasKeys(gradientTokens) ? buildGradientsSection(gradientTokens) : null,
     hasKeys(motionTokens) ? buildMotionSection(motionTokens) : null,
     hasComponentEvidence(result) ? buildComponentsSection(result) : null,
+    hasKeys(assetTokens) ? buildAssetsSection(assetTokens) : null,
   ].filter(Boolean);
 
   return `---\n${toYaml(frontMatter)}---\n\n${sections.join('\n\n')}\n`;
@@ -304,6 +309,29 @@ function shadowDepth(shadow) {
   return lengths.reduce((sum, length) => sum + Math.abs(parseFloat(length)), 0);
 }
 
+function buildAssetTokens(result) {
+  const favicons = result.favicons ?? [];
+  const isIcon = favicon => /icon/i.test(favicon.type ?? '');
+  const isSocial = favicon => /og:image|twitter:image/i.test(favicon.type ?? '');
+  const favicon = favicons.find(f => isIcon(f) && f.sizes) ?? favicons.find(isIcon);
+
+  return compactObject({
+    logo: result.logo?.url ?? result.logo?.src ?? null,
+    favicon: favicon?.url ?? null,
+    socialImage: favicons.find(isSocial)?.url ?? null,
+  }) ?? {};
+}
+
+function buildMetaTokens(result) {
+  const googleFonts = result.typography?.sources?.googleFonts ?? [];
+
+  return compactObject({
+    source: result.url ?? null,
+    extractedAt: result.extractedAt ?? null,
+    fontProvider: googleFonts.length ? `Google Fonts (${googleFonts.join(', ')})` : null,
+  }) ?? {};
+}
+
 function buildComponentTokens(result, colorRoles, roundedTokens) {
   const components = {};
   const button = (result.components?.buttons ?? [])
@@ -429,6 +457,15 @@ function buildMotionSection(motionTokens) {
     lines.push(`- **Easings**: ${easings}`);
   }
 
+  return lines.join('\n');
+}
+
+function buildAssetsSection(assetTokens) {
+  const labels = { logo: 'Logo', favicon: 'Favicon', socialImage: 'Social image' };
+  const lines = ['## Assets'];
+  for (const [key, url] of Object.entries(assetTokens)) {
+    lines.push(`- **${labels[key] ?? titleize(key)}**: ${url}`);
+  }
   return lines.join('\n');
 }
 

--- a/test/markdown.test.mjs
+++ b/test/markdown.test.mjs
@@ -5,7 +5,13 @@ import { generateDesignMd } from '../lib/formatters/markdown.js';
 test('generateDesignMd emits Google DESIGN.md front matter and ordered sections', () => {
   const output = generateDesignMd({
     url: 'https://example.com',
+    extractedAt: '2026-05-22T00:00:00.000Z',
     siteName: 'Example Product',
+    logo: { url: 'https://example.com/logo.svg', type: 'wordmark' },
+    favicons: [
+      { type: 'icon', url: 'https://example.com/favicon-32.png', sizes: '32x32' },
+      { type: 'og:image', url: 'https://example.com/og.png', sizes: null },
+    ],
     colors: {
       semantic: {
         primary: 'rgb(26, 28, 30)',
@@ -18,6 +24,7 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
       ],
     },
     typography: {
+      sources: { googleFonts: ['Public Sans'] },
       styles: [
         {
           fontFamily: 'Public Sans',
@@ -98,6 +105,8 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
   assert.match(output, /motion:\n  duration:\n    fast: "150ms"\n    base: "300ms"\n  easing:\n    ease-out: "ease-out"/);
   assert.match(output, /breakpoints:\n  sm: "768px"\n  md: "1024px"/);
   assert.match(output, /components:\n  button-observed:\n    backgroundColor: "\{colors.primary\}"/);
+  assert.match(output, /assets:\n  logo: "https:\/\/example.com\/logo.svg"\n  favicon: "https:\/\/example.com\/favicon-32.png"\n  socialImage: "https:\/\/example.com\/og.png"/);
+  assert.match(output, /meta:\n  source: "https:\/\/example.com"\n  extractedAt: "2026-05-22T00:00:00.000Z"\n  fontProvider: "Google Fonts \(Public Sans\)"/);
   assert.doesNotMatch(output, /## Do's and Don'ts/);
 
   const sectionOrder = [
@@ -110,6 +119,7 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
     '## Gradients',
     '## Motion',
     '## Components',
+    '## Assets',
   ];
 
   let previousIndex = -1;
@@ -136,8 +146,10 @@ test('generateDesignMd does not invent token defaults when extraction data is ab
   assert.doesNotMatch(output, /\nmotion:/);
   assert.doesNotMatch(output, /\nbreakpoints:/);
   assert.doesNotMatch(output, /\ncomponents:/);
+  assert.doesNotMatch(output, /\nassets:/);
   assert.doesNotMatch(output, /#000000|#FFFFFF|system-ui|16px|8px|button-observed/);
   assert.match(output, /without redesigning or correcting the source site/);
+  assert.match(output, /\nmeta:\n  source: "https:\/\/empty.example"/);
 });
 
 test('generateDesignMd does not promote transparent colors to opaque tokens', () => {

--- a/test/markdown.test.mjs
+++ b/test/markdown.test.mjs
@@ -52,7 +52,29 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
         { value: '50%', confidence: 'medium' },
       ],
     },
-    shadows: [],
+    shadows: [
+      { shadow: '0 1px 2px rgba(0, 0, 0, 0.1)', count: 10 },
+      { shadow: '0 8px 24px rgba(0, 0, 0, 0.2)', count: 4 },
+    ],
+    borders: {
+      combinations: [
+        { width: '1px', style: 'solid', color: 'rgb(220, 220, 220)', count: 12 },
+      ],
+    },
+    gradients: [
+      { gradient: 'linear-gradient(90deg, rgb(0, 0, 0), rgb(255, 255, 255))', type: 'linear', count: 5 },
+    ],
+    motion: {
+      durations: [
+        { value: '150ms', ms: 150, count: 5 },
+        { value: '300ms', ms: 300, count: 3 },
+      ],
+      easings: [
+        { value: 'ease-out', type: 'ease-out', count: 8 },
+        { value: 'cubic-bezier(0.34, 1.56, 0.64, 1)', type: 'spring', count: 2 },
+      ],
+    },
+    breakpoints: [{ px: '768px' }, { px: '1024px' }],
     components: {
       buttons: [
         {
@@ -70,6 +92,11 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
   assert.match(output, /typography:\n  headline-display:\n    fontFamily: "Public Sans"\n    fontSize: "48px"\n    fontWeight: 600\n    lineHeight: 1.1\n    letterSpacing: "-0.02em"/);
   assert.match(output, /spacing:\n  base: "8px"/);
   assert.match(output, /rounded:\n  sm: "4px"\n  md: "8px"\n  full: "9999px"/);
+  assert.match(output, /elevation:\n  sm: "0 1px 2px rgba/);
+  assert.match(output, /borders:\n  sm:\n    width: "1px"\n    style: "solid"\n    color: "#DCDCDC"/);
+  assert.match(output, /gradients:\n  linear: "linear-gradient/);
+  assert.match(output, /motion:\n  duration:\n    fast: "150ms"\n    base: "300ms"\n  easing:\n    ease-out: "ease-out"/);
+  assert.match(output, /breakpoints:\n  sm: "768px"\n  md: "1024px"/);
   assert.match(output, /components:\n  button-observed:\n    backgroundColor: "\{colors.primary\}"/);
   assert.doesNotMatch(output, /## Do's and Don'ts/);
 
@@ -80,6 +107,8 @@ test('generateDesignMd emits Google DESIGN.md front matter and ordered sections'
     '## Layout',
     '## Elevation & Depth',
     '## Shapes',
+    '## Gradients',
+    '## Motion',
     '## Components',
   ];
 
@@ -101,6 +130,11 @@ test('generateDesignMd does not invent token defaults when extraction data is ab
   assert.doesNotMatch(output, /\ntypography:/);
   assert.doesNotMatch(output, /\nspacing:/);
   assert.doesNotMatch(output, /\nrounded:/);
+  assert.doesNotMatch(output, /\nelevation:/);
+  assert.doesNotMatch(output, /\nborders:/);
+  assert.doesNotMatch(output, /\ngradients:/);
+  assert.doesNotMatch(output, /\nmotion:/);
+  assert.doesNotMatch(output, /\nbreakpoints:/);
   assert.doesNotMatch(output, /\ncomponents:/);
   assert.doesNotMatch(output, /#000000|#FFFFFF|system-ui|16px|8px|button-observed/);
   assert.match(output, /without redesigning or correcting the source site/);


### PR DESCRIPTION
## What

Adds two **non-token** blocks to the DESIGN.md front matter, holding observed facts about the source site:

```yaml
assets:
  logo: "https://example.com/logo.svg"
  favicon: "https://example.com/favicon-32.png"
  socialImage: "https://example.com/og.png"
meta:
  source: "https://example.com"
  extractedAt: "2026-05-22T00:00:00.000Z"
  fontProvider: "Google Fonts (Inter, Roboto Mono)"
```

- **`assets`** — primary logo URL, best favicon (prefers a sized `rel=icon`/`apple-touch-icon`, falls back to any icon), and social share image (`og:image`/`twitter:image`). All real URLs read from the DOM.
- **`meta`** — source URL, extraction timestamp, and font provider detected from `<link>` tags.

## Conformance to the DESIGN.md format

This keeps to [Google's DESIGN.md draft format](https://stitch.withgoogle.com/docs/design-md) the generator already targets (YAML front matter + ordered Markdown sections). `assets` and `meta` are **format-consistent extensions** — deliberately kept *out* of the spec's token namespace (`colors`, `typography`, …) under their own top-level keys, because they describe the source rather than the design system. They never alter or shadow the documented token blocks, so a consumer reading only the spec's keys sees an unchanged schema; a consumer that wants provenance or brand assets gets them in the same YAML structure.

## Why a separate namespace

These are *facts*, not design decisions. `assets` is omitted when no logo or favicon was observed; `meta` always records provenance (we did extract from that URL at that time). Adds an `## Assets` body section listing the URLs.

## Tests

Extends `test/markdown.test.mjs` with assertions for both blocks and the `## Assets` section ordering, plus a negative case confirming `assets` is omitted (but `meta.source` retained) on an empty extraction. `node --test test/markdown.test.mjs` → 4/4.

---

> **Stacked on #59.** This branch is built on top of the Tier 1 token-blocks PR, so it currently shows both commits. Once #59 merges to `main`, this PR's diff narrows to just the assets/meta commit. Review/merge #59 first.