### PR TITLE
fix(report): breakpoint pxpx + topbar overflow; add CI drift-gate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ dembrandt https://app.example.com --json-only > baseline.json
 dembrandt https://app.example.com --compare baseline.json --html report.html
 ```
 
+A ready-to-use GitHub Actions workflow (preview vs production, run summary, report artifact, host-auth bypass) is in [`examples/drift-gate.yml`](examples/drift-gate.yml).
+
 ### Exit codes
 
 A pipeline can branch on the exit code; "design drifted" and "extraction broke" are distinct:

--- a/examples/drift-gate.yml
+++ b/examples/drift-gate.yml
@@ -1,0 +1,86 @@
+# Design drift gate — copy into .github/workflows/ of your app repo.
+#
+# On every successful preview deploy, extracts the preview and compares its
+# design tokens against production. Fails the check when the drift score crosses
+# the threshold, writes a per-page verdict to the run summary, and uploads a
+# self-contained HTML report. No design-review meeting needed to catch that a
+# color or spacing step quietly changed.
+#
+# Requires: dembrandt 0.19+ (ships --compare / --html). playwright is a peer dep,
+# so install it explicitly.
+
+name: Design drift
+on:
+  deployment_status            # fires when Vercel/Netlify finish a preview deploy
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment != 'Production'
+    runs-on: ubuntu-latest
+    env:
+      PREVIEW: ${{ github.event.deployment_status.environment_url }}
+      PROD: https://example.com          # your production URL (the pinned baseline)
+      # Preview deployments are often behind host auth (e.g. Vercel Deployment
+      # Protection). Without a bypass, the extractor is redirected to a login
+      # page and every page reads as 100% drift. Enable "Protection Bypass for
+      # Automation" and store the secret as VERCEL_AUTOMATION_BYPASS_SECRET.
+      BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dembrandt + Playwright
+        run: |
+          npm i -g dembrandt playwright
+          npx playwright install --with-deps chromium
+
+      - name: Drift gate
+        run: |
+          set +e   # handle each page's exit code; never abort the loop
+          mkdir -p reports
+          fail=0
+          {
+            echo "## Design drift: preview vs production"
+            echo ""
+            echo "| Page | Verdict | Score | Changed | Added | Removed |"
+            echo "|------|---------|------:|--------:|------:|--------:|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          HDR=()
+          [ -n "$BYPASS" ] && HDR=(--header "x-vercel-protection-bypass: ${BYPASS}")
+          # one entry per tracked page: "name:path"
+          for entry in "home:/" "pricing:/pricing" "app:/app"; do
+            name="${entry%%:*}"; path="${entry#*:}"
+            echo "-> $name ($path)"
+            if ! dembrandt "${PROD}${path}" --json-only > "reports/${name}.baseline.json"; then
+              echo "| \`${path}\` | prod extract failed | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
+              fail=1; continue
+            fi
+            dembrandt "${PREVIEW}${path}" "${HDR[@]}" \
+              --compare "reports/${name}.baseline.json" --html "reports/${name}.html" \
+              > "reports/${name}.log" 2>&1
+            code=$?
+            score=$(grep -oiE '(stable|drift) [0-9]+' "reports/${name}.log" | tail -1 | grep -oE '[0-9]+')
+            chg=$(grep -oE '[0-9]+ changed' "reports/${name}.log" | tail -1 | grep -oE '[0-9]+')
+            add=$(grep -oE '[0-9]+ added'   "reports/${name}.log" | tail -1 | grep -oE '[0-9]+')
+            rem=$(grep -oE '[0-9]+ removed' "reports/${name}.log" | tail -1 | grep -oE '[0-9]+')
+            case "$code" in
+              0) verdict="stable" ;;
+              1) verdict="DRIFT"; fail=1 ;;
+              *) verdict="FAILED ${code}"; fail=1 ;;
+            esac
+            echo "| \`${path}\` | ${verdict} | ${score:--} | ${chg:--} | ${add:--} | ${rem:--} |" >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Score is 0-100 (0 = identical); threshold is 10. Full HTML reports in the artifact below." >> "$GITHUB_STEP_SUMMARY"
+          exit $fail
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: drift-reports
+          path: reports/*.html
+          if-no-files-found: ignore

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -97,7 +97,7 @@ a:hover{color:var(--accent-hover);text-decoration:underline;text-underline-offse
 .ttl::after{content:"Light"}
 :root:has(#theme:checked) .ttl::after{content:"Dark"}
 .counts{text-align:center;color:var(--muted);font-size:var(--t-sm);margin:0;padding:14px 24px 0}
-.topbar .u{color:var(--muted);font-family:var(--mono);font-size:var(--t-sm);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.topbar .u{flex:1;min-width:0;color:var(--muted);font-family:var(--mono);font-size:var(--t-sm);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .topbar .meta{margin-left:auto;color:var(--muted);font-size:var(--t-sm);white-space:nowrap}
 .wrap{max-width:960px;margin:0 auto;padding:8px 24px 80px}
 .gauges{display:flex;flex-wrap:wrap;gap:34px;justify-content:center;padding:18px 0 28px;border-bottom:1px solid var(--line)}
@@ -431,7 +431,12 @@ function wcagSection(result: BrandingResult): string {
 function metaSection(result: BrandingResult): string {
   const fw = (result.frameworks ?? []).map((f) => f.name);
   const icons = (result.iconSystem ?? []).map((i) => i.name);
-  const bps = (result.breakpoints ?? []).map((b) => `${b.px}px`);
+  const bps = (result.breakpoints ?? []).map((b) => {
+    // b.px may be a bare number (360) or already a CSS length ("360px", "20rem").
+    // Only append the unit when it is a bare number, else we get "360pxpx".
+    const s = String(b.px).trim();
+    return /^\d+(\.\d+)?$/.test(s) ? `${s}px` : s;
+  });
   const items: string[] = [];
   if (fw.length) items.push(`<span><span class="muted">Frameworks:</span> ${esc(fw.join(", "))}</span>`);
   if (icons.length) items.push(`<span><span class="muted">Icons:</span> ${esc(icons.join(", "))}</span>`);


### PR DESCRIPTION
Two HTML-report bugs + the example workflow.

## Fixes
- **Breakpoints `360pxpx`**: `b.px` is typed `number | string`; the formatter blindly appended `px`, doubling it for string values. Now only bare numbers get the unit.
- **Topbar overflow on mobile (360-375px)**: the URL is a flex child with `text-overflow:ellipsis` but no `min-width:0`, so it refused to shrink and pushed the sticky bar past the viewport. Added `flex:1;min-width:0` so it truncates.

## Added
- `examples/drift-gate.yml` — copy-paste GitHub Actions drift gate: preview vs production, markdown run summary, HTML report artifact, and the Vercel/host auth bypass header. README links it.

Verified the report renders `360px, 370px, 375px` and the topbar truncates.