### PR TITLE
chore: release 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 0.18.0.

## Contents since v0.17.1
- #82 — output contract schemaVersion 1.0.0 -> 1.1.0, guaranteed SpacingValue.display
- ce35cee — hidden internal --teach flag (data generation, hidden from --help, no public docs)

## Bump rationale
Minor: additive output contract (display field) plus a new flag. Pre-1.0, no breaking change.

## Verified
- build, lint pass
- 169 unit tests pass
- SCHEMA_VERSION already 1.1.0 in lib/version.ts; toolVersion -> 0.18.0 via package.json

## After merge
1. Tag v0.18.0 on main, manual npm publish (granular token bypasses OTP) or rely on release.yml
2. gh release create v0.18.0 -> triggers idempotent npm publish + downstream sync
3. dembrandt-next: extract-types.ts display field, layout.tsx softwareVersion; merge skills before next