### PR TITLE
Polish brand guide PDF: cover, color blocks, logo fixes

### DIFF
--- a/lib/formatters/pdf.js
+++ b/lib/formatters/pdf.js
@@ -108,6 +108,52 @@ function formatCmyk(hexStr) {
   return `${c}, ${m}, ${y}, ${Math.round(k * 100)}`;
 }
 
+/** Chroma proxy: max-min of RGB channels (0–255). Higher = more saturated. */
+function chroma(hexStr) {
+  const rgb = hexToRgb(hexStr);
+  if (!rgb) return 0;
+  return Math.max(rgb.r, rgb.g, rgb.b) - Math.min(rgb.r, rgb.g, rgb.b);
+}
+
+function titleCase(s) {
+  return String(s).replace(/[-_]+/g, ' ').trim().replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/** Descriptive name from hue/lightness for unlabeled palette colors. */
+function hueName(hexStr) {
+  const rgb = hexToRgb(hexStr);
+  if (!rgb) return 'Color';
+  const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b), d = max - min;
+  const l = (max + min) / 2;
+  const s = max === 0 ? 0 : d / max;
+  if (s < 0.10) {
+    if (l > 0.92) return 'White';
+    if (l > 0.6) return 'Light Gray';
+    if (l > 0.32) return 'Gray';
+    if (l > 0.1) return 'Dark Gray';
+    return 'Black';
+  }
+  let h;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+  h *= 360;
+  if (h < 15 || h >= 345) return 'Red';
+  if (h < 45) return 'Orange';
+  if (h < 70) return 'Yellow';
+  if (h < 160) return 'Green';
+  if (h < 200) return 'Teal';
+  if (h < 255) return 'Blue';
+  if (h < 290) return 'Purple';
+  return 'Pink';
+}
+
+/** Display name: semantic role if labelled, else a descriptive hue name. */
+function colorName(c) {
+  return c.label ? titleCase(c.label) : hueName(c.hex);
+}
+
 function weightName(w) {
   const map = { 100: 'Thin', 200: 'Extra Light', 300: 'Light', 400: 'Regular', 500: 'Medium', 600: 'Semi Bold', 700: 'Bold', 800: 'Extra Bold', 900: 'Black' };
   return map[w] || `Weight ${w}`;
@@ -130,10 +176,6 @@ function buildHTML(data) {
   const colors = sortByHue([...semanticColors, ...paletteColors]);
   const fonts = gatherFonts(data.typography);
   const googleFonts = data.typography?.sources?.googleFonts || [];
-  const shadows = (data.shadows || [])
-    .filter(s => s.confidence === 'high')
-    .slice(0, 6);
-  const showShadows = shadows.length >= 3;
 
   // Build Google Fonts import URL for available fonts
   const googleFontImport = (() => {
@@ -226,38 +268,100 @@ function buildHTML(data) {
     justify-content: center;
     align-items: center;
     text-align: center;
-    padding: 80px;
+    padding: 96px 80px;
     background: ${primaryColor};
     color: ${coverTextColor};
   }
 
   .cover .logo-img {
-    max-width: 360px;
-    max-height: 220px;
-    margin-bottom: 48px;
+    max-width: 340px;
+    max-height: 180px;
+    margin-bottom: 64px;
     object-fit: contain;
   }
 
   .cover .domain {
-    font-size: 36px;
+    font-size: 56px;
     font-weight: 700;
-    letter-spacing: -0.5px;
-    line-height: 1.1;
-    margin-bottom: 12px;
+    line-height: 1.04;
+    margin-bottom: 28px;
+  }
+
+  .cover .rule {
+    width: 48px;
+    height: 2px;
+    background: ${coverTextColor};
+    opacity: 0.5;
+    margin: 0 auto 28px;
   }
 
   .cover .subtitle {
-    font-size: 16px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 3px;
+    font-size: 15px;
+    font-weight: 600;
     color: ${coverSubtitleColor};
-    margin-bottom: 8px;
   }
 
-  .cover .date {
-    font-size: 14px;
+  .cover .cover-meta {
+    position: absolute;
+    bottom: 64px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 13px;
     color: ${coverDateColor};
+  }
+
+  /* Back cover */
+  .back-cover {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    background: ${primaryColor};
+    color: ${coverTextColor};
+  }
+
+  .back-cover .logo-img {
+    max-width: 220px;
+    max-height: 110px;
+    object-fit: contain;
+    margin-bottom: 28px;
+  }
+
+  .back-cover .rule {
+    width: 40px;
+    height: 2px;
+    background: ${coverTextColor};
+    opacity: 0.45;
+    margin: 0 auto 24px;
+  }
+
+  .back-cover .back-doc {
+    font-size: 14px;
+    font-weight: 600;
+    color: ${coverSubtitleColor};
+    margin-bottom: 14px;
+  }
+
+  .back-cover .back-copyright {
+    font-size: 12px;
+    line-height: 1.7;
+    color: ${coverDateColor};
+  }
+
+  .back-cover .back-attrib {
+    position: absolute;
+    bottom: 56px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 11px;
+    color: ${coverDateColor};
+  }
+
+  .back-cover .back-attrib strong {
+    font-weight: 700;
   }
 
 
@@ -271,71 +375,59 @@ function buildHTML(data) {
     border-bottom: 2px solid #1a1a1a;
   }
 
-  .color-group-label {
-    font-size: 13px;
+  /* Colors — block layout */
+  .color-hero {
+    border-radius: 10px;
+    padding: 24px 28px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    min-height: 150px;
+    margin-bottom: 24px;
+  }
+
+  .color-hero .ch-name {
+    font-size: 22px;
     font-weight: 600;
-    color: #4a4a4a;
-    margin-bottom: 12px;
-    margin-top: 24px;
+    margin-bottom: 10px;
   }
 
-  .color-group-label:first-of-type { margin-top: 0; }
-
-  /* Colors — table layout */
-  .color-table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  .color-table thead th {
-    font-size: 11px;
-    font-weight: 700;
-    color: #4a4a4a;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0 12px 10px;
-    text-align: left;
-    border-bottom: 2px solid #1a1a1a;
-  }
-
-  .color-table thead th:first-child {
-    padding-left: 0;
-    width: 52px;
-  }
-
-  .color-table tbody td {
-    padding: 8px 12px;
+  .color-hero .ch-values {
     font-size: 12px;
     font-family: 'SF Mono', 'Menlo', monospace;
-    color: #1a1a1a;
-    vertical-align: middle;
-    border-bottom: 1px solid #d0d0d0;
+    line-height: 1.7;
+    opacity: 0.85;
   }
 
-  .color-table tbody td:first-child {
-    padding-left: 0;
-    padding-right: 12px;
+  .color-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
   }
 
-  .color-swatch {
-    width: 44px;
-    height: 28px;
-    border-radius: 4px;
-    border: 1px solid rgba(0,0,0,0.12);
-    display: inline-block;
+  .color-card .chip {
+    border-radius: 8px;
+    min-height: 96px;
+    display: flex;
+    align-items: flex-end;
+    padding: 12px 14px;
   }
 
-  .color-table .color-label-cell {
-    font-family: -apple-system, 'Helvetica Neue', Arial, sans-serif;
-    font-size: 11px;
+  .color-card .chip-name {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .color-card .card-meta {
+    padding: 10px 2px 0;
+    font-size: 10px;
+    font-family: 'SF Mono', 'Menlo', monospace;
     color: #555;
-    max-width: 120px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.7;
   }
 
-  .color-table .hex-cell {
+  .color-card .card-meta .cm-hex {
+    color: #1a1a1a;
     font-weight: 600;
   }
 
@@ -403,31 +495,6 @@ function buildHTML(data) {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  /* Shadows */
-  .shadow-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-  }
-
-  .shadow-card {
-    width: 100%;
-    aspect-ratio: 1.4;
-    background: #fff;
-    border-radius: 12px;
-    display: flex;
-    align-items: flex-end;
-    padding: 14px;
-  }
-
-  .shadow-label {
-    font-size: 10px;
-    font-family: 'SF Mono', 'Menlo', monospace;
-    color: #555;
-    word-break: break-all;
-    line-height: 1.3;
   }
 
   /* Footer */
@@ -535,6 +602,59 @@ function buildHTML(data) {
     max-width: 280px;
     max-height: 100px;
   }
+
+  /* Logo misuse — "don't" grid */
+  .misuse-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    margin-top: 16px;
+  }
+
+  .misuse-box {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 24px 16px 38px;
+    min-height: 124px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .misuse-box img {
+    max-width: 150px;
+    max-height: 56px;
+    object-fit: contain;
+  }
+
+  .misuse-mark {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #d92d20;
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+
+  .misuse-label {
+    position: absolute;
+    bottom: 12px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 11px;
+    color: #555;
+  }
 </style>
 </head>
 <body>
@@ -543,8 +663,9 @@ function buildHTML(data) {
 <div class="page cover">
   ${logoUrl ? `<img class="logo-img" src="${escapeAttr(logoUrl)}" />` : ''}
   <div class="domain">${escapeHtml(companyName)}</div>
-  <div class="subtitle">Brand Guide</div>
-  <div class="date">${escapeHtml(domain)}  /  ${date}</div>
+  <div class="rule"></div>
+  <div class="subtitle">Brand Guidelines</div>
+  <div class="cover-meta">${escapeHtml(domain)}&nbsp;&nbsp;&middot;&nbsp;&nbsp;${date}${data.meta?.dembrandtVersion ? `&nbsp;&nbsp;&middot;&nbsp;&nbsp;v${escapeHtml(data.meta.dembrandtVersion)}` : ''}</div>
 </div>
 
 <!-- TABLE OF CONTENTS -->
@@ -554,6 +675,8 @@ ${(() => {
   let tocPage = pageNum + 1;
   if (logoUrl) {
     tocEntries.push({ title: 'Logo', page: tocPage });
+    tocPage++;
+    tocEntries.push({ title: 'Logo Misuse', page: tocPage });
     tocPage++;
   }
   if (colors.length > 0) {
@@ -568,11 +691,7 @@ ${(() => {
       tocPage++;
     }
   }
-  if (showShadows) {
-    tocEntries.push({ title: 'Elevation', page: tocPage });
-    tocPage++;
-  }
-  // Group entries: Logo | Colors | Typography... | Elevation
+  // Group entries: Logo | Colors | Typography...
   const groups = [];
   let currentGroup = [];
   for (const e of tocEntries) {
@@ -677,47 +796,80 @@ ${logoUrl ? (() => {
 </div>`;
 })() : ''}
 
+<!-- LOGO MISUSE -->
+${logoUrl ? (() => {
+  pageNum++;
+  const boxBg = logoIsLight ? '#0a0a0a' : '#ffffff';
+  const violations = [
+    { label: "Don't stretch", style: 'transform:scaleX(1.55)' },
+    { label: "Don't condense", style: 'transform:scaleY(0.55)' },
+    { label: "Don't rotate", style: 'transform:rotate(-12deg)' },
+    { label: "Don't recolor", style: 'filter:hue-rotate(150deg) saturate(2.2)' },
+    { label: "Don't add effects", style: 'filter:drop-shadow(3px 4px 2px rgba(0,0,0,0.45))' },
+    { label: "Don't reduce contrast", style: 'opacity:0.32', boxBg: 'linear-gradient(135deg,#9aa0a6,#cdd1d6)' },
+  ];
+  return `
+<div class="page">
+  <div class="section-title">Logo Misuse</div>
+  <p style="font-size:12px;color:#555;line-height:1.7;max-width:520px;margin-bottom:8px">
+    Keep the logo consistent. Do not alter its proportions, colors, orientation, or apply effects.
+    The examples below are incorrect.
+  </p>
+  <div class="misuse-grid">
+    ${violations.map(v => `
+    <div class="misuse-box" style="background:${escapeAttr(v.boxBg || boxBg)}">
+      <img src="${escapeAttr(logoUrl)}" style="${v.style}" />
+      <span class="misuse-mark">&#10005;</span>
+      <span class="misuse-label">${escapeHtml(v.label)}</span>
+    </div>`).join('')}
+  </div>
+  ${footer(pageNum)}
+</div>`;
+})() : ''}
+
 <!-- COLORS -->
 ${colors.length > 0 ? (() => {
-  const sortedSemantic = sortByHue(semanticColors);
-  const sortedPalette = sortByHue(paletteColors);
-  const allSorted = [...sortedSemantic, ...sortedPalette];
-  const n = allSorted.length;
-  if (n === 0) return '';
-  // A4 usable height ~920px, minus title ~70px, thead ~30px, footer ~40px = ~780px for rows
-  const availH = 780;
-  const rowTotal = Math.floor(availH / n);
-  const swatchH = rowTotal >= 40 ? 28 : rowTotal >= 32 ? 20 : rowTotal >= 26 ? 16 : 12;
-  const rowPad = Math.max(1, Math.floor((rowTotal - swatchH) / 2));
-  const fontSize = rowTotal < 30 ? 10 : 12;
+  const ordered = [...sortByHue(semanticColors), ...sortByHue(paletteColors)];
+  if (!ordered.length) return '';
 
-  const colorRow = (c) => `
-      <tr>
-        <td style="padding:${rowPad}px 12px ${rowPad}px 0"><div class="color-swatch" style="background:${c.hex};height:${swatchH}px"></div></td>
-        ${c.label ? `<td class="color-label-cell" style="padding:${rowPad}px 12px;font-size:${fontSize}px">${escapeHtml(c.label)}</td>` : `<td style="padding:${rowPad}px 12px"></td>`}
-        <td class="hex-cell" style="padding:${rowPad}px 12px;font-size:${fontSize}px">${c.hex.toUpperCase()}</td>
-        <td style="padding:${rowPad}px 12px;font-size:${fontSize}px">${formatRgb(c.hex)}</td>
-        <td style="padding:${rowPad}px 12px;font-size:${fontSize}px">${formatCmyk(c.hex)}</td>
-      </tr>`;
+  // Primary = the explicit 'primary' role, else first semantic, else most chromatic
+  const primary = semanticColors.find(c => /primary/i.test(c.label || ''))
+    || semanticColors[0]
+    || ordered.reduce((best, c) => chroma(c.hex) > chroma(best.hex) ? c : best, ordered[0]);
+
+  const rest = ordered.filter(c => c.hex !== primary.hex).slice(0, 9);
+
+  const heroFg = textColor(primary.hex);
+  const heroValues = heroFg === '#fff' ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.6)';
+
+  const card = (c) => {
+    const fg = textColor(c.hex);
+    return `
+    <div class="color-card">
+      <div class="chip" style="background:${c.hex};color:${fg}">
+        <span class="chip-name">${escapeHtml(colorName(c))}</span>
+      </div>
+      <div class="card-meta">
+        <span class="cm-hex">${c.hex.toUpperCase()}</span><br>
+        RGB ${formatRgb(c.hex)}<br>
+        CMYK ${formatCmyk(c.hex)}
+      </div>
+    </div>`;
+  };
 
   pageNum++;
   return `
 <div class="page">
   <div class="section-title">Color Palette</div>
-  <table class="color-table">
-    <thead>
-      <tr>
-        <th></th>
-        <th></th>
-        <th>hex</th>
-        <th>rgb</th>
-        <th>cmyk</th>
-      </tr>
-    </thead>
-    <tbody>
-      ${allSorted.map(c => colorRow(c)).join('')}
-    </tbody>
-  </table>
+  <div class="color-hero" style="background:${primary.hex};color:${heroFg}">
+    <div class="ch-name">${escapeHtml(colorName(primary))}</div>
+    <div class="ch-values" style="color:${heroValues}">
+      ${primary.hex.toUpperCase()}&nbsp;&nbsp;&middot;&nbsp;&nbsp;RGB ${formatRgb(primary.hex)}&nbsp;&nbsp;&middot;&nbsp;&nbsp;CMYK ${formatCmyk(primary.hex)}
+    </div>
+  </div>
+  <div class="color-grid">
+    ${rest.map(card).join('')}
+  </div>
   ${footer(pageNum)}
 </div>`;
 })() : ''}
@@ -805,36 +957,21 @@ ${fonts.length > 0 ? (() => {
   return pages.join('\n');
 })() : ''}
 
-<!-- SHADOWS -->
-${showShadows ? (() => {
-  pageNum++;
-  return `
-<div class="page">
-  <div class="section-title">Elevation</div>
-  <div class="shadow-grid">
-    ${shadows.map(s => `
-    <div class="shadow-card" style="box-shadow:${escapeAttr(s.shadow)}">
-      <div class="shadow-label">${escapeHtml(truncate(s.shadow, 70))}</div>
-    </div>`).join('')}
-  </div>
-  ${footer(pageNum)}
-</div>`;
-})() : ''}
-
-<!-- CLOSING PAGE -->
+<!-- BACK COVER -->
 ${(() => {
-  const closeBg = primaryColor;
-  const closeFg = coverTextColor;
-  const subtleFg = closeFg === '#fff' ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.25)';
-  const dembrandtFg = closeFg === '#fff' ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)';
+  const year = (() => { const y = new Date(data.extractedAt).getFullYear(); return Number.isFinite(y) ? y : new Date().getFullYear(); })();
+  const version = data.meta?.dembrandtVersion;
   return `
-<div class="page" style="display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;background:${closeBg}">
-  ${logoUrl ? `<img src="${escapeAttr(logoUrl)}" style="max-width:240px;max-height:120px;object-fit:contain;margin-bottom:64px" />` : ''}
-  <div style="margin-top:auto"></div>
-  <div style="margin-bottom:48px;text-align:center">
-    <div style="font-size:10px;color:${subtleFg};letter-spacing:1px;margin-bottom:8px">Extracted with</div>
-    <div style="font-size:16px;font-weight:700;color:${dembrandtFg};letter-spacing:2px">DEMBRANDT</div>
-    <div style="font-size:9px;color:${subtleFg};margin-top:4px">dembrandt.com</div>
+<div class="page back-cover">
+  ${logoUrl ? `<img class="logo-img" src="${escapeAttr(logoUrl)}" />` : ''}
+  <div class="rule"></div>
+  <div class="back-doc">Brand Guidelines</div>
+  <div class="back-copyright">
+    &copy; ${year} ${escapeHtml(companyName)}. All rights reserved.<br>
+    These guidelines and the assets within remain the property of ${escapeHtml(companyName)}.
+  </div>
+  <div class="back-attrib">
+    Created with <strong>DEMBRANDT</strong>&nbsp;&nbsp;&middot;&nbsp;&nbsp;dembrandt.com${version ? `&nbsp;&nbsp;&middot;&nbsp;&nbsp;v${escapeHtml(version)}` : ''}
   </div>
 </div>`;
 })()}
@@ -844,7 +981,17 @@ ${(() => {
 }
 
 function getLogoImageUrl(data) {
-  const isImageUrl = (url) => /\.(svg|png|jpg|jpeg|webp|gif)(\?.*)?$/i.test(url);
+  const isImageUrl = (url) => {
+    if (/\.(svg|png|jpg|jpeg|webp|gif|avif)(\?.*)?$/i.test(url)) return true;
+    // Image optimizers (Next.js /_next/image, Cloudflare /cdn-cgi/image, etc.)
+    // embed the real file in a query param and serve an image. The extension
+    // lands mid-URL, so check the decoded form too.
+    try {
+      const decoded = decodeURIComponent(url);
+      if (/\.(svg|png|jpg|jpeg|webp|gif|avif)(?=[?&]|$)/i.test(decoded)) return true;
+    } catch { /* malformed encoding — fall through */ }
+    return false;
+  };
 
   // Inline SVG logos carry their own self-contained data URI.
   if (data.logo?.inline && data.logo.dataUri) {
@@ -966,10 +1113,4 @@ function escapeAttr(str) {
     .replace(/'/g, '&#39;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
-}
-
-function truncate(str, max) {
-  if (!str) return '';
-  if (str.length <= max) return str;
-  return str.slice(0, max - 1) + '\u2026';
 }


### PR DESCRIPTION
Brand guide PDF (`--brand-guide`) reworked toward a marketing-style brand book rather than a design-system dump.

## Changes
- **Cover / back cover**: larger, readable type; removed squinty 9px text and decorative letter-spacing. Back cover follows brand-guide convention with a copyright + property notice.
- **Color page**: replaced the dev-style hex/rgb/cmyk table with marketing color blocks. A primary hero block plus a named-swatch grid. Names come from semantic roles where available, otherwise a descriptive hue name.
- **Logo Misuse page**: standard "don't" examples (stretch, condense, rotate, recolor, effects, low contrast).
- **Logo detection fix**: image-optimizer URLs (Next.js `/_next/image`, Cloudflare `/cdn-cgi/image`) carry the file extension mid-URL, so `isImageUrl` failed and the PDF fell back to the favicon. Now decodes and matches, so the real logo renders.
- **Version**: shown on cover and back cover from `data.meta.dembrandtVersion`.
- **Removed Elevation/shadows page**: design-system vocabulary, out of place in a marketing brand guide. Dropped the section, its TOC entry, CSS, and now-dead `truncate` helper.

## Verification
Generated for dembrandt.com: cover, color page, and back cover render correctly; TOC page numbers stay in sync; logo now shows the real wordmark instead of the favicon triangle.

## Notes
Hue naming is heuristic. Semantic-labelled colors are exact; unlabelled palette colors get approximate names (e.g. a sky blue may read as "Teal", and two colors can share a name). Tunable later via hue boundaries or shade qualifiers.