### PR TITLE
feat: HTML drift report + --compare gate (0.19.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,31 @@ npx playwright@$(node -p "require('playwright-core/package.json').version") inst
 
 A mismatched version fails with "Executable doesn't exist". The container image avoids this entirely — just match its tag (`v1.60.0`) to the `playwright-core` version.
 
+### Drift gate
+
+Compare an extraction against a committed baseline and fail the job on drift:
+
+```bash
+# capture a baseline once (same environment you will check against)
+dembrandt https://app.example.com --json-only > baseline.json
+
+# in CI — exits non-zero on drift; writes a report artifact
+dembrandt https://app.example.com --compare baseline.json --html report.html
+```
+
+### Exit codes
+
+A pipeline can branch on the exit code; "design drifted" and "extraction broke" are distinct:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success, or stable (no drift) under `--compare` |
+| `1` | Drift detected (`--compare`) |
+| `2` | Extraction failure (`EXTRACTION_FAILED`, `BROWSER_UNAVAILABLE`) |
+| `67` | Navigation/connection timeout (`NAVIGATION_TIMEOUT`) — retryable, try `--slow` |
+
+With `--json-only`, a failure also prints a machine-readable `{ "error": { "code", "message" } }` to stdout.
+
 ## Recipes
 
 **Quick brand scan**

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { checkRobotsTxt } from "./lib/robots.js";
+import { EXIT, classifyError } from "./lib/exit-codes.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -38,23 +39,6 @@ const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "ut
 function spinnerOptions(useStderr = false) {
   const stream = useStderr ? process.stderr : process.stdout;
   return { stream, isEnabled: Boolean(stream.isTTY) && !process.env.CI };
-}
-
-/**
- * CI exit-code contract. A pipeline branches on these to tell apart "design
- * drifted" (review the diff) from "extraction broke" (retry / investigate):
- *   0  success / stable      1  drift detected (--compare)
- *   2  extraction failure    67 navigation/connection timeout (retryable, try --slow)
- */
-const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 };
-
-/** Classify an extraction failure into a stable {code, exit} for CI consumers. */
-function classifyError(err: any): { code: string; exit: number } {
-  const m = String(err?.message ?? "");
-  if (/Timeout|net::ERR_|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ERR_NAME_NOT_RESOLVED/i.test(m)) {
-    return { code: "NAVIGATION_TIMEOUT", exit: EXIT.TIMEOUT };
-  }
-  return { code: "EXTRACTION_FAILED", exit: EXIT.RUNTIME };
 }
 
 program

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { computeDrift } from "./lib/drift.js";
 import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
-import { join, dirname } from "path";
+import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { checkRobotsTxt } from "./lib/robots.js";
 
@@ -430,7 +430,7 @@ program
           const htmlDomain = new URL(url).hostname.replace("www.", "");
           let htmlPath;
           if (typeof opts.html === "string") {
-            htmlPath = join(process.cwd(), opts.html);
+            htmlPath = resolve(process.cwd(), opts.html);
             mkdirSync(dirname(htmlPath), { recursive: true });
           } else {
             const htmlStamp = new Date().toISOString().replace(/[:.]/g, "-").split(".")[0];

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generatePDF } from "./lib/formatters/pdf.js";
 import { generateDesignMd } from "./lib/formatters/markdown.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
-import { computeDrift } from "./lib/drift.js";
+import { resolveCompare } from "./lib/compare.js";
 import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
@@ -74,7 +74,7 @@ program
   .option("--brand-guide", "Export a brand guide PDF")
   .option("--design-md", "Export a DESIGN.md file")
   .option("--html [path]", "Write a self-contained HTML report (default: output/<domain>/<timestamp>.html)")
-  .option("--compare <baseline>", "Compare against a baseline extraction JSON (as saved by --save-output); reports drift and exits 1 on drift")
+  .option("--compare <baseline>", "Drift-compare against a baseline: a local JSON file, or an App baseline id (posts to the .dembrandtrc endpoint, default dembrandt.com). Exits 1 on drift.")
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a viewport screenshot of the page (not full-page)")
@@ -402,23 +402,30 @@ program
         }
       }
 
-      // Compare against a baseline extraction (deterministic, structured-token diff)
+      // Compare against a baseline: a local file (free, offline) or an App
+      // baseline id (platform). resolveCompare dispatches on file-vs-id.
       let driftReport;
       if (opts.compare) {
         try {
-          const baseline = JSON.parse(readFileSync(opts.compare, "utf-8"));
-          driftReport = computeDrift(baseline, result);
-          const verdict = driftReport.status === "drift"
-            ? color.warning(`drift ${driftReport.score} (threshold ${driftReport.threshold})`)
-            : color.accent(`stable ${driftReport.score}`);
+          // The App endpoint for baseline-id compares comes from .dembrandtrc.
+          let apiBase;
+          try {
+            const rc = JSON.parse(readFileSync(join(process.cwd(), ".dembrandtrc"), "utf-8"));
+            if (typeof rc.endpoint === "string") apiBase = rc.endpoint;
+          } catch { /* no .dembrandtrc, or unreadable — use the default */ }
+          const { report, source, mode } = await resolveCompare(opts.compare, result, apiBase ? { api: apiBase } : {});
+          driftReport = report;
+          const verdict = report.status === "drift"
+            ? color.warning(`drift ${report.score} (threshold ${report.threshold})`)
+            : color.accent(`stable ${report.score}`);
           savedNotices.push(
             chalk.dim(
-              `⟂ Drift vs ${opts.compare}: ${verdict} — ` +
-              `${driftReport.summary.changed} changed, ${driftReport.summary.added} added, ${driftReport.summary.removed} removed`
+              `⟂ Drift vs ${source} (${mode}): ${verdict} — ` +
+              `${report.summary.changed} changed, ${report.summary.added} added, ${report.summary.removed} removed`
             )
           );
-          // CI gate: drift beyond threshold fails the run, but the report still writes first.
-          if (driftReport.status === "drift") process.exitCode = EXIT.DRIFT;
+          // CI gate: drift fails the run, but the report still writes first.
+          if (report.status === "drift") process.exitCode = EXIT.DRIFT;
         } catch (err) {
           console.log(color.warning(`! Could not compare against baseline: ${err.message}`));
         }

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,8 @@ import { color } from "./lib/formatters/theme.js";
 import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generatePDF } from "./lib/formatters/pdf.js";
 import { generateDesignMd } from "./lib/formatters/markdown.js";
+import { generateHtmlReport } from "./lib/formatters/html.js";
+import { computeDrift } from "./lib/drift.js";
 import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
@@ -54,6 +56,8 @@ program
   .option("--slow", "3x longer timeouts for slow-loading sites")
   .option("--brand-guide", "Export a brand guide PDF")
   .option("--design-md", "Export a DESIGN.md file")
+  .option("--html [path]", "Write a self-contained HTML report (default: output/<domain>/<timestamp>.html)")
+  .option("--compare <baseline>", "Compare against a baseline extraction JSON (as saved by --save-output); reports drift and exits 1 on drift")
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
   .option("--screenshot <path>", "Save a viewport screenshot of the page (not full-page)")
@@ -377,6 +381,59 @@ program
         }
       }
 
+      // Compare against a baseline extraction (deterministic, structured-token diff)
+      let driftReport;
+      if (opts.compare) {
+        try {
+          const baseline = JSON.parse(readFileSync(opts.compare, "utf-8"));
+          driftReport = computeDrift(baseline, result);
+          const verdict = driftReport.status === "drift"
+            ? color.warning(`drift ${driftReport.score} (threshold ${driftReport.threshold})`)
+            : color.accent(`stable ${driftReport.score}`);
+          savedNotices.push(
+            chalk.dim(
+              `⟂ Drift vs ${opts.compare}: ${verdict} — ` +
+              `${driftReport.summary.changed} changed, ${driftReport.summary.added} added, ${driftReport.summary.removed} removed`
+            )
+          );
+          // CI gate: drift beyond threshold fails the run, but the report still writes first.
+          if (driftReport.status === "drift") process.exitCode = 1;
+        } catch (err) {
+          console.log(color.warning(`! Could not compare against baseline: ${err.message}`));
+        }
+      }
+
+      // Generate self-contained HTML report
+      if (opts.html !== undefined) {
+        try {
+          const htmlDomain = new URL(url).hostname.replace("www.", "");
+          let htmlPath;
+          if (typeof opts.html === "string") {
+            htmlPath = join(process.cwd(), opts.html);
+            mkdirSync(dirname(htmlPath), { recursive: true });
+          } else {
+            const htmlStamp = new Date().toISOString().replace(/[:.]/g, "-").split(".")[0];
+            const htmlDir = join(process.cwd(), "output", htmlDomain);
+            mkdirSync(htmlDir, { recursive: true });
+            htmlPath = join(htmlDir, `${htmlStamp}_v${version}.html`);
+          }
+          writeFileSync(
+            htmlPath,
+            generateHtmlReport(result, {
+              version,
+              drift: driftReport,
+              baselineLabel: opts.compare,
+            })
+          );
+          const htmlLabel = typeof opts.html === "string" ? opts.html : `output/${htmlDomain}/${htmlPath.split("/").pop()}`;
+          savedNotices.push(
+            chalk.dim(`💾 HTML report saved (--html): ${color.info(htmlLabel)}`)
+          );
+        } catch (err) {
+          console.log(color.warning(`! Could not write HTML report: ${err.message}`));
+        }
+      }
+
       // Output to terminal
       const summaryLine =
         color.accent('✨ Analysis summary: ') +
@@ -412,8 +469,8 @@ program
 // so render them via a custom formatHelp. Subcommands keep a single flat list.
 const OPTION_GROUPS = [
   ["Extraction", ["--dark-mode", "--mobile", "--slow", "--crawl", "--sitemap", "--browser"]],
-  ["Output & export", ["--json-only", "--save-output", "--dtcg", "--brand-guide", "--design-md", "--screenshot", "--raw-colors"]],
-  ["Analysis", ["--wcag"]],
+  ["Output & export", ["--json-only", "--save-output", "--dtcg", "--brand-guide", "--design-md", "--html", "--screenshot", "--raw-colors"]],
+  ["Analysis", ["--wcag", "--compare"]],
   ["Network & auth", ["--cookie", "--header", "--user-agent", "--locale", "--timezone", "--accept-language", "--screen-size"]],
   ["Anti-detection", ["--stealth", "--no-sandbox"]],
 ];

--- a/index.ts
+++ b/index.ts
@@ -40,6 +40,23 @@ function spinnerOptions(useStderr = false) {
   return { stream, isEnabled: Boolean(stream.isTTY) && !process.env.CI };
 }
 
+/**
+ * CI exit-code contract. A pipeline branches on these to tell apart "design
+ * drifted" (review the diff) from "extraction broke" (retry / investigate):
+ *   0  success / stable      1  drift detected (--compare)
+ *   2  extraction failure    67 navigation/connection timeout (retryable, try --slow)
+ */
+const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 };
+
+/** Classify an extraction failure into a stable {code, exit} for CI consumers. */
+function classifyError(err: any): { code: string; exit: number } {
+  const m = String(err?.message ?? "");
+  if (/Timeout|net::ERR_|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ERR_NAME_NOT_RESOLVED/i.test(m)) {
+    return { code: "NAVIGATION_TIMEOUT", exit: EXIT.TIMEOUT };
+  }
+  return { code: "EXTRACTION_FAILED", exit: EXIT.RUNTIME };
+}
+
 program
   .name("dembrandt")
   .description("Extract design tokens from any website.")
@@ -112,7 +129,11 @@ program
       ({ chromium, firefox } = await loadBrowserEngines());
     } catch (err) {
       spinner.fail(err.message);
-      process.exit(1);
+      if (opts.jsonOnly) {
+        console.log = originalConsoleLog;
+        console.log(JSON.stringify({ url, error: { code: "BROWSER_UNAVAILABLE", message: err.message } }, null, 2));
+      }
+      process.exit(EXIT.RUNTIME);
     }
 
     let browser = null;
@@ -397,7 +418,7 @@ program
             )
           );
           // CI gate: drift beyond threshold fails the run, but the report still writes first.
-          if (driftReport.status === "drift") process.exitCode = 1;
+          if (driftReport.status === "drift") process.exitCode = EXIT.DRIFT;
         } catch (err) {
           console.log(color.warning(`! Could not compare against baseline: ${err.message}`));
         }
@@ -455,11 +476,18 @@ program
         for (const notice of savedNotices) console.log(notice);
       }
     } catch (err) {
+      const { code, exit } = classifyError(err);
       spinner.fail("Failed");
-      console.error(chalk.red("\n✗ Extraction failed"));
-      console.error(chalk.red(`  Error: ${err.message}`));
-      console.error(chalk.dim(`  URL: ${url}`));
-      process.exit(1);
+      if (opts.jsonOnly) {
+        console.log = originalConsoleLog;
+        console.log(JSON.stringify({ url, error: { code, message: err.message } }, null, 2));
+      } else {
+        console.error(chalk.red("\n✗ Extraction failed"));
+        console.error(chalk.red(`  Error [${code}]: ${err.message}`));
+        console.error(chalk.dim(`  URL: ${url}`));
+        if (exit === EXIT.TIMEOUT) console.error(chalk.dim("  Hint: retry with --slow"));
+      }
+      process.exit(exit);
     } finally {
       if (browser) await browser.close();
     }

--- a/lib/compare.ts
+++ b/lib/compare.ts
@@ -1,0 +1,70 @@
+/**
+ * --compare dispatch. The argument is either:
+ *   - a local file  → diff against it here (free, offline, deterministic)
+ *   - a baseline id → POST the candidate to the Dembrandt App, which stores
+ *                     baselines and runs the same engine server-side
+ *
+ * Same flag, two backends — the local path is the free wedge; the id path is the
+ * App platform (dembrandt-next/app). Both call the one canonical drift engine.
+ *
+ * Dependencies are injectable so the dispatch is unit-testable without a real
+ * filesystem or network.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { computeDrift } from "./drift.js";
+import type { BrandingResult } from "./types.js";
+import type { DriftReport } from "./drift.js";
+
+export interface CompareResult {
+  report: DriftReport;
+  /** Human label for where the baseline came from (file path or "<api> #<id>"). */
+  source: string;
+  /** "local" file diff or "platform" App diff. */
+  mode: "local" | "platform";
+}
+
+export interface CompareDeps {
+  isFile?: (p: string) => boolean;
+  readFile?: (p: string, enc: "utf-8") => string;
+  fetchFn?: typeof fetch;
+  /** App base URL. Caller passes the `.dembrandtrc` `endpoint`; default is the
+   *  production App at https://dembrandt.com. */
+  api?: string;
+}
+
+/** Resolve a `--compare <arg>` into a drift report, dispatching on file vs id. */
+export async function resolveCompare(
+  arg: string,
+  candidate: BrandingResult,
+  deps: CompareDeps = {},
+): Promise<CompareResult> {
+  const isFile = deps.isFile ?? existsSync;
+  const readFile = deps.readFile ?? (readFileSync as (p: string, enc: "utf-8") => string);
+
+  if (isFile(arg)) {
+    const baseline = JSON.parse(readFile(arg, "utf-8")) as BrandingResult;
+    return { report: computeDrift(baseline, candidate), source: arg, mode: "local" };
+  }
+
+  // Not a local file → treat as a platform baseline id.
+  const fetchFn = deps.fetchFn ?? fetch;
+  const api = (deps.api ?? "https://dembrandt.com").replace(/\/$/, "");
+  const res = await fetchFn(`${api}/api/app/drift`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ baselineId: arg, candidate }),
+  });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const e = (await res.json()) as { error?: string };
+      if (e?.error) detail = e.error;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(`platform compare failed (${res.status}): ${detail}`);
+  }
+  const data = (await res.json()) as { drift: DriftReport };
+  return { report: data.drift, source: `${api} #${arg}`, mode: "platform" };
+}

--- a/lib/exit-codes.ts
+++ b/lib/exit-codes.ts
@@ -1,0 +1,30 @@
+/**
+ * CI exit-code contract. A pipeline branches on these to tell apart "design
+ * drifted" (review the diff) from "extraction broke" (retry / investigate):
+ *   0  success / stable      1  drift detected (--compare)
+ *   2  extraction failure    67 navigation/connection timeout (retryable, try --slow)
+ *
+ * Kept in its own module (not index.ts, which runs the CLI on import) so the
+ * classifier is importable and unit-testable without spawning a subprocess.
+ * Consumers (dembrandt-next/.github/workflows/drift.yml) depend on these values;
+ * changing one is a breaking change to the gate.
+ */
+
+export const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 } as const;
+
+/** Stable failure code surfaced to CI alongside the numeric exit. */
+export type ErrorCode = "NAVIGATION_TIMEOUT" | "EXTRACTION_FAILED";
+
+/**
+ * Classify an extraction failure into a stable {code, exit} for CI consumers.
+ * Network/DNS/timeout errors map to the retryable TIMEOUT exit; everything else
+ * is a generic RUNTIME failure. Reads only `err.message`, so a bare string or a
+ * malformed error never throws.
+ */
+export function classifyError(err: any): { code: ErrorCode; exit: number } {
+  const m = String(err?.message ?? "");
+  if (/Timeout|net::ERR_|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ERR_NAME_NOT_RESOLVED/i.test(m)) {
+    return { code: "NAVIGATION_TIMEOUT", exit: EXIT.TIMEOUT };
+  }
+  return { code: "EXTRACTION_FAILED", exit: EXIT.RUNTIME };
+}

--- a/lib/findings.ts
+++ b/lib/findings.ts
@@ -1,0 +1,190 @@
+/**
+ * Design-system findings — the honest, computable audits that back the report's
+ * summary scores. Every gauge number traces to a concrete finding here; nothing
+ * is a vanity metric. These are the decay signals product-strategy names: a hex
+ * off by a hair (ΔE), a role with no visual hierarchy, a brand colour that fails
+ * contrast, an off-scale spacing value. Pure and deterministic — given the same
+ * extraction it always returns the same findings, so it is safe to gate on.
+ *
+ * This mirrors the documented `--lint` categories (development-prompts.md): each
+ * finding has a severity, and the consistency score is derived from them.
+ */
+
+import { deltaE2000, relativeLuminance } from "./colors.js";
+import type { BrandingResult } from "./types.js";
+
+export type FindingSeverity = "error" | "warn";
+export type FindingCategory = "contrast" | "consistency" | "duplication";
+
+export interface Finding {
+  category: FindingCategory;
+  /** Display grouping for the report (Gestalt proximity): Color, Typography, … */
+  group: string;
+  severity: FindingSeverity;
+  message: string;
+}
+
+export interface FindingsReport {
+  findings: Finding[];
+  /** 0-100 from the type/spacing/duplication findings. 100 = no issues. */
+  consistency: number;
+  /** 0-100 from the contrast findings. 100 = no contrast issues. */
+  contrast: number;
+  /** How complete the captured token set is, as a fraction. */
+  coverage: { present: number; total: number };
+}
+
+/** Parse a hex or rgb()/rgba() string to #rrggbb, or null if unparseable. */
+function toHex(input: string | undefined | null): string | null {
+  if (!input) return null;
+  const s = String(input).trim();
+  if (/^#[0-9a-f]{6}$/i.test(s)) return s.toLowerCase();
+  if (/^#[0-9a-f]{3}$/i.test(s)) {
+    return ("#" + s.slice(1).split("").map((c) => c + c).join("")).toLowerCase();
+  }
+  const m = s.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+  if (m) {
+    const h = (n: string) => Math.max(0, Math.min(255, Number(n))).toString(16).padStart(2, "0");
+    return ("#" + h(m[1]) + h(m[2]) + h(m[3])).toLowerCase();
+  }
+  return null;
+}
+
+/** WCAG contrast ratio between two colours (any parseable form), or null. */
+function contrastRatio(a: string, b: string): number | null {
+  const ha = toHex(a);
+  const hb = toHex(b);
+  if (!ha || !hb) return null;
+  const la = relativeLuminance(ha);
+  const lb = relativeLuminance(hb);
+  if (la == null || lb == null) return null;
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Leading pixel value of a size string like "40px (2.50rem)", or null. */
+function pxOf(size: string | undefined): number | null {
+  if (!size) return null;
+  const m = String(size).match(/(-?\d+(?:\.\d+)?)\s*px/);
+  return m ? Number(m[1]) : null;
+}
+
+export function computeFindings(result: BrandingResult): FindingsReport {
+  const findings: Finding[] = [];
+
+  // 1. Near-duplicate palette colours (ΔE2000 < just-noticeable). The "#133074
+  //    where #133174 should be" decay — two tokens that are visually one colour.
+  const palette = (result.colors?.palette ?? [])
+    .map((c) => (c.normalized || c.color || "").toLowerCase())
+    .filter((h) => /^#[0-9a-f]{6}$/i.test(h));
+  const seenDup = new Set<string>();
+  for (let i = 0; i < palette.length; i++) {
+    for (let j = i + 1; j < palette.length; j++) {
+      const d = deltaE2000(palette[i], palette[j]);
+      // < 1.0 = indistinguishable. Looser (the 2.3 JND) flags intentional
+      // surface tokens (e.g. #fff vs #f6f6f7 at ΔE 1.9) and creates noise.
+      if (d < 1.0) {
+        const key = [palette[i], palette[j]].sort().join("|");
+        if (seenDup.has(key)) continue;
+        seenDup.add(key);
+        findings.push({
+          category: "duplication",
+          group: "Color",
+          severity: "warn",
+          message: `${palette[i]} and ${palette[j]} are perceptually identical (ΔE ${d.toFixed(1)}) — likely one token split in two.`,
+        });
+      }
+    }
+  }
+
+  // 2. Type roles with no hierarchy — two distinct roles sharing size + weight.
+  //    Only flag where hierarchy is *expected*: two heading levels that collide,
+  //    or a heading sharing a size with body. Body/link/ui sharing a size is the
+  //    convention, not a smell, so those groups are skipped.
+  const isHierarchy = (r: string) => /heading|display|title|^h[1-6]$/i.test(r);
+  const isText = (r: string) => /body|text|paragraph|^p$/i.test(r);
+  const styles = result.typography?.styles ?? [];
+  const byKey = new Map<number, Map<string, string[]>>();
+  for (const s of styles) {
+    const px = pxOf(s.size);
+    if (px == null || !s.context) continue;
+    const rounded = Math.round(px);
+    const weight = String(s.weight ?? "");
+    const wmap = byKey.get(rounded) ?? new Map<string, string[]>();
+    const arr = wmap.get(weight) ?? [];
+    if (!arr.includes(s.context)) arr.push(s.context);
+    wmap.set(weight, arr);
+    byKey.set(rounded, wmap);
+  }
+  for (const [px, wmap] of byKey) {
+    for (const [weight, roles] of wmap) {
+      if (roles.length < 2) continue;
+      const relevant = roles.filter(isHierarchy).length >= 2 || (roles.some(isHierarchy) && roles.some(isText));
+      if (!relevant) continue;
+      findings.push({
+        category: "consistency",
+        group: "Typography",
+        severity: "warn",
+        message: `${roles.slice(0, 4).join(", ")} share ${px}px${weight ? ` / ${weight}` : ""} — no visual hierarchy between them.`,
+      });
+    }
+  }
+
+  // 3. Brand colour contrast on white — the default canvas. A primary that can't
+  //    meet AA as text on white is the "brand colour fails contrast" decay. Warn
+  //    (not error): it may be used only as a fill behind white text, which we
+  //    can't confirm here. Checked against white only — every colour trivially
+  //    clears one of pure black/white, so "best of the two" would never fire.
+  const primary = result.colors?.semantic?.primary as string | undefined;
+  if (primary) {
+    const onWhite = contrastRatio(primary, "#ffffff");
+    if (onWhite != null && onWhite < 4.5) {
+      findings.push({
+        category: "contrast",
+        group: "Contrast",
+        severity: "warn",
+        message: `Primary ${primary} has low contrast on white (${onWhite.toFixed(1)}:1) — fails WCAG AA for text.`,
+      });
+    }
+  }
+
+  // 4. Off-scale spacing — values that break the detected base grid.
+  const scaleType = result.spacing?.scaleType ?? "";
+  const base = scaleType === "base-8" ? 8 : scaleType === "base-4" ? 4 : 0;
+  if (base) {
+    const off = (result.spacing?.commonValues ?? [])
+      .map((v) => v.px)
+      .filter((px): px is number => typeof px === "number" && px >= base && px % base !== 0);
+    if (off.length) {
+      findings.push({
+        category: "consistency",
+        group: "Spacing",
+        severity: "warn",
+        message: `${off.slice(0, 5).map((p) => `${p}px`).join(", ")} ${off.length === 1 ? "is" : "are"} off the ${scaleType} spacing grid.`,
+      });
+    }
+  }
+
+  // Two scores, each derived from its own findings — never invented. Errors
+  // cost more than warnings. Consistency = type/spacing/duplication; Contrast =
+  // accessibility. Both are always computable, so the header is never one lone
+  // gauge.
+  const cost = (f: Finding) => (f.severity === "error" ? 12 : 6);
+  const sum = (cat: (f: Finding) => boolean) =>
+    Math.max(0, 100 - findings.filter(cat).reduce((n, f) => n + cost(f), 0));
+  const consistency = sum((f) => f.category !== "contrast");
+  const contrast = sum((f) => f.category === "contrast");
+
+  // Coverage: how complete the captured token set is.
+  const present = [
+    (result.colors?.palette?.length ?? 0) > 0,
+    (result.typography?.styles?.length ?? 0) > 0,
+    (result.spacing?.commonValues?.length ?? 0) > 0,
+    (result.borderRadius?.values?.length ?? 0) > 0,
+    (result.shadows?.length ?? 0) > 0,
+    (result.breakpoints?.length ?? 0) > 0,
+  ].filter(Boolean).length;
+
+  return { findings, consistency, contrast, coverage: { present, total: 6 } };
+}

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -8,8 +8,9 @@
  * renders structured tokens and single-render contrast only, never re-derives
  * drift from rendered CSS. Mode B reuses the canonical `computeDrift` engine.
  *
- * Like Lighthouse's standalone report, the machine-readable result is embedded
- * in a <script> so the file is both a human view and a data artifact.
+ * The summary header is Lighthouse-style: big score gauges, each backed by a
+ * concrete finding (lib/findings.ts) so no number is a vanity metric. The file
+ * is the rendered view only — the machine-readable form is `--json-only`.
  */
 
 import type {
@@ -22,6 +23,8 @@ import type {
   CssState,
 } from "../types.js";
 import type { DriftReport, DriftChange } from "../drift.js";
+import { computeFindings } from "../findings.js";
+import type { FindingsReport, Finding } from "../findings.js";
 
 export interface HtmlReportOptions {
   /** When present, render a drift banner + changes at the top of the report. */
@@ -45,18 +48,6 @@ function esc(s: unknown): string {
 }
 
 /**
- * Sanitize a JSON string for inlining inside a <script> tag. Mirrors Lighthouse's
- * report-generator: `<` would let a `</script>` in the data break out of the tag,
- * and U+2028/U+2029 are valid JSON but terminate JS string literals.
- */
-function sanitizeJson(object: unknown): string {
-  return JSON.stringify(object)
-    .replace(/</g, "\\u003c")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
-}
-
-/**
  * Allow only safe CSS color/length-ish tokens into inline style values, so
  * extracted site CSS cannot inject `}` / `<` / `url()` etc. into the report.
  * Anything outside the allowlist is dropped.
@@ -73,68 +64,92 @@ function safeCss(value: unknown): string {
 
 // Dembrandt design system (dark, Linear-inspired). This is the report's *chrome* —
 // a Dembrandt report looks like Dembrandt. The extracted site's tokens are content
-// (swatches, values) shown inside it, never the skin. Tokens from dembrandt-next
-// design.md / globals.css. Brand fonts are declared with system fallbacks (the App
-// loads them; a standalone file falls back gracefully, staying self-contained).
+/*
+ * Dark by default (matching the App at /app), with a CSS-only light toggle — no
+ * JS, just `:root:has(#theme:checked)` flipping the token block. System fonts,
+ * no web fonts, no embedded JSON: stays small at scale. color-scheme is pinned
+ * per theme so a browser's own dark mode can't repaint it.
+ */
 const STYLE = `
-:root{--bg:#000000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--line-hover:#3F4150;--ink:#ffffff;--muted:#8A8F98;--accent:#38BDF8;--accent-hover:#7dd3fc;--warm:#EA580C;--good:#4ade80;--bad:#ef4444;--r-sm:6px;--r-md:8px;--r-lg:12px}
+:root{color-scheme:dark;--bg:#000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--ink:#fff;--muted:#8A8F98;--accent:#38BDF8;--good:#4ade80;--avg:#fbbf24;--bad:#f87171;--swring:rgba(255,255,255,.12);--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
+:root:has(#theme:checked){color-scheme:light;--bg:#fff;--surface:#f7f7f7;--elevated:#f0f0f0;--line:#e0e0e0;--ink:#1f1f1f;--muted:#5c5c5c;--accent:#0c6ae0;--good:#0a8c4a;--avg:#b36b00;--bad:#c0392b;--swring:rgba(0,0,0,.12)}
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.6 'Red Hat Display',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;-webkit-font-smoothing:antialiased}
+html{background:var(--bg)}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;line-height:1.55}
 a{color:var(--accent);text-decoration:none}
-a:hover{color:var(--accent-hover)}
-.mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
+a:hover{text-decoration:underline}
+.mono{font-family:var(--mono)}
 .muted{color:var(--muted)}
 .sub{color:var(--muted);font-size:14px}
 .row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
 .kvs{display:flex;flex-wrap:wrap;gap:8px 22px;font-size:14px}
-.topbar{position:sticky;top:0;z-index:10;background:rgba(0,0,0,.82);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);padding:10px 24px;display:flex;align-items:baseline;gap:12px}
-.topbar .bm{font-size:14px;font-weight:700;color:var(--accent);letter-spacing:.01em;display:inline-flex;align-items:center;gap:7px}
-.topbar .bm svg{height:15px;width:auto}
-.topbar .u{color:var(--muted);font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.wrap{max-width:1000px;margin:0 auto;padding:8px 24px 88px}
-.cap{text-align:center;color:var(--muted);font-size:14px;margin:22px 0 4px}
+.kvs span{white-space:nowrap}
+.topbar{position:sticky;top:0;z-index:10;background:var(--bg);border-bottom:1px solid var(--line);padding:8px 24px;display:flex;align-items:center;gap:12px}
+.topbar .bm{display:inline-flex;align-items:center;color:var(--ink);flex:none}
+.topbar .bm svg{height:16px;width:auto;display:block}
+.tt{position:absolute;width:0;height:0;opacity:0;pointer-events:none}
+.ttl{cursor:pointer;font-size:14px;color:var(--muted);user-select:none}
+.ttl:hover{color:var(--ink)}
+.ttl::after{content:"Light"}
+:root:has(#theme:checked) .ttl::after{content:"Dark"}
+.counts{text-align:center;color:var(--muted);font-size:14px;margin:0;padding:14px 24px 0}
+.topbar .u{color:var(--muted);font-family:var(--mono);font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.topbar .meta{margin-left:auto;color:var(--muted);font-size:14px;white-space:nowrap}
+.wrap{max-width:960px;margin:0 auto;padding:8px 24px 80px}
 .gauges{display:flex;flex-wrap:wrap;gap:34px;justify-content:center;padding:18px 0 28px;border-bottom:1px solid var(--line)}
-.gauge{display:flex;flex-direction:column;align-items:center;gap:9px}
+.gauge{display:flex;flex-direction:column;align-items:center;gap:9px;text-decoration:none;color:inherit}
+a.gauge:hover .glabel{text-decoration:underline}
+.fgroup{margin-bottom:16px}
+.fgroup:last-child{margin-bottom:0}
+.fgrouph{font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);padding-bottom:8px;border-bottom:1px solid var(--line);margin-bottom:10px}
+.findings{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
+.findings li{display:grid;grid-template-columns:56px 1fr;gap:12px;align-items:baseline;font-size:14px}
+.conf{font-size:14px;font-weight:600}
+.c-high{color:var(--good)}.c-med{color:var(--avg)}.c-low{color:var(--muted)}
+.sev{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.03em}
+.s-err{color:var(--bad)}.s-warn{color:var(--avg)}
 .gring{width:84px;height:84px}
 .gring .gbg{fill:none;stroke:var(--line);stroke-width:8}
 .gring .gfg{fill:none;stroke-width:8;stroke-linecap:round}
 .gring.g-pass .gfg{stroke:var(--good)}.gring.g-pass .gnum{fill:var(--good)}
-.gring.g-avg .gfg{stroke:var(--warm)}.gring.g-avg .gnum{fill:var(--warm)}
+.gring.g-avg .gfg{stroke:var(--avg)}.gring.g-avg .gnum{fill:var(--avg)}
 .gring.g-fail .gfg{stroke:var(--bad)}.gring.g-fail .gnum{fill:var(--bad)}
-.gnum{font:700 28px 'Red Hat Display',system-ui,sans-serif}
+.gnum{font-weight:700;font-size:30px}
 .glabel{font-size:14px;color:var(--ink);font-weight:600}
 .gsub{font-size:14px;color:var(--muted)}
-details.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);padding:16px 20px;margin:14px 0}
-details.card>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--muted)}
+details.card{border:1px solid var(--line);border-radius:8px;padding:16px 20px;margin:14px 0}
+details.card>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
 details.card>summary::-webkit-details-marker{display:none}
 details.card>summary::after{content:"";margin-left:auto;width:8px;height:8px;border-right:2px solid var(--muted);border-bottom:2px solid var(--muted);transform:rotate(45deg);transition:transform .15s}
 details.card[open]>summary::after{transform:rotate(-135deg)}
+details.card>summary:hover::after{border-color:var(--accent)}
 .cardbody{margin-top:16px}
-.colors{display:flex;flex-wrap:wrap;gap:16px}
-.color{display:flex;flex-direction:column;gap:6px;width:104px}
-.color .sw2{width:100%;height:48px;border-radius:var(--r-md);box-shadow:0 0 0 1px rgba(255,255,255,.1)}
-.color .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;color:var(--ink)}
-.color .cmeta{font-size:14px;color:var(--muted);display:flex;align-items:center;gap:6px}
+.colors{display:flex;flex-wrap:wrap;gap:14px}
+.color{display:flex;flex-direction:column;gap:5px;align-items:flex-start}
+.color .sw2{width:36px;height:36px;border-radius:6px;box-shadow:inset 0 0 0 1px var(--swring)}
+.color .hex{font-family:var(--mono);font-size:14px;color:var(--ink)}
+.color .cmeta{font-size:14px;color:var(--muted);display:flex;align-items:center;gap:6px;white-space:nowrap}
 .color .role{color:var(--accent);font-size:14px;text-transform:uppercase;letter-spacing:.03em}
 .chips{display:flex;flex-wrap:wrap;gap:8px}
-.tok{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-sm);padding:6px 12px;font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;color:var(--ink)}
+.tok{background:var(--surface);border:1px solid var(--line);border-radius:6px;padding:6px 12px;font-family:var(--mono);font-size:14px;color:var(--ink)}
 table{width:100%;border-collapse:collapse;font-size:14px}
-th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
-th{color:var(--muted);font-weight:600;font-size:14px;text-transform:uppercase;letter-spacing:.05em}
+th,td{text-align:left;padding:8px 12px;vertical-align:top}
+thead th{border-bottom:1px solid var(--line);color:var(--muted);font-weight:600;font-size:14px;text-transform:uppercase;letter-spacing:.04em}
 .badge{display:inline-block;padding:2px 10px;border-radius:999px;font-size:14px;font-weight:600}
-.b-good{background:rgba(74,222,128,.16);color:var(--good)}
-.b-warn{background:rgba(234,88,12,.18);color:var(--warm)}
-.b-bad{background:rgba(239,68,68,.18);color:var(--bad)}
-.b-mut{background:var(--elevated);color:var(--muted)}
-.drift{border:1px solid var(--line);border-radius:var(--r-lg);padding:20px 22px;margin:14px 0;background:var(--surface)}
-.drift.is-drift{border-color:rgba(239,68,68,.45)}
-.drift.is-stable{border-color:rgba(74,222,128,.4)}
-.score{font-size:40px;font-weight:700;line-height:1;letter-spacing:-.02em}
+.b-good{background:rgba(10,140,74,.14);color:var(--good)}
+.b-warn{background:rgba(179,107,0,.16);color:var(--avg)}
+.b-bad{background:rgba(192,57,43,.14);color:var(--bad)}
+.b-mut{background:var(--surface);color:var(--muted)}
+.badgepv{display:inline-block;padding:3px 12px;border:1px solid var(--line);border-radius:999px;font-size:14px}
+.drift{border:1px solid var(--line);border-radius:8px;padding:20px 22px;margin:14px 0}
+.drift.is-drift{border-color:var(--bad)}
+.drift.is-stable{border-color:var(--good)}
+.score{font-size:38px;font-weight:700;line-height:1;letter-spacing:-.02em}
 .previewbtn{cursor:pointer}
-.shadowbox{width:84px;height:52px;border-radius:var(--r-md);background:var(--elevated);display:inline-block}
-.shadowpanel{background:#e5e5e5;border-radius:var(--r-md);padding:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:center}
-.shadowpanel .sb{width:56px;height:56px;border-radius:var(--r-md);background:#fff}
-footer{margin-top:56px;color:var(--muted);font-size:14px;border-top:1px solid var(--line);padding-top:18px;text-align:center}
+.shadowbox{width:84px;height:52px;border-radius:8px;background:#fff;display:inline-block;border:1px solid var(--line)}
+.shadowpanel{background:#f0f0f0;border-radius:8px;padding:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:center}
+.shadowpanel .sb{width:56px;height:56px;border-radius:8px;background:#fff}
+footer{margin-top:48px;color:var(--muted);font-size:14px;text-align:center}
 `;
 
 // Dembrandt brand mark (from dembrandt-next/components/AppMarkIcon.tsx). Inlined,
@@ -144,43 +159,98 @@ const LOGO = `<svg viewBox="0 0 316.6 310.01" fill="currentColor" aria-hidden="t
 /* ------------------------------ components ------------------------------ */
 
 function confBadge(c?: string): string {
-  const cls = c === "high" ? "b-good" : c === "medium" ? "b-warn" : "b-mut";
-  return `<span class="badge ${cls}">${esc(c ?? "low")}</span>`;
+  const cls = c === "high" ? "c-high" : c === "medium" ? "c-med" : "c-low";
+  return `<span class="conf ${cls}">${esc(c ?? "low")}</span>`;
 }
 
 // Collapsible section card (Lighthouse-style, native <details> — no JS, stays
 // self-contained). Open by default; the user can collapse any section.
-function section(title: string, body: string): string {
+function section(title: string, body: string, id?: string): string {
   if (!body.trim()) return "";
-  return `<details class="card" open><summary>${esc(title)}</summary><div class="cardbody">${body}</div></details>`;
+  return `<details class="card"${id ? ` id="${esc(id)}"` : ""} open><summary>${esc(title)}</summary><div class="cardbody">${body}</div></details>`;
 }
 
 /** A Lighthouse-style circular score gauge (0-100), coloured by threshold. */
-function gauge(value: number, label: string, sub?: string): string {
+function gauge(value: number, label: string, sub?: string, invert = false, href?: string): string {
   const v = Math.max(0, Math.min(100, Math.round(value)));
-  const cls = v >= 90 ? "g-pass" : v >= 50 ? "g-avg" : "g-fail";
+  const cls = (invert ? v <= 10 : v >= 90) ? "g-pass" : (invert ? v <= 40 : v >= 50) ? "g-avg" : "g-fail";
   const C = 339.292; // 2πr, r=54
   const arc = ((C * v) / 100).toFixed(1);
-  return `<div class="gauge"><svg viewBox="0 0 120 120" class="gring ${cls}" role="img" aria-label="${esc(label)} ${v} of 100"><circle class="gbg" cx="60" cy="60" r="54"/><circle class="gfg" cx="60" cy="60" r="54" stroke-dasharray="${arc} ${C}" transform="rotate(-90 60 60)"/><text class="gnum" x="60" y="60" text-anchor="middle" dominant-baseline="central">${v}</text></svg><span class="glabel">${esc(label)}</span>${sub ? `<span class="gsub">${esc(sub)}</span>` : ""}</div>`;
+  const inner = `<svg viewBox="0 0 120 120" class="gring ${cls}" role="img" aria-label="${esc(label)} ${v} of 100"><circle class="gbg" cx="60" cy="60" r="54"/><circle class="gfg" cx="60" cy="60" r="54" stroke-dasharray="${arc} ${C}" transform="rotate(-90 60 60)"/><text class="gnum" x="60" y="60" text-anchor="middle" dominant-baseline="central">${v}</text></svg><span class="glabel">${esc(label)}</span>${sub ? `<span class="gsub">${esc(sub)}</span>` : ""}`;
+  return href
+    ? `<a class="gauge" href="${esc(href)}">${inner}</a>`
+    : `<div class="gauge">${inner}</div>`;
 }
 
-/** The top "ranking" row — gauges that summarise the report's status. */
-function summaryGauges(result: BrandingResult, drift?: DriftReport): string {
+/** A Lighthouse-style fraction tile (e.g. token coverage 6/6). */
+/**
+ * The top "ranking" row — Dembrandt's axes, not Lighthouse's. Drift (did it
+ * change vs a baseline) and Contrast (WCAG AA) appear only when that data
+ * exists; Consistency is always computable. Every gauge links to the card that
+ * explains it, so no number is a mystery.
+ */
+function summaryGauges(result: BrandingResult, fr: FindingsReport, drift?: DriftReport): string {
   const g: string[] = [];
   if (drift) {
-    g.push(gauge(Math.max(0, 100 - Math.min(100, drift.score)), "Stability", `drift ${drift.score}`));
+    g.push(gauge(drift.score, "Drift", drift.status === "drift" ? "vs baseline" : "stable", true, "#drift"));
   }
+  const cIssues = fr.findings.filter((f) => f.category !== "contrast").length;
+  g.push(gauge(fr.consistency, "Consistency", cIssues ? `${cIssues} issue${cIssues === 1 ? "" : "s"}` : "clean", false, "#findings"));
+  // Contrast is always present: real WCAG pairs when --wcag ran, else the
+  // self-computed contrast findings.
   const wcag = result.wcag ?? [];
   if (wcag.length) {
     const passed = wcag.filter((p) => p.aa).length;
-    g.push(gauge((100 * passed) / wcag.length, "Accessibility", `${passed}/${wcag.length} AA`));
+    g.push(gauge((100 * passed) / wcag.length, "Contrast", `${passed}/${wcag.length} pairs AA`, false, "#wcag"));
+  } else {
+    const xIssues = fr.findings.filter((f) => f.category === "contrast").length;
+    g.push(gauge(fr.contrast, "Contrast", xIssues ? `${xIssues} issue${xIssues === 1 ? "" : "s"}` : "clean", false, "#findings"));
   }
-  const palette = result.colors?.palette ?? [];
-  if (palette.length) {
-    const high = palette.filter((c) => c.confidence === "high").length;
-    g.push(gauge((100 * high) / palette.length, "Confidence", `${high}/${palette.length} high`));
+  return `<div class="gauges">${g.join("")}</div>`;
+}
+
+/** An at-a-glance executive line of token counts — honest, no score. */
+function summaryCounts(result: BrandingResult): string {
+  const n = (a: unknown) => (Array.isArray(a) ? a.length : 0);
+  const plural = (c: number, one: string, many = one + "s") => `${c} ${c === 1 ? one : many}`;
+  const parts: string[] = [];
+  const colors = n(result.colors?.palette);
+  if (colors) parts.push(plural(colors, "color"));
+  const styles = n(result.typography?.styles);
+  if (styles) parts.push(plural(styles, "text style"));
+  const spacing = n(result.spacing?.commonValues);
+  if (spacing) parts.push(`${spacing} spacing`);
+  const radii = n(result.borderRadius?.values);
+  if (radii) parts.push(plural(radii, "radius", "radii"));
+  const shadows = n(result.shadows);
+  if (shadows) parts.push(plural(shadows, "shadow"));
+  const bps = n(result.breakpoints);
+  if (bps) parts.push(plural(bps, "breakpoint"));
+  return parts.length ? `<p class="counts">${esc(parts.join(" · "))}</p>` : "";
+}
+
+/** Actionable findings — the audits behind the scores, Lighthouse-style. */
+function findingsSection(fr: FindingsReport): string {
+  if (!fr.findings.length) return "";
+  const sev = (s: Finding["severity"]) =>
+    s === "error" ? `<span class="sev s-err">error</span>` : `<span class="sev s-warn">warn</span>`;
+  // Group by display group (Gestalt proximity) so the list reads as Color /
+  // Typography / Spacing / Contrast rather than a flat mixed stream.
+  const groups = new Map<string, Finding[]>();
+  for (const f of fr.findings) {
+    const arr = groups.get(f.group) ?? [];
+    arr.push(f);
+    groups.set(f.group, arr);
   }
-  return g.length ? `<div class="gauges">${g.join("")}</div>` : "";
+  const blocks = [...groups.entries()]
+    .map(([group, items]) => {
+      const rows = items
+        .map((f) => `<li>${sev(f.severity)}<span>${esc(f.message)}</span></li>`)
+        .join("");
+      return `<div class="fgroup"><div class="fgrouph">${esc(group)} <span class="muted">${items.length}</span></div><ul class="findings">${rows}</ul></div>`;
+    })
+    .join("");
+  return `<details class="card" id="findings" open><summary>Findings (${fr.findings.length})</summary><div class="cardbody">${blocks}</div></details>`;
 }
 
 function paletteSection(result: BrandingResult): string {
@@ -195,7 +265,7 @@ function paletteSection(result: BrandingResult): string {
     .map((c: PaletteColor) => {
       const hex = c.normalized || c.color;
       const role = roleByHex.get(String(hex).toLowerCase());
-      return `<div class="color"><div class="sw2" style="background:${safeCss(hex) || "transparent"}"></div><div class="hex">${esc(hex)}</div><div class="cmeta">${esc(c.count ?? 0)}× ${confBadge(c.confidence)}</div>${role ? `<div class="role">${esc(role)}</div>` : ""}</div>`;
+      return `<div class="color"><div class="sw2" style="background:${safeCss(hex) || "transparent"}"></div><div class="hex">${esc(hex)}</div>${role ? `<div class="role">${esc(role)}</div>` : `<div class="cmeta">${confBadge(c.confidence)}</div>`}</div>`;
     })
     .join("");
   return section("Palette", `<div class="colors">${cards}</div>`);
@@ -301,13 +371,11 @@ function badgesSection(result: BrandingResult): string {
       const style = [
         bd.backgroundColor ? `background:${safeCss(bd.backgroundColor)}` : "",
         bd.color ? `color:${safeCss(bd.color)}` : "",
-        bd.borderRadius ? `border-radius:${safeCss(bd.borderRadius)}` : "border-radius:999px",
-        bd.padding ? `padding:${safeCss(bd.padding)}` : "padding:2px 10px",
-        bd.fontSize ? `font-size:${safeCss(bd.fontSize)}` : "font-size:12px",
+        bd.borderRadius ? `border-radius:${safeCss(bd.borderRadius)}` : "",
       ]
         .filter(Boolean)
         .join(";");
-      return `<span style="${esc(style)}">${esc(bd.styleType || "Badge")}</span>`;
+      return `<span class="badgepv" style="${esc(style)}">${esc(bd.styleType || "badge")}</span>`;
     })
     .join(" ");
   return section("Badges", `<div class="row">${chips}</div>`);
@@ -325,7 +393,8 @@ function wcagSection(result: BrandingResult): string {
     .join("");
   return section(
     "WCAG contrast",
-    `<table><thead><tr><th>bg</th><th>Foreground</th><th>Background</th><th>Ratio</th><th>AA</th></tr></thead><tbody>${rows}</tbody></table>`
+    `<table><thead><tr><th>bg</th><th>Foreground</th><th>Background</th><th>Ratio</th><th>AA</th></tr></thead><tbody>${rows}</tbody></table>`,
+    "wcag"
   );
 }
 
@@ -365,7 +434,7 @@ function driftSection(drift: DriftReport, baselineLabel?: string): string {
     })
     .join("");
   const more = drift.changes.length > 120 ? `<p class="sub">… ${drift.changes.length - 120} more changes</p>` : "";
-  return `<div class="drift ${cls}"><div class="row"><div class="score">${esc(drift.score)}</div><div><div>${verdict} <span class="sub">threshold ${esc(drift.threshold)}</span></div><div class="sub">${esc(drift.summary.changed)} changed · ${esc(drift.summary.added)} added · ${esc(drift.summary.removed)} removed${baselineLabel ? ` · vs ${esc(baselineLabel)}` : ""}</div></div></div>${
+  return `<div class="drift ${cls}" id="drift"><div class="row"><div class="score">${esc(drift.score)}</div><div><div>${verdict} <span class="sub">threshold ${esc(drift.threshold)}</span></div><div class="sub">${esc(drift.summary.changed)} changed · ${esc(drift.summary.added)} added · ${esc(drift.summary.removed)} removed${baselineLabel ? ` · vs ${esc(baselineLabel)}` : ""}</div></div></div>${
     cats ? `<table style="margin-top:14px"><thead><tr><th>Category</th><th>Score</th><th>Δ</th><th>+</th><th>−</th></tr></thead><tbody>${cats}</tbody></table>` : ""
   }${
     changes ? `<table style="margin-top:10px"><thead><tr><th>Category</th><th>Kind</th><th>Token</th><th>Change</th><th>Δ</th></tr></thead><tbody>${changes}</tbody></table>${more}` : ""
@@ -381,11 +450,12 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
   } catch {
     /* leave as-is */
   }
-  const summary = `${result.colors?.palette?.length ?? 0} colors · ${result.typography?.styles?.length ?? 0} text styles · ${result.spacing?.commonValues?.length ?? 0} spacing · ${result.breakpoints?.length ?? 0} breakpoints`;
   const version = options.version ?? result.meta?.dembrandtVersion ?? "";
+  const fr = computeFindings(result);
 
   const body = [
     options.drift ? driftSection(options.drift, options.baselineLabel) : "",
+    findingsSection(fr),
     paletteSection(result),
     semanticSection(result),
     typographySection(result),
@@ -398,10 +468,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
     metaSection(result),
   ].join("\n");
 
-  // Embed the machine-readable data so the report is also a data artifact,
-  // re-parseable from the same file (Lighthouse pattern).
-  const data = sanitizeJson({ result, drift: options.drift ?? null });
-  const gauges = summaryGauges(result, options.drift);
+  const gauges = summaryGauges(result, fr, options.drift);
 
   return `<!doctype html>
 <html lang="en">
@@ -413,14 +480,14 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <style>${STYLE}</style>
 </head>
 <body>
-<div class="topbar"><span class="bm">${LOGO}</span><span class="u">${esc(result.url)}</span></div>
+<input type="checkbox" id="theme" class="tt">
+<div class="topbar"><span class="bm">${LOGO}</span><span class="u">${esc(result.url)}</span><span class="meta">${esc(result.extractedAt)}${version ? " · v" + esc(version) : ""}</span><label for="theme" class="ttl" title="Toggle light / dark"></label></div>
 <div class="wrap">
-<div class="cap">${esc(domain)} · extracted ${esc(result.extractedAt)}${version ? " · v" + esc(version) : ""} · ${esc(summary)}</div>
 ${gauges}
+${summaryCounts(result)}
 ${body}
 <footer>Generated by <a href="https://github.com/dembrandt/dembrandt">Dembrandt</a>${version ? " " + esc(version) : ""} · <a href="https://github.com/dembrandt/dembrandt/issues">File an issue</a></footer>
 </div>
-<script type="application/json" id="dembrandt-data">${data}</script>
 </body>
 </html>`;
 }

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -71,43 +71,52 @@ function safeCss(value: unknown): string {
 
 /* -------------------------------- styles -------------------------------- */
 
+// Dembrandt design system (dark, Linear-inspired). This is the report's *chrome* —
+// a Dembrandt report looks like Dembrandt. The extracted site's tokens are content
+// (swatches, values) shown inside it, never the skin. Tokens from dembrandt-next
+// design.md / globals.css. Brand fonts are declared with system fallbacks (the App
+// loads them; a standalone file falls back gracefully, staying self-contained).
 const STYLE = `
-:root{--bg:#ffffff;--panel:#f7f8fa;--panel2:#eef1f5;--ink:#1a1d23;--muted:#6b7280;--line:#e6e8ec;--accent:#133174;--good:#15803d;--warn:#b45309;--bad:#b91c1c}
+:root{--bg:#000000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--line-hover:#3F4150;--ink:#ffffff;--muted:#8A8F98;--tertiary:#5E6772;--accent:#38BDF8;--accent-hover:#7dd3fc;--warm:#EA580C;--good:#4ade80;--warn:#EA580C;--bad:#ef4444;--r-sm:6px;--r-md:8px;--r-lg:12px}
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
-.wrap{max-width:980px;margin:0 auto;padding:32px 20px 64px}
-h1{font-size:22px;margin:0 0 4px;color:var(--accent)}
-h2{font-size:15px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:32px 0 12px;border-bottom:2px solid var(--accent);padding-bottom:6px}
-a{color:var(--accent)}
-.sub{color:var(--muted);font-size:13px}
-.grid{display:grid;gap:10px}
-.swatches{grid-template-columns:repeat(auto-fill,minmax(120px,1fr))}
-.sw{background:var(--panel);border:1px solid var(--line);border-radius:8px;overflow:hidden}
-.sw .chip{height:64px}
-.sw .meta{padding:8px 10px;font-size:12px}
-.sw .hex{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.sw .role{color:var(--accent);font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.6 'Red Hat Display',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1000px;margin:0 auto;padding:48px 24px 80px}
+.brand{font-size:13px;font-weight:700;letter-spacing:.02em;color:var(--accent);margin:0 0 18px}
+h1{font-size:30px;font-weight:700;letter-spacing:-.02em;margin:0 0 6px;color:var(--ink)}
+h2{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.09em;color:var(--muted);margin:44px 0 16px}
+a{color:var(--accent);text-decoration:none}
+a:hover{color:var(--accent-hover)}
+.sub{color:var(--muted);font-size:14px}
+.mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
+.grid{display:grid;gap:12px}
+.swatches{grid-template-columns:repeat(auto-fill,minmax(132px,1fr))}
+.sw{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);overflow:hidden;transition:border-color .15s}
+.sw:hover{border-color:var(--line-hover)}
+.sw .chip{height:72px}
+.sw .meta{padding:10px 12px;font-size:12px}
+.sw .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;color:var(--ink)}
+.sw .role{color:var(--accent);font-size:11px;text-transform:uppercase;letter-spacing:.04em;margin-top:3px}
 .chips{display:flex;flex-wrap:wrap;gap:8px}
-.tok{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:4px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+.tok{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-sm);padding:5px 11px;font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:12px;color:var(--ink)}
 table{width:100%;border-collapse:collapse;font-size:13px}
-th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);vertical-align:top}
-th{color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
-.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-.badge{display:inline-block;padding:1px 8px;border-radius:999px;font-size:11px;font-weight:600}
-.b-good{background:rgba(63,185,80,.15);color:var(--good)}
-.b-warn{background:rgba(210,153,34,.15);color:var(--warn)}
-.b-bad{background:rgba(248,81,73,.15);color:var(--bad)}
-.b-mut{background:var(--panel2);color:var(--muted)}
-.drift{border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:8px 0 0;background:var(--panel)}
-.drift.is-drift{border-color:rgba(248,81,73,.5)}
-.drift.is-stable{border-color:rgba(63,185,80,.4)}
-.score{font-size:34px;font-weight:700;line-height:1}
+th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.06em}
+.badge{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:600}
+.b-good{background:rgba(74,222,128,.14);color:var(--good)}
+.b-warn{background:rgba(234,88,12,.16);color:var(--warm)}
+.b-bad{background:rgba(239,68,68,.16);color:var(--bad)}
+.b-mut{background:var(--elevated);color:var(--muted)}
+.drift{border:1px solid var(--line);border-radius:var(--r-lg);padding:20px 22px;margin:8px 0 0;background:var(--surface)}
+.drift.is-drift{border-color:rgba(239,68,68,.45)}
+.drift.is-stable{border-color:rgba(74,222,128,.4)}
+.score{font-size:40px;font-weight:700;line-height:1;letter-spacing:-.02em}
 .row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
-.previewbtn{border:0;cursor:default}
-.shadowbox{width:80px;height:48px;border-radius:8px;background:#fff;display:inline-block}
+.previewbtn{cursor:pointer}
+.shadowbox{width:84px;height:52px;border-radius:var(--r-md);background:var(--elevated);display:inline-block}
 .muted{color:var(--muted)}
-.kvs{display:flex;flex-wrap:wrap;gap:6px 18px}
-footer{margin-top:48px;color:var(--muted);font-size:12px;border-top:1px solid var(--line);padding-top:14px}
+.kvs{display:flex;flex-wrap:wrap;gap:8px 20px}
+header{border-bottom:1px solid var(--line);padding-bottom:22px}
+footer{margin-top:56px;color:var(--tertiary);font-size:12px;border-top:1px solid var(--line);padding-top:16px}
 `;
 
 /* ------------------------------ components ------------------------------ */
@@ -341,19 +350,6 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
     metaSection(result),
   ].join("\n");
 
-  // Self-theme: the report wears the brand it reported on. Accent = the extracted
-  // primary (the report of site X looks like site X), with a neutral readable base
-  // so it stays legible whatever the brand. Heading font follows the extracted
-  // heading family when present (declaration only — no external font fetch).
-  const semantic = result.colors?.semantic ?? {};
-  const accent =
-    semantic.primary || semantic.brand || semantic.accent ||
-    result.colors?.palette?.[0]?.normalized || result.colors?.palette?.[0]?.color || "#133174";
-  const headingStyle = (result.typography?.styles ?? []).find((s) => /head|display|title/i.test(s.context ?? ""));
-  const headingFamily = ((headingStyle ?? result.typography?.styles?.[0])?.family ?? "").split(",")[0].replace(/["']/g, "").trim();
-  const fontRule = /^[\w .-]+$/.test(headingFamily) && headingFamily ? `h1,h2{font-family:'${headingFamily}',system-ui,sans-serif}` : "";
-  const themed = `:root{--accent:${safeCss(accent) || "#133174"}}${fontRule}`;
-
   // Embed the machine-readable data so the report is also a data artifact,
   // re-parseable from the same file (Lighthouse pattern).
   const data = sanitizeJson({ result, drift: options.drift ?? null });
@@ -365,12 +361,12 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="generator" content="dembrandt${version ? " " + esc(version) : ""}">
 <title>Dembrandt report — ${esc(domain)}</title>
-<style>${STYLE}
-${themed}</style>
+<style>${STYLE}</style>
 </head>
 <body>
 <div class="wrap">
 <header>
+<div class="brand">dembrandt</div>
 <h1>${esc(domain)}</h1>
 <div class="sub"><a href="${esc(result.url)}">${esc(result.url)}</a> · extracted ${esc(result.extractedAt)}</div>
 <div class="sub">${esc(summary)}</div>

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -128,6 +128,8 @@ details.card>summary::after{content:"";margin-left:auto;width:8px;height:8px;bor
 details.card[open]>summary::after{transform:rotate(-135deg)}
 details.card>summary:hover::after{border-color:var(--accent)}
 .cardbody{margin-top:16px}
+.cardrow{display:flex;gap:14px;flex-wrap:wrap;margin:14px 0}
+.cardrow>details.card{flex:1 1 280px;margin:0}
 .colors{display:flex;flex-wrap:wrap;gap:14px}
 .color{display:flex;flex-direction:column;gap:5px;align-items:center;text-align:center}
 .color .sw2{width:36px;height:36px;border-radius:6px;box-shadow:inset 0 0 0 1px var(--swring)}
@@ -172,6 +174,13 @@ function confBadge(c?: string): string {
 function section(title: string, body: string, id?: string): string {
   if (!body.trim()) return "";
   return `<details class="card"${id ? ` id="${esc(id)}"` : ""} open><summary>${esc(title)}</summary><div class="cardbody">${body}</div></details>`;
+}
+
+/** Lay two (or more) small cards side by side — related scales read together. */
+function cardRow(...cards: string[]): string {
+  const present = cards.filter((c) => c.trim());
+  if (present.length < 2) return present.join("");
+  return `<div class="cardrow">${present.join("")}</div>`;
 }
 
 /** A Lighthouse-style circular score gauge (0-100), coloured by threshold. */
@@ -480,8 +489,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
     paletteSection(result),
     semanticSection(result),
     typographySection(result),
-    spacingSection(result),
-    radiusSection(result),
+    cardRow(spacingSection(result), radiusSection(result)),
     shadowsSection(result),
     buttonsSection(result),
     badgesSection(result),

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -88,7 +88,8 @@ a:hover{color:var(--accent-hover)}
 .row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
 .kvs{display:flex;flex-wrap:wrap;gap:8px 22px;font-size:14px}
 .topbar{position:sticky;top:0;z-index:10;background:rgba(0,0,0,.82);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);padding:10px 24px;display:flex;align-items:baseline;gap:12px}
-.topbar .bm{font-size:14px;font-weight:700;color:var(--accent);letter-spacing:.01em}
+.topbar .bm{font-size:14px;font-weight:700;color:var(--accent);letter-spacing:.01em;display:inline-flex;align-items:center;gap:7px}
+.topbar .bm svg{height:15px;width:auto}
 .topbar .u{color:var(--muted);font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .wrap{max-width:1000px;margin:0 auto;padding:8px 24px 88px}
 .cap{text-align:center;color:var(--muted);font-size:14px;margin:22px 0 4px}
@@ -135,6 +136,10 @@ th{color:var(--muted);font-weight:600;font-size:14px;text-transform:uppercase;le
 .shadowpanel .sb{width:56px;height:56px;border-radius:var(--r-md);background:#fff}
 footer{margin-top:56px;color:var(--muted);font-size:14px;border-top:1px solid var(--line);padding-top:18px;text-align:center}
 `;
+
+// Dembrandt brand mark (from dembrandt-next/components/AppMarkIcon.tsx). Inlined,
+// fill=currentColor so it inherits the topbar accent. Self-contained — no asset fetch.
+const LOGO = `<svg viewBox="0 0 316.6 310.01" fill="currentColor" aria-hidden="true"><path d="M81.48,20.83h-34.92C20.85,20.83,0,41.68,0,67.39v175.22c0,25.72,20.85,46.56,46.56,46.56h34.92c2.3,0,4.17-1.87,4.17-4.17V25c0-2.3-1.87-4.17-4.17-4.17Z"/><path d="M268.66,0H110.47c-2.3,0-4.17,1.87-4.17,4.17v301.67c0,2.3,1.87,4.17,4.17,4.17h158.18c26.48,0,47.95-21.47,47.95-47.95V47.95c0-26.48-21.47-47.95-47.95-47.95Z"/></svg>`;
 
 /* ------------------------------ components ------------------------------ */
 
@@ -408,7 +413,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <style>${STYLE}</style>
 </head>
 <body>
-<div class="topbar"><span class="bm">dembrandt</span><span class="u">${esc(result.url)}</span></div>
+<div class="topbar"><span class="bm">${LOGO}dembrandt</span><span class="u">${esc(result.url)}</span></div>
 <div class="wrap">
 <div class="cap">${esc(domain)} · extracted ${esc(result.extractedAt)}${version ? " · v" + esc(version) : ""} · ${esc(summary)}</div>
 ${gauges}

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -72,12 +72,12 @@ function safeCss(value: unknown): string {
 /* -------------------------------- styles -------------------------------- */
 
 const STYLE = `
-:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212b;--ink:#e6e9ef;--muted:#9aa3b2;--line:#2a2f3a;--accent:#7c9cff;--good:#3fb950;--warn:#d29922;--bad:#f85149}
+:root{--bg:#ffffff;--panel:#f7f8fa;--panel2:#eef1f5;--ink:#1a1d23;--muted:#6b7280;--line:#e6e8ec;--accent:#133174;--good:#15803d;--warn:#b45309;--bad:#b91c1c}
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
 .wrap{max-width:980px;margin:0 auto;padding:32px 20px 64px}
-h1{font-size:22px;margin:0 0 4px}
-h2{font-size:15px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:32px 0 12px;border-bottom:1px solid var(--line);padding-bottom:6px}
+h1{font-size:22px;margin:0 0 4px;color:var(--accent)}
+h2{font-size:15px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:32px 0 12px;border-bottom:2px solid var(--accent);padding-bottom:6px}
 a{color:var(--accent)}
 .sub{color:var(--muted);font-size:13px}
 .grid{display:grid;gap:10px}
@@ -341,6 +341,19 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
     metaSection(result),
   ].join("\n");
 
+  // Self-theme: the report wears the brand it reported on. Accent = the extracted
+  // primary (the report of site X looks like site X), with a neutral readable base
+  // so it stays legible whatever the brand. Heading font follows the extracted
+  // heading family when present (declaration only — no external font fetch).
+  const semantic = result.colors?.semantic ?? {};
+  const accent =
+    semantic.primary || semantic.brand || semantic.accent ||
+    result.colors?.palette?.[0]?.normalized || result.colors?.palette?.[0]?.color || "#133174";
+  const headingStyle = (result.typography?.styles ?? []).find((s) => /head|display|title/i.test(s.context ?? ""));
+  const headingFamily = ((headingStyle ?? result.typography?.styles?.[0])?.family ?? "").split(",")[0].replace(/["']/g, "").trim();
+  const fontRule = /^[\w .-]+$/.test(headingFamily) && headingFamily ? `h1,h2{font-family:'${headingFamily}',system-ui,sans-serif}` : "";
+  const themed = `:root{--accent:${safeCss(accent) || "#133174"}}${fontRule}`;
+
   // Embed the machine-readable data so the report is also a data artifact,
   // re-parseable from the same file (Lighthouse pattern).
   const data = sanitizeJson({ result, drift: options.drift ?? null });
@@ -352,7 +365,8 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="generator" content="dembrandt${version ? " " + esc(version) : ""}">
 <title>Dembrandt report — ${esc(domain)}</title>
-<style>${STYLE}</style>
+<style>${STYLE}
+${themed}</style>
 </head>
 <body>
 <div class="wrap">

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -67,46 +67,50 @@ function safeCss(value: unknown): string {
 /*
  * Dark by default (matching the App at /app), with a CSS-only light toggle — no
  * JS, just `:root:has(#theme:checked)` flipping the token block. System fonts,
- * no web fonts, no embedded JSON: stays small at scale. color-scheme is pinned
- * per theme so a browser's own dark mode can't repaint it.
+ * no embedded JSON: stays small at scale. Typography is generic/system on
+ * purpose (no Red Hat Display / web fonts — keeps the file light); the fluid
+ * type scale, brand surfaces, #38BDF8 accent and tight Linear radii still mirror
+ * the App's design system (dembrandt-next/app/globals.css). color-scheme is
+ * pinned per theme so a browser's own dark mode can't repaint it. Type steps
+ * stay >=14px (the App's 2xs/xs at 11-13px are dropped for the no-sub-14px rule).
  */
 const STYLE = `
-:root{color-scheme:dark;--bg:#000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--ink:#fff;--muted:#8A8F98;--accent:#38BDF8;--good:#4ade80;--avg:#fbbf24;--bad:#f87171;--swring:rgba(255,255,255,.12);--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
-:root:has(#theme:checked){color-scheme:light;--bg:#fff;--surface:#f7f7f7;--elevated:#f0f0f0;--line:#e0e0e0;--ink:#1f1f1f;--muted:#5c5c5c;--accent:#0c6ae0;--good:#0a8c4a;--avg:#b36b00;--bad:#c0392b;--swring:rgba(0,0,0,.12)}
+:root{color-scheme:dark;--bg:#000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--ink:#fff;--muted:#8A8F98;--tertiary:#5E6772;--accent:#38BDF8;--accent-hover:#7dd3fc;--good:#4ade80;--avg:#fbbf24;--bad:#ef4444;--swring:rgba(255,255,255,.12);--sans:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;--mono:ui-monospace,SFMono-Regular,Menlo,monospace;--t-sm:clamp(0.875rem,0.85rem + 0.15vw,0.938rem);--t-base:clamp(1rem,0.975rem + 0.125vw,1.063rem);--t-md:clamp(1.125rem,1.075rem + 0.25vw,1.25rem);--t-lg:clamp(1.25rem,1.175rem + 0.375vw,1.5rem);--t-xl:clamp(1.5rem,1.375rem + 0.625vw,1.875rem);--t-2xl:clamp(1.875rem,1.675rem + 1vw,2.5rem)}
+:root:has(#theme:checked){color-scheme:light;--bg:#F5F5F7;--surface:#ffffff;--elevated:#ECECEF;--line:#D8D8DE;--ink:#111827;--muted:#5E6772;--tertiary:#8A8F98;--accent:#0C6AE0;--accent-hover:#0a55b5;--good:#0a8c4a;--avg:#b36b00;--bad:#c0392b;--swring:rgba(0,0,0,.12)}
 *{box-sizing:border-box}
 html{background:var(--bg)}
-body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;line-height:1.55}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:var(--t-base);line-height:1.55;-webkit-font-smoothing:antialiased}
 a{color:var(--accent);text-decoration:none}
-a:hover{text-decoration:underline}
+a:hover{color:var(--accent-hover);text-decoration:underline;text-underline-offset:3px}
 .mono{font-family:var(--mono)}
 .muted{color:var(--muted)}
-.sub{color:var(--muted);font-size:14px}
+.sub{color:var(--muted);font-size:var(--t-sm)}
 .row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
-.kvs{display:flex;flex-wrap:wrap;gap:8px 22px;font-size:14px}
+.kvs{display:flex;flex-wrap:wrap;gap:8px 22px;font-size:var(--t-sm)}
 .kvs span{white-space:nowrap}
 .topbar{position:sticky;top:0;z-index:10;background:var(--bg);border-bottom:1px solid var(--line);padding:8px 24px;display:flex;align-items:center;gap:12px}
 .topbar .bm{display:inline-flex;align-items:center;color:var(--ink);flex:none}
 .topbar .bm svg{height:16px;width:auto;display:block}
 .tt{position:absolute;width:0;height:0;opacity:0;pointer-events:none}
-.ttl{cursor:pointer;font-size:14px;color:var(--muted);user-select:none}
+.ttl{cursor:pointer;font-size:var(--t-sm);color:var(--muted);user-select:none}
 .ttl:hover{color:var(--ink)}
 .ttl::after{content:"Light"}
 :root:has(#theme:checked) .ttl::after{content:"Dark"}
-.counts{text-align:center;color:var(--muted);font-size:14px;margin:0;padding:14px 24px 0}
-.topbar .u{color:var(--muted);font-family:var(--mono);font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.topbar .meta{margin-left:auto;color:var(--muted);font-size:14px;white-space:nowrap}
+.counts{text-align:center;color:var(--muted);font-size:var(--t-sm);margin:0;padding:14px 24px 0}
+.topbar .u{color:var(--muted);font-family:var(--mono);font-size:var(--t-sm);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.topbar .meta{margin-left:auto;color:var(--muted);font-size:var(--t-sm);white-space:nowrap}
 .wrap{max-width:960px;margin:0 auto;padding:8px 24px 80px}
 .gauges{display:flex;flex-wrap:wrap;gap:34px;justify-content:center;padding:18px 0 28px;border-bottom:1px solid var(--line)}
 .gauge{display:flex;flex-direction:column;align-items:center;gap:9px;text-decoration:none;color:inherit}
 a.gauge:hover .glabel{text-decoration:underline}
 .fgroup{margin-bottom:16px}
 .fgroup:last-child{margin-bottom:0}
-.fgrouph{font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);padding-bottom:8px;border-bottom:1px solid var(--line);margin-bottom:10px}
+.fgrouph{font-size:var(--t-sm);font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);padding-bottom:8px;border-bottom:1px solid var(--line);margin-bottom:10px}
 .findings{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
-.findings li{display:grid;grid-template-columns:56px 1fr;gap:12px;align-items:baseline;font-size:14px}
-.conf{font-size:14px;font-weight:600}
+.findings li{display:grid;grid-template-columns:56px 1fr;gap:12px;align-items:baseline;font-size:var(--t-sm)}
+.conf{font-size:var(--t-sm);font-weight:600}
 .c-high{color:var(--good)}.c-med{color:var(--avg)}.c-low{color:var(--muted)}
-.sev{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.03em}
+.sev{font-size:var(--t-sm);font-weight:700;text-transform:uppercase;letter-spacing:.03em}
 .s-err{color:var(--bad)}.s-warn{color:var(--avg)}
 .gring{width:84px;height:84px}
 .gring .gbg{fill:none;stroke:var(--line);stroke-width:8}
@@ -114,42 +118,42 @@ a.gauge:hover .glabel{text-decoration:underline}
 .gring.g-pass .gfg{stroke:var(--good)}.gring.g-pass .gnum{fill:var(--good)}
 .gring.g-avg .gfg{stroke:var(--avg)}.gring.g-avg .gnum{fill:var(--avg)}
 .gring.g-fail .gfg{stroke:var(--bad)}.gring.g-fail .gnum{fill:var(--bad)}
-.gnum{font-weight:700;font-size:30px}
-.glabel{font-size:14px;color:var(--ink);font-weight:600}
-.gsub{font-size:14px;color:var(--muted)}
+.gnum{font-weight:700;font-size:var(--t-2xl)}
+.glabel{font-size:var(--t-sm);color:var(--ink);font-weight:600}
+.gsub{font-size:var(--t-sm);color:var(--muted)}
 details.card{border:1px solid var(--line);border-radius:8px;padding:16px 20px;margin:14px 0}
-details.card>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+details.card>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-size:var(--t-sm);font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
 details.card>summary::-webkit-details-marker{display:none}
 details.card>summary::after{content:"";margin-left:auto;width:8px;height:8px;border-right:2px solid var(--muted);border-bottom:2px solid var(--muted);transform:rotate(45deg);transition:transform .15s}
 details.card[open]>summary::after{transform:rotate(-135deg)}
 details.card>summary:hover::after{border-color:var(--accent)}
 .cardbody{margin-top:16px}
 .colors{display:flex;flex-wrap:wrap;gap:14px}
-.color{display:flex;flex-direction:column;gap:5px;align-items:flex-start}
+.color{display:flex;flex-direction:column;gap:5px;align-items:center;text-align:center}
 .color .sw2{width:36px;height:36px;border-radius:6px;box-shadow:inset 0 0 0 1px var(--swring)}
-.color .hex{font-family:var(--mono);font-size:14px;color:var(--ink)}
-.color .cmeta{font-size:14px;color:var(--muted);display:flex;align-items:center;gap:6px;white-space:nowrap}
-.color .role{color:var(--accent);font-size:14px;text-transform:uppercase;letter-spacing:.03em}
+.color .hex{font-family:var(--mono);font-size:var(--t-sm);color:var(--ink)}
+.color .cmeta{font-size:var(--t-sm);color:var(--muted);display:flex;align-items:center;gap:6px;white-space:nowrap}
+.color .role{color:var(--accent);font-size:var(--t-sm);text-transform:uppercase;letter-spacing:.03em}
 .chips{display:flex;flex-wrap:wrap;gap:8px}
-.tok{background:var(--surface);border:1px solid var(--line);border-radius:6px;padding:6px 12px;font-family:var(--mono);font-size:14px;color:var(--ink)}
-table{width:100%;border-collapse:collapse;font-size:14px}
+.tok{background:var(--surface);border:1px solid var(--line);border-radius:6px;padding:6px 12px;font-family:var(--mono);font-size:var(--t-sm);color:var(--ink)}
+table{width:100%;border-collapse:collapse;font-size:var(--t-sm)}
 th,td{text-align:left;padding:8px 12px;vertical-align:top}
-thead th{border-bottom:1px solid var(--line);color:var(--muted);font-weight:600;font-size:14px;text-transform:uppercase;letter-spacing:.04em}
-.badge{display:inline-block;padding:2px 10px;border-radius:999px;font-size:14px;font-weight:600}
+thead th{border-bottom:1px solid var(--line);color:var(--muted);font-weight:600;font-size:var(--t-sm);text-transform:uppercase;letter-spacing:.04em}
+.badge{display:inline-block;padding:2px 10px;border-radius:999px;font-size:var(--t-sm);font-weight:600}
 .b-good{background:rgba(10,140,74,.14);color:var(--good)}
 .b-warn{background:rgba(179,107,0,.16);color:var(--avg)}
 .b-bad{background:rgba(192,57,43,.14);color:var(--bad)}
 .b-mut{background:var(--surface);color:var(--muted)}
-.badgepv{display:inline-block;padding:3px 12px;border:1px solid var(--line);border-radius:999px;font-size:14px}
+.badgepv{display:inline-block;padding:3px 12px;border:1px solid var(--line);border-radius:999px;font-size:var(--t-sm)}
 .drift{border:1px solid var(--line);border-radius:8px;padding:20px 22px;margin:14px 0}
 .drift.is-drift{border-color:var(--bad)}
 .drift.is-stable{border-color:var(--good)}
-.score{font-size:38px;font-weight:700;line-height:1;letter-spacing:-.02em}
+.score{font-size:var(--t-2xl);font-weight:700;line-height:1;letter-spacing:-.02em}
 .previewbtn{cursor:pointer}
 .shadowbox{width:84px;height:52px;border-radius:8px;background:#fff;display:inline-block;border:1px solid var(--line)}
 .shadowpanel{background:#f0f0f0;border-radius:8px;padding:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:center}
 .shadowpanel .sb{width:56px;height:56px;border-radius:8px;background:#fff}
-footer{margin-top:48px;color:var(--muted);font-size:14px;text-align:center}
+footer{margin-top:48px;color:var(--muted);font-size:var(--t-sm);text-align:center}
 `;
 
 // Dembrandt brand mark (from dembrandt-next/components/AppMarkIcon.tsx). Inlined,
@@ -306,10 +310,27 @@ function typographySection(result: BrandingResult): string {
   );
 }
 
-function tokenChips(values: { value?: string; display?: string; px?: number | string; count?: number }[]): string {
+type TokenValue = { value?: string; display?: string; px?: number | string; numericValue?: number; count?: number };
+
+/** Numeric px of a token value, for ordering a scale low → high. */
+function tokenPx(v: TokenValue): number {
+  if (typeof v.numericValue === "number") return v.numericValue;
+  if (typeof v.px === "number") return v.px;
+  const m = String(v.display ?? v.value ?? v.px ?? "").match(/-?\d+(?:\.\d+)?/);
+  return m ? parseFloat(m[0]) : Number.POSITIVE_INFINITY;
+}
+
+/** Sort token values ascending so a scale reads in order. */
+function sortByPx(values: TokenValue[]): TokenValue[] {
+  return [...values].sort((a, b) => tokenPx(a) - tokenPx(b));
+}
+
+function tokenChips(values: TokenValue[]): string {
   return values
     .map((v) => {
-      const label = v.display ?? v.value ?? (v.px != null ? `${v.px}px` : "");
+      // px may already be a string like "2px" (pre-1.1.0 extractions); don't
+      // re-append the unit.
+      const label = v.display ?? v.value ?? (typeof v.px === "string" ? v.px : v.px != null ? `${v.px}px` : "");
       if (!label) return "";
       return `<span class="tok">${esc(label)}${v.count != null ? ` <span class="muted">${esc(v.count)}×</span>` : ""}</span>`;
     })
@@ -320,13 +341,13 @@ function spacingSection(result: BrandingResult): string {
   const vals = result.spacing?.commonValues ?? [];
   if (!vals.length) return "";
   const scale = result.spacing?.scaleType ? `<p class="sub">Scale: ${esc(result.spacing.scaleType)}</p>` : "";
-  return section("Spacing", `<div class="chips">${tokenChips(vals as any)}</div>${scale}`);
+  return section("Spacing", `<div class="chips">${tokenChips(sortByPx(vals as TokenValue[]))}</div>${scale}`);
 }
 
 function radiusSection(result: BrandingResult): string {
   const vals = result.borderRadius?.values ?? [];
   if (!vals.length) return "";
-  return section("Border radius", `<div class="chips">${tokenChips(vals as any)}</div>`);
+  return section("Border radius", `<div class="chips">${tokenChips(sortByPx(vals as TokenValue[]))}</div>`);
 }
 
 function shadowsSection(result: BrandingResult): string {

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -413,7 +413,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <style>${STYLE}</style>
 </head>
 <body>
-<div class="topbar"><span class="bm">${LOGO}dembrandt</span><span class="u">${esc(result.url)}</span></div>
+<div class="topbar"><span class="bm">${LOGO}</span><span class="u">${esc(result.url)}</span></div>
 <div class="wrap">
 <div class="cap">${esc(domain)} · extracted ${esc(result.extractedAt)}${version ? " · v" + esc(version) : ""} · ${esc(summary)}</div>
 ${gauges}

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -77,56 +77,63 @@ function safeCss(value: unknown): string {
 // design.md / globals.css. Brand fonts are declared with system fallbacks (the App
 // loads them; a standalone file falls back gracefully, staying self-contained).
 const STYLE = `
-:root{--bg:#000000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--line-hover:#3F4150;--ink:#ffffff;--muted:#8A8F98;--tertiary:#5E6772;--accent:#38BDF8;--accent-hover:#7dd3fc;--warm:#EA580C;--good:#4ade80;--warn:#EA580C;--bad:#ef4444;--r-sm:6px;--r-md:8px;--r-lg:12px}
+:root{--bg:#000000;--surface:#0D0D0D;--elevated:#1A1A1A;--line:#242424;--line-hover:#3F4150;--ink:#ffffff;--muted:#8A8F98;--accent:#38BDF8;--accent-hover:#7dd3fc;--warm:#EA580C;--good:#4ade80;--bad:#ef4444;--r-sm:6px;--r-md:8px;--r-lg:12px}
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.6 'Red Hat Display',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;-webkit-font-smoothing:antialiased}
-.wrap{max-width:1000px;margin:0 auto;padding:48px 24px 80px}
-.brand{font-size:13px;font-weight:700;letter-spacing:.02em;color:var(--accent);margin:0 0 18px}
-h1{font-size:30px;font-weight:700;letter-spacing:-.02em;margin:0 0 6px;color:var(--ink)}
-h2{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.09em;color:var(--muted);margin:44px 0 16px}
 a{color:var(--accent);text-decoration:none}
 a:hover{color:var(--accent-hover)}
-.sub{color:var(--muted);font-size:14px}
 .mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
-.grid{display:grid;gap:12px}
-.swatches{grid-template-columns:repeat(auto-fill,minmax(132px,1fr))}
-.sw{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);overflow:hidden;transition:border-color .15s}
-.sw:hover{border-color:var(--line-hover)}
-.sw .chip{height:72px}
-.sw .meta{padding:10px 12px;font-size:12px}
-.sw .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;color:var(--ink)}
-.sw .role{color:var(--accent);font-size:11px;text-transform:uppercase;letter-spacing:.04em;margin-top:3px}
+.muted{color:var(--muted)}
+.sub{color:var(--muted);font-size:14px}
+.row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.kvs{display:flex;flex-wrap:wrap;gap:8px 22px;font-size:14px}
+.topbar{position:sticky;top:0;z-index:10;background:rgba(0,0,0,.82);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);padding:10px 24px;display:flex;align-items:baseline;gap:12px}
+.topbar .bm{font-size:14px;font-weight:700;color:var(--accent);letter-spacing:.01em}
+.topbar .u{color:var(--muted);font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wrap{max-width:1000px;margin:0 auto;padding:8px 24px 88px}
+.cap{text-align:center;color:var(--muted);font-size:14px;margin:22px 0 4px}
+.gauges{display:flex;flex-wrap:wrap;gap:34px;justify-content:center;padding:18px 0 28px;border-bottom:1px solid var(--line)}
+.gauge{display:flex;flex-direction:column;align-items:center;gap:9px}
+.gring{width:84px;height:84px}
+.gring .gbg{fill:none;stroke:var(--line);stroke-width:8}
+.gring .gfg{fill:none;stroke-width:8;stroke-linecap:round}
+.gring.g-pass .gfg{stroke:var(--good)}.gring.g-pass .gnum{fill:var(--good)}
+.gring.g-avg .gfg{stroke:var(--warm)}.gring.g-avg .gnum{fill:var(--warm)}
+.gring.g-fail .gfg{stroke:var(--bad)}.gring.g-fail .gnum{fill:var(--bad)}
+.gnum{font:700 28px 'Red Hat Display',system-ui,sans-serif}
+.glabel{font-size:14px;color:var(--ink);font-weight:600}
+.gsub{font-size:14px;color:var(--muted)}
+details.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);padding:16px 20px;margin:14px 0}
+details.card>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px;font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--muted)}
+details.card>summary::-webkit-details-marker{display:none}
+details.card>summary::after{content:"";margin-left:auto;width:8px;height:8px;border-right:2px solid var(--muted);border-bottom:2px solid var(--muted);transform:rotate(45deg);transition:transform .15s}
+details.card[open]>summary::after{transform:rotate(-135deg)}
+.cardbody{margin-top:16px}
+.colors{display:flex;flex-wrap:wrap;gap:16px}
+.color{display:flex;flex-direction:column;gap:6px;width:104px}
+.color .sw2{width:100%;height:48px;border-radius:var(--r-md);box-shadow:0 0 0 1px rgba(255,255,255,.1)}
+.color .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;color:var(--ink)}
+.color .cmeta{font-size:14px;color:var(--muted);display:flex;align-items:center;gap:6px}
+.color .role{color:var(--accent);font-size:14px;text-transform:uppercase;letter-spacing:.03em}
 .chips{display:flex;flex-wrap:wrap;gap:8px}
-.tok{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-sm);padding:5px 11px;font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:12px;color:var(--ink)}
-table{width:100%;border-collapse:collapse;font-size:13px}
-th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
-th{color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.06em}
-.badge{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:600}
-.b-good{background:rgba(74,222,128,.14);color:var(--good)}
-.b-warn{background:rgba(234,88,12,.16);color:var(--warm)}
-.b-bad{background:rgba(239,68,68,.16);color:var(--bad)}
+.tok{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-sm);padding:6px 12px;font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:14px;color:var(--ink)}
+table{width:100%;border-collapse:collapse;font-size:14px}
+th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--muted);font-weight:600;font-size:14px;text-transform:uppercase;letter-spacing:.05em}
+.badge{display:inline-block;padding:2px 10px;border-radius:999px;font-size:14px;font-weight:600}
+.b-good{background:rgba(74,222,128,.16);color:var(--good)}
+.b-warn{background:rgba(234,88,12,.18);color:var(--warm)}
+.b-bad{background:rgba(239,68,68,.18);color:var(--bad)}
 .b-mut{background:var(--elevated);color:var(--muted)}
-.drift{border:1px solid var(--line);border-radius:var(--r-lg);padding:20px 22px;margin:8px 0 0;background:var(--surface)}
+.drift{border:1px solid var(--line);border-radius:var(--r-lg);padding:20px 22px;margin:14px 0;background:var(--surface)}
 .drift.is-drift{border-color:rgba(239,68,68,.45)}
 .drift.is-stable{border-color:rgba(74,222,128,.4)}
 .score{font-size:40px;font-weight:700;line-height:1;letter-spacing:-.02em}
-.row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
 .previewbtn{cursor:pointer}
 .shadowbox{width:84px;height:52px;border-radius:var(--r-md);background:var(--elevated);display:inline-block}
-.muted{color:var(--muted)}
-.kvs{display:flex;flex-wrap:wrap;gap:8px 20px}
-header{border-bottom:1px solid var(--line);padding-bottom:22px}
-footer{margin-top:56px;color:var(--tertiary);font-size:12px;border-top:1px solid var(--line);padding-top:16px}
-.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);padding:18px 20px;margin:16px 0}
-.card h2{margin:0 0 14px}
-.colors{display:flex;flex-wrap:wrap;gap:14px}
-.color{display:flex;flex-direction:column;gap:6px;width:84px}
-.color .sw2{width:100%;height:46px;border-radius:var(--r-md);box-shadow:0 0 0 1px rgba(255,255,255,.1)}
-.color .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:11px;color:var(--ink)}
-.color .cmeta{font-size:10px;color:var(--muted);display:flex;align-items:center;gap:5px}
-.color .role{color:var(--accent);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
 .shadowpanel{background:#e5e5e5;border-radius:var(--r-md);padding:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:center}
 .shadowpanel .sb{width:56px;height:56px;border-radius:var(--r-md);background:#fff}
+footer{margin-top:56px;color:var(--muted);font-size:14px;border-top:1px solid var(--line);padding-top:18px;text-align:center}
 `;
 
 /* ------------------------------ components ------------------------------ */
@@ -136,9 +143,39 @@ function confBadge(c?: string): string {
   return `<span class="badge ${cls}">${esc(c ?? "low")}</span>`;
 }
 
+// Collapsible section card (Lighthouse-style, native <details> — no JS, stays
+// self-contained). Open by default; the user can collapse any section.
 function section(title: string, body: string): string {
   if (!body.trim()) return "";
-  return `<section class="card"><h2>${esc(title)}</h2>${body}</section>`;
+  return `<details class="card" open><summary>${esc(title)}</summary><div class="cardbody">${body}</div></details>`;
+}
+
+/** A Lighthouse-style circular score gauge (0-100), coloured by threshold. */
+function gauge(value: number, label: string, sub?: string): string {
+  const v = Math.max(0, Math.min(100, Math.round(value)));
+  const cls = v >= 90 ? "g-pass" : v >= 50 ? "g-avg" : "g-fail";
+  const C = 339.292; // 2πr, r=54
+  const arc = ((C * v) / 100).toFixed(1);
+  return `<div class="gauge"><svg viewBox="0 0 120 120" class="gring ${cls}" role="img" aria-label="${esc(label)} ${v} of 100"><circle class="gbg" cx="60" cy="60" r="54"/><circle class="gfg" cx="60" cy="60" r="54" stroke-dasharray="${arc} ${C}" transform="rotate(-90 60 60)"/><text class="gnum" x="60" y="60" text-anchor="middle" dominant-baseline="central">${v}</text></svg><span class="glabel">${esc(label)}</span>${sub ? `<span class="gsub">${esc(sub)}</span>` : ""}</div>`;
+}
+
+/** The top "ranking" row — gauges that summarise the report's status. */
+function summaryGauges(result: BrandingResult, drift?: DriftReport): string {
+  const g: string[] = [];
+  if (drift) {
+    g.push(gauge(Math.max(0, 100 - Math.min(100, drift.score)), "Stability", `drift ${drift.score}`));
+  }
+  const wcag = result.wcag ?? [];
+  if (wcag.length) {
+    const passed = wcag.filter((p) => p.aa).length;
+    g.push(gauge((100 * passed) / wcag.length, "Accessibility", `${passed}/${wcag.length} AA`));
+  }
+  const palette = result.colors?.palette ?? [];
+  if (palette.length) {
+    const high = palette.filter((c) => c.confidence === "high").length;
+    g.push(gauge((100 * high) / palette.length, "Confidence", `${high}/${palette.length} high`));
+  }
+  return g.length ? `<div class="gauges">${g.join("")}</div>` : "";
 }
 
 function paletteSection(result: BrandingResult): string {
@@ -359,6 +396,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
   // Embed the machine-readable data so the report is also a data artifact,
   // re-parseable from the same file (Lighthouse pattern).
   const data = sanitizeJson({ result, drift: options.drift ?? null });
+  const gauges = summaryGauges(result, options.drift);
 
   return `<!doctype html>
 <html lang="en">
@@ -370,15 +408,12 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
 <style>${STYLE}</style>
 </head>
 <body>
+<div class="topbar"><span class="bm">dembrandt</span><span class="u">${esc(result.url)}</span></div>
 <div class="wrap">
-<header>
-<div class="brand">dembrandt</div>
-<h1>${esc(domain)}</h1>
-<div class="sub"><a href="${esc(result.url)}">${esc(result.url)}</a> · extracted ${esc(result.extractedAt)}</div>
-<div class="sub">${esc(summary)}</div>
-</header>
+<div class="cap">${esc(domain)} · extracted ${esc(result.extractedAt)}${version ? " · v" + esc(version) : ""} · ${esc(summary)}</div>
+${gauges}
 ${body}
-<footer>Generated by dembrandt${version ? " v" + esc(version) : ""} · self-contained report, no external resources.</footer>
+<footer>Generated by <a href="https://github.com/dembrandt/dembrandt">Dembrandt</a>${version ? " " + esc(version) : ""} · <a href="https://github.com/dembrandt/dembrandt/issues">File an issue</a></footer>
 </div>
 <script type="application/json" id="dembrandt-data">${data}</script>
 </body>

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -1,0 +1,370 @@
+/**
+ * HTML report formatter — a single self-contained HTML file (inline CSS, no
+ * external fetches) that renders an extraction and, optionally, a drift diff.
+ *
+ * This is the pre-platform bridge (DEM-94): a CI artifact you can open offline
+ * and attach to a PR, before the hosted dashboard exists. It is a *view* over
+ * the same deterministic data the platform will later diff server-side — it
+ * renders structured tokens and single-render contrast only, never re-derives
+ * drift from rendered CSS. Mode B reuses the canonical `computeDrift` engine.
+ *
+ * Like Lighthouse's standalone report, the machine-readable result is embedded
+ * in a <script> so the file is both a human view and a data artifact.
+ */
+
+import type {
+  BrandingResult,
+  PaletteColor,
+  TypographyStyle,
+  ButtonStyle,
+  BadgeStyle,
+  WcagPair,
+  CssState,
+} from "../types.js";
+import type { DriftReport, DriftChange } from "../drift.js";
+
+export interface HtmlReportOptions {
+  /** When present, render a drift banner + changes at the top of the report. */
+  drift?: DriftReport;
+  /** Label for the baseline the drift was computed against (e.g. a filename). */
+  baselineLabel?: string;
+  /** CLI version, surfaced in the footer. */
+  version?: string;
+}
+
+/* ------------------------------- escaping ------------------------------- */
+
+/** Escape text for HTML body / attribute context. */
+function esc(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Sanitize a JSON string for inlining inside a <script> tag. Mirrors Lighthouse's
+ * report-generator: `<` would let a `</script>` in the data break out of the tag,
+ * and U+2028/U+2029 are valid JSON but terminate JS string literals.
+ */
+function sanitizeJson(object: unknown): string {
+  return JSON.stringify(object)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/**
+ * Allow only safe CSS color/length-ish tokens into inline style values, so
+ * extracted site CSS cannot inject `}` / `<` / `url()` etc. into the report.
+ * Anything outside the allowlist is dropped.
+ */
+function safeCss(value: unknown): string {
+  const v = String(value ?? "").trim();
+  if (!v) return "";
+  // hex, rgb/rgba, hsl/hsla, named-ish words, numbers+units, commas, %, spaces, parens, dots, slashes (for line-height font shorthand)
+  if (/^[#0-9a-zA-Z().,%\s/\-+]+$/.test(v) && !/[<>{};]/.test(v)) return v;
+  return "";
+}
+
+/* -------------------------------- styles -------------------------------- */
+
+const STYLE = `
+:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212b;--ink:#e6e9ef;--muted:#9aa3b2;--line:#2a2f3a;--accent:#7c9cff;--good:#3fb950;--warn:#d29922;--bad:#f85149}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif}
+.wrap{max-width:980px;margin:0 auto;padding:32px 20px 64px}
+h1{font-size:22px;margin:0 0 4px}
+h2{font-size:15px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:32px 0 12px;border-bottom:1px solid var(--line);padding-bottom:6px}
+a{color:var(--accent)}
+.sub{color:var(--muted);font-size:13px}
+.grid{display:grid;gap:10px}
+.swatches{grid-template-columns:repeat(auto-fill,minmax(120px,1fr))}
+.sw{background:var(--panel);border:1px solid var(--line);border-radius:8px;overflow:hidden}
+.sw .chip{height:64px}
+.sw .meta{padding:8px 10px;font-size:12px}
+.sw .hex{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.sw .role{color:var(--accent);font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+.chips{display:flex;flex-wrap:wrap;gap:8px}
+.tok{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:4px 10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.badge{display:inline-block;padding:1px 8px;border-radius:999px;font-size:11px;font-weight:600}
+.b-good{background:rgba(63,185,80,.15);color:var(--good)}
+.b-warn{background:rgba(210,153,34,.15);color:var(--warn)}
+.b-bad{background:rgba(248,81,73,.15);color:var(--bad)}
+.b-mut{background:var(--panel2);color:var(--muted)}
+.drift{border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:8px 0 0;background:var(--panel)}
+.drift.is-drift{border-color:rgba(248,81,73,.5)}
+.drift.is-stable{border-color:rgba(63,185,80,.4)}
+.score{font-size:34px;font-weight:700;line-height:1}
+.row{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.previewbtn{border:0;cursor:default}
+.shadowbox{width:80px;height:48px;border-radius:8px;background:#fff;display:inline-block}
+.muted{color:var(--muted)}
+.kvs{display:flex;flex-wrap:wrap;gap:6px 18px}
+footer{margin-top:48px;color:var(--muted);font-size:12px;border-top:1px solid var(--line);padding-top:14px}
+`;
+
+/* ------------------------------ components ------------------------------ */
+
+function confBadge(c?: string): string {
+  const cls = c === "high" ? "b-good" : c === "medium" ? "b-warn" : "b-mut";
+  return `<span class="badge ${cls}">${esc(c ?? "low")}</span>`;
+}
+
+function section(title: string, body: string): string {
+  if (!body.trim()) return "";
+  return `<h2>${esc(title)}</h2>${body}`;
+}
+
+function paletteSection(result: BrandingResult): string {
+  const palette = result.colors?.palette ?? [];
+  if (!palette.length) return "";
+  // role lookup: hex -> role from semantic map
+  const roleByHex = new Map<string, string>();
+  for (const [role, hex] of Object.entries(result.colors?.semantic ?? {})) {
+    if (hex) roleByHex.set(String(hex).toLowerCase(), role);
+  }
+  const cards = palette
+    .map((c: PaletteColor) => {
+      const hex = c.normalized || c.color;
+      const role = roleByHex.get(String(hex).toLowerCase());
+      return `<div class="sw"><div class="chip" style="background:${safeCss(hex) || "transparent"}"></div><div class="meta"><div class="hex">${esc(hex)}</div><div class="sub">${esc(c.count ?? 0)}× ${confBadge(c.confidence)}</div>${role ? `<div class="role">${esc(role)}</div>` : ""}</div></div>`;
+    })
+    .join("");
+  return section("Palette", `<div class="grid swatches">${cards}</div>`);
+}
+
+function semanticSection(result: BrandingResult): string {
+  const sem = Object.entries(result.colors?.semantic ?? {}).filter(([, v]) => v);
+  if (!sem.length) return "";
+  const chips = sem
+    .map(
+      ([role, hex]) =>
+        `<div class="sw" style="min-width:120px"><div class="chip" style="height:40px;background:${safeCss(hex) || "transparent"}"></div><div class="meta"><div class="role">${esc(role)}</div><div class="hex">${esc(hex)}</div></div></div>`
+    )
+    .join("");
+  return section("Semantic colors", `<div class="chips">${chips}</div>`);
+}
+
+function typographySection(result: BrandingResult): string {
+  const styles = result.typography?.styles ?? [];
+  if (!styles.length) return "";
+  const rows = styles
+    .map(
+      (s: TypographyStyle) =>
+        `<tr><td>${esc(s.context)}</td><td>${esc((s.family ?? "").split(",")[0])}</td><td class="mono">${esc(s.size)}</td><td class="mono">${esc(s.weight)}</td><td class="mono">${esc(s.lineHeight ?? "")}</td></tr>`
+    )
+    .join("");
+  const srcs = result.typography?.sources ?? {};
+  const fams = [
+    ...(srcs.googleFonts ?? []),
+    ...(Array.isArray(srcs.adobeFonts) ? srcs.adobeFonts : []),
+    ...(srcs.customFonts ?? []),
+    ...(srcs.selfHostedFonts ?? []),
+  ];
+  const srcLine = fams.length ? `<p class="sub">Sources: ${esc(fams.join(", "))}</p>` : "";
+  return section(
+    "Typography",
+    `<table><thead><tr><th>Context</th><th>Family</th><th>Size</th><th>Weight</th><th>Line height</th></tr></thead><tbody>${rows}</tbody></table>${srcLine}`
+  );
+}
+
+function tokenChips(values: { value?: string; display?: string; px?: number | string; count?: number }[]): string {
+  return values
+    .map((v) => {
+      const label = v.display ?? v.value ?? (v.px != null ? `${v.px}px` : "");
+      if (!label) return "";
+      return `<span class="tok">${esc(label)}${v.count != null ? ` <span class="muted">${esc(v.count)}×</span>` : ""}</span>`;
+    })
+    .join("");
+}
+
+function spacingSection(result: BrandingResult): string {
+  const vals = result.spacing?.commonValues ?? [];
+  if (!vals.length) return "";
+  const scale = result.spacing?.scaleType ? `<p class="sub">Scale: ${esc(result.spacing.scaleType)}</p>` : "";
+  return section("Spacing", `<div class="chips">${tokenChips(vals as any)}</div>${scale}`);
+}
+
+function radiusSection(result: BrandingResult): string {
+  const vals = result.borderRadius?.values ?? [];
+  if (!vals.length) return "";
+  return section("Border radius", `<div class="chips">${tokenChips(vals as any)}</div>`);
+}
+
+function shadowsSection(result: BrandingResult): string {
+  const shadows = result.shadows ?? [];
+  if (!shadows.length) return "";
+  const rows = shadows
+    .map(
+      (s) =>
+        `<div class="row" style="margin-bottom:8px"><span class="shadowbox" style="box-shadow:${safeCss(s.shadow)}"></span><span class="mono sub">${esc(s.shadow)}</span></div>`
+    )
+    .join("");
+  return section("Shadows", rows);
+}
+
+function buttonsSection(result: BrandingResult): string {
+  const buttons = result.components?.buttons ?? [];
+  if (!buttons.length) return "";
+  const previews = buttons
+    .slice(0, 12)
+    .map((b: ButtonStyle) => {
+      const st: CssState = b.states?.default ?? {};
+      const style = [
+        st.backgroundColor ? `background:${safeCss(st.backgroundColor)}` : "",
+        st.color ? `color:${safeCss(st.color)}` : "",
+        st.borderRadius ? `border-radius:${safeCss(st.borderRadius)}` : "",
+        st.padding ? `padding:${safeCss(st.padding)}` : "padding:8px 14px",
+        st.border ? `border:${safeCss(st.border)}` : "",
+        b.fontWeight ? `font-weight:${safeCss(b.fontWeight)}` : "",
+        b.fontSize ? `font-size:${safeCss(b.fontSize)}` : "",
+      ]
+        .filter(Boolean)
+        .join(";");
+      return `<button class="previewbtn" style="${esc(style)}">${esc(b.text || "Button")}</button>`;
+    })
+    .join(" ");
+  return section("Buttons", `<div class="row">${previews}</div>`);
+}
+
+function badgesSection(result: BrandingResult): string {
+  const raw = result.components?.badges;
+  const list: BadgeStyle[] = Array.isArray(raw) ? raw : raw?.all ?? [];
+  if (!list.length) return "";
+  const chips = list
+    .slice(0, 16)
+    .map((bd: BadgeStyle) => {
+      const style = [
+        bd.backgroundColor ? `background:${safeCss(bd.backgroundColor)}` : "",
+        bd.color ? `color:${safeCss(bd.color)}` : "",
+        bd.borderRadius ? `border-radius:${safeCss(bd.borderRadius)}` : "border-radius:999px",
+        bd.padding ? `padding:${safeCss(bd.padding)}` : "padding:2px 10px",
+        bd.fontSize ? `font-size:${safeCss(bd.fontSize)}` : "font-size:12px",
+      ]
+        .filter(Boolean)
+        .join(";");
+      return `<span style="${esc(style)}">${esc(bd.styleType || "Badge")}</span>`;
+    })
+    .join(" ");
+  return section("Badges", `<div class="row">${chips}</div>`);
+}
+
+function wcagSection(result: BrandingResult): string {
+  const pairs = result.wcag ?? [];
+  if (!pairs.length) return "";
+  const rows = pairs
+    .slice(0, 60)
+    .map((p: WcagPair) => {
+      const verdict = p.aa ? `<span class="badge b-good">AA</span>` : p.aaLarge ? `<span class="badge b-warn">AA Large</span>` : `<span class="badge b-bad">Fail</span>`;
+      return `<tr><td><span class="shadowbox" style="width:22px;height:22px;border-radius:4px;background:${safeCss(p.bg)};border:1px solid var(--line)"></span></td><td class="mono">${esc(p.fg)}</td><td class="mono">${esc(p.bg)}</td><td class="mono">${esc(p.ratio?.toFixed ? p.ratio.toFixed(2) : p.ratio)}</td><td>${verdict}</td></tr>`;
+    })
+    .join("");
+  return section(
+    "WCAG contrast",
+    `<table><thead><tr><th>bg</th><th>Foreground</th><th>Background</th><th>Ratio</th><th>AA</th></tr></thead><tbody>${rows}</tbody></table>`
+  );
+}
+
+function metaSection(result: BrandingResult): string {
+  const fw = (result.frameworks ?? []).map((f) => f.name);
+  const icons = (result.iconSystem ?? []).map((i) => i.name);
+  const bps = (result.breakpoints ?? []).map((b) => `${b.px}px`);
+  const items: string[] = [];
+  if (fw.length) items.push(`<span><span class="muted">Frameworks:</span> ${esc(fw.join(", "))}</span>`);
+  if (icons.length) items.push(`<span><span class="muted">Icons:</span> ${esc(icons.join(", "))}</span>`);
+  if (bps.length) items.push(`<span><span class="muted">Breakpoints:</span> ${esc(bps.join(", "))}</span>`);
+  if (!items.length) return "";
+  return section("Detected", `<div class="kvs">${items.join("")}</div>`);
+}
+
+/* -------------------------------- drift --------------------------------- */
+
+function driftSection(drift: DriftReport, baselineLabel?: string): string {
+  const cls = drift.status === "drift" ? "is-drift" : "is-stable";
+  const verdict =
+    drift.status === "drift"
+      ? `<span class="badge b-bad">DRIFT</span>`
+      : `<span class="badge b-good">STABLE</span>`;
+  const cats = drift.categories
+    .filter((c) => c.changed + c.added + c.removed > 0)
+    .map(
+      (c) =>
+        `<tr><td>${esc(c.category)}</td><td>${esc(Math.round(c.score * 100))}</td><td>${esc(c.changed)}</td><td>${esc(c.added)}</td><td>${esc(c.removed)}</td></tr>`
+    )
+    .join("");
+  const changes = drift.changes
+    .slice(0, 120)
+    .map((ch: DriftChange) => {
+      const kindCls = ch.kind === "added" ? "b-good" : ch.kind === "removed" ? "b-bad" : "b-warn";
+      const detail = ch.before && ch.after ? `${esc(ch.before)} → ${esc(ch.after)}` : esc(ch.before ?? ch.after ?? "");
+      return `<tr><td>${esc(ch.category)}</td><td><span class="badge ${kindCls}">${esc(ch.kind)}</span></td><td class="mono">${esc(ch.label)}</td><td class="mono">${detail}</td><td class="mono">${ch.delta != null ? esc(ch.delta) : ""}</td></tr>`;
+    })
+    .join("");
+  const more = drift.changes.length > 120 ? `<p class="sub">… ${drift.changes.length - 120} more changes</p>` : "";
+  return `<div class="drift ${cls}"><div class="row"><div class="score">${esc(drift.score)}</div><div><div>${verdict} <span class="sub">threshold ${esc(drift.threshold)}</span></div><div class="sub">${esc(drift.summary.changed)} changed · ${esc(drift.summary.added)} added · ${esc(drift.summary.removed)} removed${baselineLabel ? ` · vs ${esc(baselineLabel)}` : ""}</div></div></div>${
+    cats ? `<table style="margin-top:14px"><thead><tr><th>Category</th><th>Score</th><th>Δ</th><th>+</th><th>−</th></tr></thead><tbody>${cats}</tbody></table>` : ""
+  }${
+    changes ? `<table style="margin-top:10px"><thead><tr><th>Category</th><th>Kind</th><th>Token</th><th>Change</th><th>Δ</th></tr></thead><tbody>${changes}</tbody></table>${more}` : ""
+  }</div>`;
+}
+
+/* -------------------------------- entry --------------------------------- */
+
+export function generateHtmlReport(result: BrandingResult, options: HtmlReportOptions = {}): string {
+  let domain = result.url;
+  try {
+    domain = new URL(result.url).hostname.replace(/^www\./, "");
+  } catch {
+    /* leave as-is */
+  }
+  const summary = `${result.colors?.palette?.length ?? 0} colors · ${result.typography?.styles?.length ?? 0} text styles · ${result.spacing?.commonValues?.length ?? 0} spacing · ${result.breakpoints?.length ?? 0} breakpoints`;
+  const version = options.version ?? result.meta?.dembrandtVersion ?? "";
+
+  const body = [
+    options.drift ? driftSection(options.drift, options.baselineLabel) : "",
+    paletteSection(result),
+    semanticSection(result),
+    typographySection(result),
+    spacingSection(result),
+    radiusSection(result),
+    shadowsSection(result),
+    buttonsSection(result),
+    badgesSection(result),
+    wcagSection(result),
+    metaSection(result),
+  ].join("\n");
+
+  // Embed the machine-readable data so the report is also a data artifact,
+  // re-parseable from the same file (Lighthouse pattern).
+  const data = sanitizeJson({ result, drift: options.drift ?? null });
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="generator" content="dembrandt${version ? " " + esc(version) : ""}">
+<title>Dembrandt report — ${esc(domain)}</title>
+<style>${STYLE}</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+<h1>${esc(domain)}</h1>
+<div class="sub"><a href="${esc(result.url)}">${esc(result.url)}</a> · extracted ${esc(result.extractedAt)}</div>
+<div class="sub">${esc(summary)}</div>
+</header>
+${body}
+<footer>Generated by dembrandt${version ? " v" + esc(version) : ""} · self-contained report, no external resources.</footer>
+</div>
+<script type="application/json" id="dembrandt-data">${data}</script>
+</body>
+</html>`;
+}

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -117,6 +117,16 @@ th{color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;le
 .kvs{display:flex;flex-wrap:wrap;gap:8px 20px}
 header{border-bottom:1px solid var(--line);padding-bottom:22px}
 footer{margin-top:56px;color:var(--tertiary);font-size:12px;border-top:1px solid var(--line);padding-top:16px}
+.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r-lg);padding:18px 20px;margin:16px 0}
+.card h2{margin:0 0 14px}
+.colors{display:flex;flex-wrap:wrap;gap:14px}
+.color{display:flex;flex-direction:column;gap:6px;width:84px}
+.color .sw2{width:100%;height:46px;border-radius:var(--r-md);box-shadow:0 0 0 1px rgba(255,255,255,.1)}
+.color .hex{font-family:'JetBrains Mono',ui-monospace,Menlo,monospace;font-size:11px;color:var(--ink)}
+.color .cmeta{font-size:10px;color:var(--muted);display:flex;align-items:center;gap:5px}
+.color .role{color:var(--accent);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+.shadowpanel{background:#e5e5e5;border-radius:var(--r-md);padding:18px;display:flex;flex-wrap:wrap;gap:18px;align-items:center}
+.shadowpanel .sb{width:56px;height:56px;border-radius:var(--r-md);background:#fff}
 `;
 
 /* ------------------------------ components ------------------------------ */
@@ -128,7 +138,7 @@ function confBadge(c?: string): string {
 
 function section(title: string, body: string): string {
   if (!body.trim()) return "";
-  return `<h2>${esc(title)}</h2>${body}`;
+  return `<section class="card"><h2>${esc(title)}</h2>${body}</section>`;
 }
 
 function paletteSection(result: BrandingResult): string {
@@ -143,10 +153,10 @@ function paletteSection(result: BrandingResult): string {
     .map((c: PaletteColor) => {
       const hex = c.normalized || c.color;
       const role = roleByHex.get(String(hex).toLowerCase());
-      return `<div class="sw"><div class="chip" style="background:${safeCss(hex) || "transparent"}"></div><div class="meta"><div class="hex">${esc(hex)}</div><div class="sub">${esc(c.count ?? 0)}× ${confBadge(c.confidence)}</div>${role ? `<div class="role">${esc(role)}</div>` : ""}</div></div>`;
+      return `<div class="color"><div class="sw2" style="background:${safeCss(hex) || "transparent"}"></div><div class="hex">${esc(hex)}</div><div class="cmeta">${esc(c.count ?? 0)}× ${confBadge(c.confidence)}</div>${role ? `<div class="role">${esc(role)}</div>` : ""}</div>`;
     })
     .join("");
-  return section("Palette", `<div class="grid swatches">${cards}</div>`);
+  return section("Palette", `<div class="colors">${cards}</div>`);
 }
 
 function semanticSection(result: BrandingResult): string {
@@ -155,10 +165,10 @@ function semanticSection(result: BrandingResult): string {
   const chips = sem
     .map(
       ([role, hex]) =>
-        `<div class="sw" style="min-width:120px"><div class="chip" style="height:40px;background:${safeCss(hex) || "transparent"}"></div><div class="meta"><div class="role">${esc(role)}</div><div class="hex">${esc(hex)}</div></div></div>`
+        `<div class="color"><div class="sw2" style="background:${safeCss(hex) || "transparent"}"></div><div class="role">${esc(role)}</div><div class="hex">${esc(hex)}</div></div>`
     )
     .join("");
-  return section("Semantic colors", `<div class="chips">${chips}</div>`);
+  return section("Semantic colors", `<div class="colors">${chips}</div>`);
 }
 
 function typographySection(result: BrandingResult): string {
@@ -210,13 +220,9 @@ function radiusSection(result: BrandingResult): string {
 function shadowsSection(result: BrandingResult): string {
   const shadows = result.shadows ?? [];
   if (!shadows.length) return "";
-  const rows = shadows
-    .map(
-      (s) =>
-        `<div class="row" style="margin-bottom:8px"><span class="shadowbox" style="box-shadow:${safeCss(s.shadow)}"></span><span class="mono sub">${esc(s.shadow)}</span></div>`
-    )
-    .join("");
-  return section("Shadows", rows);
+  const boxes = shadows.map((s) => `<span class="sb" style="box-shadow:${safeCss(s.shadow)}"></span>`).join("");
+  const list = shadows.map((s) => `<div class="mono sub">${esc(s.shadow)}</div>`).join("");
+  return section("Shadows", `<div class="shadowpanel">${boxes}</div><div style="margin-top:12px;display:grid;gap:4px">${list}</div>`);
 }
 
 function buttonsSection(result: BrandingResult): string {

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -14,6 +14,8 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { loadBrowserEngines, PlaywrightMissingError } from "./lib/browser.js";
 import { extractBranding } from "./lib/extractors/index.js";
+import { computeDrift } from "./lib/drift.js";
+import { generateHtmlReport } from "./lib/formatters/html.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -327,6 +329,37 @@ async function main() {
       iconSystem: d.iconSystem,
       breakpoints: d.breakpoints,
     })),
+  );
+
+  // ── Drift & report tools (synchronous, no browser) ─────────────────────
+
+  const extract = z.record(z.any()).describe("A dembrandt extraction object, as returned by get_design_tokens");
+
+  (server.tool as any)(
+    "compute_drift",
+    "Compare two dembrandt extractions and return a design-drift report: a 0-100 score (0 = identical), a stable/drift verdict, per-category scores, and the list of changed/added/removed tokens (colors, typography, spacing, radius, shadows). Pure and synchronous — no browser. Use it to check whether generated or updated UI has drifted from a brand baseline.",
+    {
+      baseline: extract,
+      candidate: extract,
+      failThreshold: z.number().optional().describe("Score above this yields a 'drift' verdict (default 10)"),
+    },
+    ({ baseline, candidate, failThreshold }: any) => {
+      const report = computeDrift(baseline, candidate, failThreshold != null ? { failThreshold } : {});
+      return jsonResult(report);
+    },
+  );
+
+  (server.tool as any)(
+    "render_report",
+    "Render a self-contained HTML report (inline CSS, no external resources) from a dembrandt extraction, optionally including a drift diff. Returns the HTML as text — write it to a .html file to open offline or attach as a CI artifact.",
+    {
+      result: extract,
+      drift: z.any().optional().describe("A drift report from compute_drift, to render the diff banner"),
+    },
+    ({ result, drift }: any) => {
+      const html = generateHtmlReport(result, { drift: drift ?? undefined });
+      return { content: [{ type: "text", text: html }] };
+    },
   );
 
   // ── Job management tools ───────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,17 @@
 {
   "name": "dembrandt",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt",
-      "version": "0.17.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
-        "ora": "^7.0.1",
-        "playwright": "^1.57.0",
-        "playwright-core": "1.60.0",
-        "zod": "4.3.6"
+        "ora": "^7.0.1"
       },
       "bin": {
         "dembrandt": "dist/index.js",
@@ -23,13 +19,37 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@types/node": "25.9.2",
         "eslint": "10.4.1",
+        "playwright": "^1.57.0",
+        "playwright-core": "1.60.0",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.60.1"
+        "typescript-eslint": "8.60.1",
+        "zod": "4.3.6"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "playwright": "^1.57.0",
+        "playwright-core": "1.60.0",
+        "zod": "4.3.6"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -164,6 +184,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -242,6 +263,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -543,6 +565,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -579,6 +602,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -595,6 +619,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -665,6 +690,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -726,6 +752,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -735,6 +762,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -748,6 +776,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -800,6 +829,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -813,6 +843,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -822,6 +853,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -831,6 +863,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -840,6 +873,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -857,6 +891,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -871,6 +906,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -895,6 +931,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -904,6 +941,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -924,12 +962,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -939,6 +979,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -948,6 +989,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -957,6 +999,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -969,6 +1012,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -1164,6 +1208,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1173,6 +1218,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -1185,6 +1231,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -1194,6 +1241,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -1237,6 +1285,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -1255,6 +1304,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1275,6 +1325,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1322,6 +1373,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1381,6 +1433,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1390,6 +1443,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1399,6 +1453,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1413,6 +1468,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1422,6 +1478,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1446,6 +1503,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -1472,6 +1530,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1484,6 +1543,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1496,6 +1556,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1508,6 +1569,7 @@
       "version": "4.12.23",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1517,6 +1579,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -1537,6 +1600,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1599,6 +1663,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1608,6 +1673,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -1652,6 +1718,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
@@ -1670,12 +1737,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1692,12 +1761,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -1767,6 +1838,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1776,6 +1848,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1785,6 +1858,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1797,6 +1871,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1806,6 +1881,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -1847,6 +1923,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -1860,6 +1937,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1869,6 +1947,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1878,6 +1957,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1890,6 +1970,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -1902,6 +1983,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2034,6 +2116,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2053,6 +2136,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2062,6 +2146,7 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
       "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2085,6 +2170,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -2094,6 +2180,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -2112,6 +2199,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -2134,6 +2222,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -2157,6 +2246,7 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2172,6 +2262,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2181,6 +2272,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -2210,6 +2302,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2235,6 +2328,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2271,6 +2365,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -2290,6 +2385,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -2316,6 +2412,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -2335,12 +2432,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2353,6 +2452,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2362,6 +2462,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2381,6 +2482,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2397,6 +2499,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -2415,6 +2518,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -2440,6 +2544,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2505,6 +2610,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -2540,6 +2646,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -2599,6 +2706,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2624,6 +2732,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2633,6 +2742,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2658,6 +2768,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
@@ -2677,6 +2788,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -2686,6 +2798,7 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/lib/drift.d.ts",
       "default": "./dist/lib/drift.js"
     },
+    "./report": {
+      "types": "./dist/lib/formatters/html.d.ts",
+      "default": "./dist/lib/formatters/html.js"
+    },
     "./normalize": "./dist/lib/normalize.js",
     "./types": {
       "types": "./dist/lib/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",

--- a/test/compare.test.ts
+++ b/test/compare.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCompare } from '../lib/compare.js';
+
+/**
+ * resolveCompare dispatches `--compare <arg>` on file-vs-id with injectable deps,
+ * so both backends are exercised without a real filesystem or network: a local
+ * file diffs here; a baseline id POSTs to the App and uses its returned report.
+ */
+
+function fixture(overrides: any = {}): any {
+  return {
+    url: 'https://example.com/',
+    extractedAt: 't',
+    colors: { palette: [{ normalized: '#133174', count: 40, confidence: 'high' }], semantic: { primary: '#133174' }, cssVariables: {} },
+    typography: { styles: [], sources: {} },
+    spacing: { scaleType: 'base-8', commonValues: [] },
+    borderRadius: { values: [] },
+    borders: {}, shadows: [],
+    components: { buttons: [], inputs: [], links: [], badges: [] },
+    breakpoints: [], iconSystem: [], frameworks: [],
+    ...overrides,
+  };
+}
+
+test('local file path: diffs against the file here', async () => {
+  const baseline = fixture();
+  const candidate = fixture({ colors: { palette: [{ normalized: '#0a0a0a', count: 40, confidence: 'high' }], semantic: {}, cssVariables: {} } });
+  const r = await resolveCompare('baseline.json', candidate, {
+    isFile: () => true,
+    readFile: () => JSON.stringify(baseline),
+  });
+  assert.equal(r.mode, 'local');
+  assert.equal(r.source, 'baseline.json');
+  assert.equal(r.report.status, 'drift');
+});
+
+test('baseline id path: POSTs candidate to the App and returns its report', async () => {
+  const candidate = fixture();
+  let captured: any = null;
+  const fakeReport = { score: 7, status: 'stable', threshold: 10, summary: { changed: 0, added: 0, removed: 0 }, categories: [], changes: [] };
+  const fetchFn = (async (url: string, init: any) => {
+    captured = { url, body: JSON.parse(init.body) };
+    return { ok: true, json: async () => ({ drift: fakeReport }) };
+  }) as any;
+
+  const r = await resolveCompare('dembrandt.com', candidate, {
+    isFile: () => false,
+    fetchFn,
+    api: 'https://app.example.com/',
+  });
+
+  assert.equal(captured.url, 'https://app.example.com/api/app/drift');
+  assert.equal(captured.body.baselineId, 'dembrandt.com');
+  assert.ok(captured.body.candidate.colors, 'sends the candidate extraction');
+  assert.equal(r.mode, 'platform');
+  assert.equal(r.report.score, 7);
+});
+
+test('baseline id path: surfaces a platform error', async () => {
+  const fetchFn = (async () => ({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({ error: 'baseline not found: nope' }) })) as any;
+  await assert.rejects(
+    () => resolveCompare('nope', fixture(), { isFile: () => false, fetchFn, api: 'https://app.example.com' }),
+    /platform compare failed \(404\): baseline not found: nope/,
+  );
+});

--- a/test/exit-codes.test.ts
+++ b/test/exit-codes.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EXIT, classifyError } from '../lib/exit-codes.js';
+
+/**
+ * The CI exit-code contract. dembrandt-next's drift.yml branches on these exact
+ * numbers (1 = drift, anything else nonzero = extraction failure) and the README
+ * documents 67 as the retryable timeout. These tests pin the contract so a
+ * refactor cannot silently renumber it.
+ */
+
+test('EXIT codes hold their documented values', () => {
+  assert.deepEqual(EXIT, { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 });
+});
+
+test('drift exit is distinct from every failure exit', () => {
+  // The whole point of the contract: a pipeline must tell "design drifted"
+  // apart from "extraction broke". DRIFT must never collide with a failure code.
+  assert.notEqual(EXIT.DRIFT, EXIT.RUNTIME);
+  assert.notEqual(EXIT.DRIFT, EXIT.TIMEOUT);
+  assert.notEqual(EXIT.DRIFT, EXIT.OK);
+});
+
+const TIMEOUT_CASES: Array<[string, string]> = [
+  ['Playwright timeout', 'Timeout 30000ms exceeded'],
+  ['Chromium net error', 'page.goto: net::ERR_CONNECTION_REFUSED at https://x'],
+  ['connection refused', 'connect ECONNREFUSED 127.0.0.1:443'],
+  ['socket timeout', 'request failed, reason: ETIMEDOUT'],
+  ['DNS not found', 'getaddrinfo ENOTFOUND nope.invalid'],
+  ['name not resolved', 'net::ERR_NAME_NOT_RESOLVED'],
+];
+
+for (const [label, message] of TIMEOUT_CASES) {
+  test(`classifyError → retryable timeout: ${label}`, () => {
+    const r = classifyError(new Error(message));
+    assert.equal(r.exit, EXIT.TIMEOUT);
+    assert.equal(r.code, 'NAVIGATION_TIMEOUT');
+  });
+}
+
+test('classifyError → timeout matching is case-insensitive', () => {
+  const r = classifyError(new Error('TIMEOUT while loading'));
+  assert.equal(r.exit, EXIT.TIMEOUT);
+});
+
+test('classifyError → generic runtime failure for non-network errors', () => {
+  const r = classifyError(new Error('Cannot read properties of undefined'));
+  assert.equal(r.exit, EXIT.RUNTIME);
+  assert.equal(r.code, 'EXTRACTION_FAILED');
+});
+
+test('classifyError never throws on malformed input', () => {
+  // index.ts catch blocks pass `err` straight in; a bare string, null, or an
+  // object without a message must degrade to a runtime failure, not crash.
+  for (const bad of [null, undefined, 'a string', 42, {}, { message: null }]) {
+    const r = classifyError(bad as any);
+    assert.equal(r.exit, EXIT.RUNTIME);
+    assert.equal(r.code, 'EXTRACTION_FAILED');
+  }
+});

--- a/test/findings.test.ts
+++ b/test/findings.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeFindings } from '../lib/findings.js';
+
+/**
+ * computeFindings is the single source of truth behind the report's summary
+ * scores. These pin the four honest checks and the derived consistency score —
+ * every gauge number must trace back to a finding here.
+ */
+
+function base(overrides: any = {}): any {
+  return {
+    url: 'https://example.com/',
+    colors: { palette: [{ normalized: '#133174', confidence: 'high', count: 40 }], semantic: { primary: '#133174' } },
+    typography: { styles: [{ context: 'body', size: '16px (1rem)', weight: 400 }] },
+    spacing: { scaleType: 'base-8', commonValues: [{ px: 16, display: '16px' }] },
+    borderRadius: { values: [{ value: '8px' }] },
+    shadows: [{ shadow: '0 1px 2px rgba(0,0,0,.1)' }],
+    breakpoints: [{ px: 768 }],
+    ...overrides,
+  };
+}
+
+test('a clean extraction yields no findings and a perfect consistency score', () => {
+  const fr = computeFindings(base());
+  assert.equal(fr.findings.length, 0);
+  assert.equal(fr.consistency, 100);
+  assert.deepEqual(fr.coverage, { present: 6, total: 6 });
+});
+
+test('perceptually identical palette colours are flagged as a duplicate token', () => {
+  const fr = computeFindings(base({
+    colors: { palette: [{ normalized: '#133174' }, { normalized: '#133074' }], semantic: {} },
+  }));
+  const dup = fr.findings.filter((f) => f.category === 'duplication');
+  assert.equal(dup.length, 1);
+  assert.match(dup[0].message, /perceptually identical/);
+  assert.equal(fr.consistency, 94); // one warn = -6
+});
+
+test('two roles sharing size + weight are flagged as no-hierarchy', () => {
+  const fr = computeFindings(base({
+    typography: { styles: [
+      { context: 'heading-2', size: '40px (2.5rem)', weight: 700 },
+      { context: 'body', size: '40px (2.5rem)', weight: 700 },
+    ] },
+  }));
+  const c = fr.findings.filter((f) => f.category === 'consistency');
+  assert.equal(c.length, 1);
+  assert.match(c[0].message, /no visual hierarchy/);
+});
+
+test('a light primary that fails AA on white is flagged (warn)', () => {
+  // #9aa0ff is bright enough to fall below 4.5:1 on white.
+  const fr = computeFindings(base({
+    colors: { palette: [{ normalized: '#9aa0ff' }], semantic: { primary: '#9aa0ff' } },
+  }));
+  const contrast = fr.findings.filter((f) => f.category === 'contrast');
+  assert.equal(contrast.length, 1);
+  assert.equal(contrast[0].severity, 'warn');
+  assert.match(contrast[0].message, /low contrast on white/);
+});
+
+test('a dark primary that clears AA on white produces no contrast finding', () => {
+  const fr = computeFindings(base({ colors: { palette: [], semantic: { primary: '#133174' } } }));
+  assert.equal(fr.findings.filter((f) => f.category === 'contrast').length, 0);
+});
+
+test('rgb() primary is parsed for the white-contrast check', () => {
+  const fr = computeFindings(base({ colors: { palette: [], semantic: { primary: 'rgb(154,160,255)' } } }));
+  assert.equal(fr.findings.filter((f) => f.category === 'contrast').length, 1);
+});
+
+test('spacing values off the detected base grid are flagged', () => {
+  const fr = computeFindings(base({
+    spacing: { scaleType: 'base-8', commonValues: [{ px: 16 }, { px: 13 }, { px: 24 }] },
+  }));
+  const c = fr.findings.filter((f) => f.message.includes('spacing grid'));
+  assert.equal(c.length, 1);
+  assert.match(c[0].message, /13px/);
+});
+
+test('coverage counts only the token categories actually present', () => {
+  const fr = computeFindings(base({ shadows: [], breakpoints: [] }));
+  assert.equal(fr.coverage.present, 4);
+});

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateHtmlReport } from '../lib/formatters/html.js';
+import { computeDrift } from '../lib/drift.js';
+
+/**
+ * generateHtmlReport is a pure result -> string formatter. These assertions pin
+ * the contract that makes it usable as a CI artifact: self-contained (no external
+ * resources), correct escaping of untrusted extracted strings, an embedded
+ * machine-readable payload that round-trips, and the drift banner in Mode B.
+ */
+
+function fixture(overrides: any = {}): any {
+  return {
+    url: 'https://example.com/',
+    extractedAt: '2026-06-13T00:00:00.000Z',
+    meta: { schemaVersion: '1.1.0', dembrandtVersion: '0.18.0' },
+    colors: {
+      palette: [
+        { color: '#133174', normalized: '#133174', count: 40, confidence: 'high' },
+        { color: '#ff8800', normalized: '#ff8800', count: 8, confidence: 'medium' },
+      ],
+      semantic: { primary: '#133174' },
+      cssVariables: {},
+    },
+    typography: { styles: [{ context: 'body', family: 'Inter, sans-serif', size: '16px', weight: 400 }], sources: {} },
+    spacing: { scaleType: 'base-8', commonValues: [{ px: 16, display: '16px', count: 12 }] },
+    borderRadius: { values: [{ value: '8px', count: 5, confidence: 'high' }] },
+    borders: {},
+    shadows: [{ shadow: '0 1px 2px rgba(0,0,0,.1)', count: 3, confidence: 'high' }],
+    components: { buttons: [{ states: { default: { backgroundColor: '#133174', color: '#fff' } }, text: 'Go' }], inputs: [], links: [], badges: [] },
+    breakpoints: [{ px: 768 }],
+    iconSystem: [],
+    frameworks: [{ name: 'Tailwind', confidence: 'high' }],
+    ...overrides,
+  };
+}
+
+test('renders a self-contained document with no external resources', () => {
+  const html = generateHtmlReport(fixture());
+  assert.match(html, /^<!doctype html>/);
+  assert.match(html, /example\.com/);
+  assert.doesNotMatch(html, /<script\s+src=/i);
+  assert.doesNotMatch(html, /<link\s/i);
+  assert.doesNotMatch(html, /src="https?:/i);
+  assert.doesNotMatch(html, /@import/i);
+});
+
+test('embeds a machine-readable payload that round-trips', () => {
+  const html = generateHtmlReport(fixture());
+  const m = html.match(/<script type="application\/json" id="dembrandt-data">([\s\S]*?)<\/script>/);
+  assert.ok(m, 'embedded data script present');
+  const data = JSON.parse(m![1]);
+  assert.equal(data.result.colors.palette.length, 2);
+  assert.equal(data.drift, null);
+});
+
+test('escapes untrusted extracted strings (no script/style breakout)', () => {
+  const evil = '</script><img src=x onerror=alert(1)>';
+  const html = generateHtmlReport(fixture({ siteName: evil, colors: { palette: [{ color: evil, normalized: evil, count: 1, confidence: 'low' }], semantic: {}, cssVariables: {} } }));
+  // The raw breakout sequence must never appear unescaped in the document.
+  assert.doesNotMatch(html, /<img src=x onerror=/);
+  // The embedded JSON must not contain a literal closing script tag.
+  const m = html.match(/id="dembrandt-data">([\s\S]*?)<\/script>/);
+  assert.ok(m);
+  assert.ok(!m![1].includes('</script>'));
+});
+
+test('Mode B renders a drift banner when a report is supplied', () => {
+  const base = fixture();
+  const cand = fixture({ colors: { palette: [{ color: '#0a0a0a', normalized: '#0a0a0a', count: 40, confidence: 'high' }], semantic: {}, cssVariables: {} } });
+  const drift = computeDrift(base, cand);
+  const html = generateHtmlReport(cand, { drift });
+  assert.match(html, /class="drift is-(drift|stable)"/);
+  assert.match(html, />(DRIFT|STABLE)</);
+  const data = JSON.parse(html.match(/id="dembrandt-data">([\s\S]*?)<\/script>/)![1]);
+  assert.equal(typeof data.drift.score, 'number');
+});

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -6,8 +6,9 @@ import { computeDrift } from '../lib/drift.js';
 /**
  * generateHtmlReport is a pure result -> string formatter. These assertions pin
  * the contract that makes it usable as a CI artifact: self-contained (no external
- * resources), correct escaping of untrusted extracted strings, an embedded
- * machine-readable payload that round-trips, and the drift banner in Mode B.
+ * resources), correct escaping of untrusted extracted strings, and the drift
+ * banner in Mode B. The report is the rendered HTML only — no embedded JSON
+ * (dropped for size; the machine-readable form is --json-only).
  */
 
 function fixture(overrides: any = {}): any {
@@ -46,33 +47,56 @@ test('renders a self-contained document with no external resources', () => {
   assert.doesNotMatch(html, /@import/i);
 });
 
-test('embeds a machine-readable payload that round-trips', () => {
-  const html = generateHtmlReport(fixture());
-  const m = html.match(/<script type="application\/json" id="dembrandt-data">([\s\S]*?)<\/script>/);
-  assert.ok(m, 'embedded data script present');
-  const data = JSON.parse(m![1]);
-  assert.equal(data.result.colors.palette.length, 2);
-  assert.equal(data.drift, null);
-});
-
-test('escapes untrusted extracted strings (no script/style breakout)', () => {
-  const evil = '</script><img src=x onerror=alert(1)>';
-  const html = generateHtmlReport(fixture({ siteName: evil, colors: { palette: [{ color: evil, normalized: evil, count: 1, confidence: 'low' }], semantic: {}, cssVariables: {} } }));
-  // The raw breakout sequence must never appear unescaped in the document.
+test('escapes untrusted extracted strings (no breakout into the document)', () => {
+  const evil = '</style><img src=x onerror=alert(1)>';
+  const html = generateHtmlReport(fixture({
+    siteName: evil,
+    colors: { palette: [{ color: evil, normalized: evil, count: 1, confidence: 'low' }], semantic: {}, cssVariables: {} },
+  }));
+  // The raw breakout sequence must never appear unescaped; the injected string
+  // must render in its escaped form (the only legit </style> is the real one).
   assert.doesNotMatch(html, /<img src=x onerror=/);
-  // The embedded JSON must not contain a literal closing script tag.
-  const m = html.match(/id="dembrandt-data">([\s\S]*?)<\/script>/);
-  assert.ok(m);
-  assert.ok(!m![1].includes('</script>'));
+  assert.match(html, /&lt;\/style&gt;&lt;img src=x onerror=alert\(1\)&gt;/);
 });
 
-test('Mode B renders a drift banner when a report is supplied', () => {
+test('the summary header always shows a Consistency gauge + a counts caption', () => {
+  // Consistency is always computable, so the header is always present; the
+  // counts caption replaces the dropped (useless) Token-coverage gauge.
+  const baseHtml = generateHtmlReport(fixture());
+  assert.match(baseHtml, /class="gauges"/);
+  assert.match(baseHtml, />Consistency</);
+  assert.match(baseHtml, />Contrast</); // always-on, self-computed from colours
+  assert.match(baseHtml, /class="counts"/);
+  assert.match(baseHtml, /text style/); // honest count, not a score
+  // Without WCAG data the Contrast gauge links to the findings, not a WCAG card.
+  assert.doesNotMatch(baseHtml, /href="#wcag"/);
+  // WCAG present → the Contrast gauge uses real pairs and links to the WCAG card.
+  const wcag = generateHtmlReport(fixture({ wcag: [{ fg: '#000', bg: '#fff', ratio: 21, aa: true, aaLarge: true, aaa: true }] }));
+  assert.match(wcag, /href="#wcag"/);
+});
+
+test('a CSS-only theme toggle is present (dark default, light when checked)', () => {
+  const html = generateHtmlReport(fixture());
+  assert.match(html, /id="theme"/);
+  assert.match(html, /:root:has\(#theme:checked\)/);
+  assert.match(html, /color-scheme:dark/); // default
+});
+
+test('findings drive the report: a contrast smell surfaces in the Findings card', () => {
+  // A light primary fails AA on white → a Findings card with a warn badge.
+  const html = generateHtmlReport(fixture({
+    colors: { palette: [{ color: '#9aa0ff', normalized: '#9aa0ff', count: 5, confidence: 'high' }], semantic: { primary: '#9aa0ff' }, cssVariables: {} },
+  }));
+  assert.match(html, /id="findings"/);
+  assert.match(html, /low contrast on white/);
+});
+
+test('Mode B renders a drift banner and a Drift gauge', () => {
   const base = fixture();
   const cand = fixture({ colors: { palette: [{ color: '#0a0a0a', normalized: '#0a0a0a', count: 40, confidence: 'high' }], semantic: {}, cssVariables: {} } });
   const drift = computeDrift(base, cand);
   const html = generateHtmlReport(cand, { drift });
   assert.match(html, /class="drift is-(drift|stable)"/);
   assert.match(html, />(DRIFT|STABLE)</);
-  const data = JSON.parse(html.match(/id="dembrandt-data">([\s\S]*?)<\/script>/)![1]);
-  assert.equal(typeof data.drift.score, 'number');
+  assert.match(html, />Drift</);
 });


### PR DESCRIPTION
Ships the 0.19.0 surface that downstream consumers (dembrandt-next drift.yml, dembrandt-skills) are waiting on.

## What
- `--html [path]` — self-contained HTML report (themed, grouped, findings engine), optionally with a drift diff banner.
- `--compare <baseline>` — drift gate against a local JSON baseline or an App baseline id; exits 1 on drift.
- `lib/exit-codes.ts` — pure, importable CI exit-code contract (0 stable / 1 drift / 2 failure / 67 timeout), with unit tests pinning it. Previously inline in index.ts and untestable without spawning the CLI.
- `0.19.0` version bump; `package-lock.json` synced.

## Why it matters
dembrandt-next's `drift.yml` no-ops until the published CLI advertises `--compare`/`--html`. This release arms that gate. The `dembrandt/drift` subpath export (already present, playwright-free) also unblocks DEM-93 (dembrandt-next deletes its forked drift engine).

## Tests
- 197 unit tests pass (11 new in `test/exit-codes.test.ts`).
- Build clean, lint clean.
- README "Drift gate" section documents the flags and exit codes.