### PR TITLE
fix: build before nightly QA and surface subprocess stderr

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
+      - name: Build
+        run: npm run build
+
       - name: Split sites and extract chunk ${{ matrix.chunk }}
         run: |
           node -e "

--- a/test/qa.mjs
+++ b/test/qa.mjs
@@ -78,7 +78,10 @@ function extractSite(domain) {
     );
     return data;
   } catch (err) {
+    const stderr = (err.stderr?.toString() || "").trim();
+    const detail = stderr ? stderr.split("\n").slice(-3).join("\n      ") : "";
     console.log(`    FAILED — ${err.message.split("\n")[0]}`);
+    if (detail) console.log(`      ${detail}`);
     return null;
   }
 }
@@ -109,7 +112,10 @@ function extractToTemp(domain) {
     fs.writeFileSync(path.join(tmpDir, "extraction.json"), JSON.stringify(data, null, 2));
     return { data, screenshotPath, dir: tmpDir };
   } catch (err) {
+    const stderr = (err.stderr?.toString() || "").trim();
+    const detail = stderr ? stderr.split("\n").slice(-3).join("\n      ") : "";
     console.log(`    FAILED — ${err.message.split("\n")[0]}`);
+    if (detail) console.log(`      ${detail}`);
     return null;
   }
 }


### PR DESCRIPTION
## Problem

The nightly Full QA workflow reported all sites as `FAILED — Command failed: node dist/index.js ...` across every chunk.

## Root cause

`nightly.yml` calls `node test/qa.mjs` directly, bypassing the `npm run qa:baseline` script — which is the only place `npm run build` runs. The workflow had `npm ci` and `npx playwright install` but **no build step**. Since `dist/` is gitignored and not committed, `dist/index.js` never existed on the runner, so every `node dist/index.js ...` threw "Cannot find module". `smoke.yml` already has this Build step; nightly was missing it.

The failure was opaque because `qa.mjs` caught the `execSync` error and printed only the first line of `err.message`, discarding the captured `err.stderr` that held the real cause.

## Changes

- `.github/workflows/nightly.yml`: add `Build` step before extraction, matching `smoke.yml`.
- `test/qa.mjs`: print the last lines of `err.stderr` on failure so future CI failures show the actual error.

## Verification

- Exact CI command runs locally (exit 0, screenshot written).
- `eslint test/qa.mjs` passes.