### PR TITLE
fix(mcp): tools/list crash from zod-3 z.record idiom (0.19.1)

### DIFF
--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -333,7 +333,9 @@ async function main() {
 
   // ── Drift & report tools (synchronous, no browser) ─────────────────────
 
-  const extract = z.record(z.any()).describe("A dembrandt extraction object, as returned by get_design_tokens");
+  // zod 4: z.record needs explicit key + value types; z.record(z.any()) treats
+  // the lone arg as the KEY and leaves value undefined, which crashes tools/list.
+  const extract = z.record(z.string(), z.any()).describe("A dembrandt extraction object, as returned by get_design_tokens");
 
   (server.tool as any)(
     "compute_drift",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dembrandt",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",


### PR DESCRIPTION
## Bug
0.19.0's MCP server crashes on `tools/list` with `Cannot read properties of undefined (reading '_zod')`. Since every MCP client calls `tools/list` before any tool call, **the entire MCP is non-functional** — no tool is discoverable. `initialize` succeeds, masking it.

## Cause
`mcp-server.ts` registers the shared `extract` param schema as `z.record(z.any())`. That is a zod-3 idiom. Under zod 4 (pinned at 4.3.6) the lone argument is the **key** type, leaving the value type `undefined`; the SDK's JSON-schema conversion then dereferences `._zod` on undefined and throws. Introduced in #86 with the new `compute_drift` / `render_report` tools, which all use this schema.

## Fix
`z.record(z.string(), z.any())`. One line.

## Verified (local server, real extraction)
- `tools/list` → all 11 tools returned: get_design_tokens, get_color_palette, get_typography, get_component_styles, get_surfaces, get_spacing, get_brand_identity, compute_drift, render_report, get_job_status, cancel_job.
- `compute_drift` → returns a drift report.
- `render_report` → 29 KB self-contained HTML with drift banner.
- 197 unit tests pass; build + lint clean.

Bumps to **0.19.1**. Needs a manual npm publish after merge (0.19.0's MCP should be considered broken).