### PR TITLE
feat: include CLI version in saved output filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ test/diff-report.md
 *.jpg
 *.jpeg
 test/sites-chunk.json
+.agents/

--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ program
           mkdirSync(outputDir, { recursive: true });
 
           const suffix = opts.dtcg ? '.tokens' : '';
-          const filename = `${timestamp}${suffix}.json`;
+          const filename = `${timestamp}_v${version}${suffix}.json`;
           const filepath = join(outputDir, filename);
           writeFileSync(filepath, JSON.stringify(outputData, null, 2));
 


### PR DESCRIPTION
Appends the CLI version to the output JSON filename.

**Before:** `2026-05-31T17-01-26-829Z.json`
**After:** `2026-05-31T17-01-26-829Z_v0.14.0.json`

Makes it easier to compare extractions from different CLI versions in `/app` drift view without having to check `meta.dembrandtVersion` inside the file.