### PR TITLE
chore(release): 0.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dembrandt",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release shipping the HTML report fixes already on main (#88):
- breakpoint unit doubling (`360pxpx`)
- sticky topbar overflow on narrow viewports (360-375px)

No code change here beyond the version bump; build clean, 197 tests pass. After merge: tag `v0.19.2`, manual npm publish, GitHub release.