### PR TITLE
fix(deps): playwright-core a regular dep, full playwright optional (0.19.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Load extractions, track token drift, and compare snapshots. **[dembrandt.com/app
 
 ## Recipes
 
-**[dembrandt.com/recipes](https://www.dembrandt.com/recipes)** — 38 ready-to-run workflows. Copy a command, paste a prompt, get a result. Covers competitor benchmarking, WCAG audits, CI/CD drift detection, Figma token push, and agentic design system builds. Filterable by role.
+**[dembrandt.com/recipes](https://www.dembrandt.com/recipes)** — ready-to-run workflows. Copy a command, paste a prompt, get a result. Covers competitor benchmarking, WCAG audits, CI/CD drift detection, Figma token push, and agentic design system builds. Filterable by role.
 
 ## What to expect from extraction?
 
@@ -143,11 +143,23 @@ dembrandt example.com --browser=firefox --save-output --dtcg
 - WSL environments where headless Chromium may struggle
 
 **Installation:**
-Firefox browser is installed automatically with `npm install`. If you need to install manually:
+Browsers are installed on demand, not by `npm install` (dembrandt depends on the lean `playwright-core`, which carries no browser binaries). Fetch the engine you need, matched to the installed `playwright-core`:
 
 ```bash
+npm run install-browser   # chromium (default)
+# or a specific engine:
 npx playwright@$(node -p "require('playwright-core/package.json').version") install firefox
 ```
+
+### Connect to an existing browser (CDP)
+
+Skip the bundled browser entirely and drive an already-running Chromium over the DevTools Protocol. Useful in CI or containers where a browser is already up, and it needs no local browser download at all:
+
+```bash
+BROWSER_CDP_ENDPOINT=http://localhost:9222 dembrandt example.com --browser chromium
+```
+
+CDP is supported only with `--browser chromium`.
 
 ### W3C Design Tokens (DTCG) Format
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1,17 +1,19 @@
 /**
  * Lazy loader for the playwright-core browser engines.
  *
- * playwright is an optional peer dependency: consumers that use only the pure
- * exports (drift, types, normalize, dtcg) are not forced to install the
- * browser stack. Anything that actually drives a browser routes its import
- * through here, so a missing install surfaces a clear instruction instead of
- * a raw ERR_MODULE_NOT_FOUND at startup. Static `import` would fail at module
- * load, before any guard could run; dynamic `import()` defers it to use.
+ * playwright-core (the driver, ~10MB, no browser download) is a regular
+ * dependency, so the import resolves on a plain install without pulling the
+ * ~150MB browser binaries onto every consumer — library-only importers
+ * (drift, types, normalize, dtcg) and Vercel/CI installs stay lean. The actual
+ * browser binary is fetched on demand (`npx playwright install chromium` or
+ * `npm run install-browser`), so only callers that really extract pay for it.
+ * The import is still routed through here and guarded so a missing engine
+ * surfaces a clear instruction; dynamic `import()` defers resolution to use.
  */
 
 export class PlaywrightMissingError extends Error {
   constructor() {
-    super('playwright not installed, run: npm i playwright');
+    super('browser engine not available, run: npx playwright install chromium');
     this.name = 'PlaywrightMissingError';
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "dembrandt",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
-        "ora": "^7.0.1"
+        "ora": "^7.0.1",
+        "playwright-core": "^1.60.0"
       },
       "bin": {
         "dembrandt": "dist/index.js",
@@ -33,8 +34,7 @@
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "playwright": "^1.57.0",
-        "playwright-core": "1.60.0",
+        "playwright": "^1.60.0",
         "zod": "4.3.6"
       },
       "peerDependenciesMeta": {
@@ -42,9 +42,6 @@
           "optional": true
         },
         "playwright": {
-          "optional": true
-        },
-        "playwright-core": {
           "optional": true
         },
         "zod": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",
@@ -67,25 +67,22 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
-    "ora": "^7.0.1"
+    "ora": "^7.0.1",
+    "playwright-core": "^1.60.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "playwright": "^1.57.0",
-    "playwright-core": "1.60.0",
+    "playwright": "^1.60.0",
     "zod": "4.3.6"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {
       "optional": true
     },
-    "playwright": {
-      "optional": true
-    },
-    "playwright-core": {
-      "optional": true
-    },
     "zod": {
+      "optional": true
+    },
+    "playwright": {
       "optional": true
     }
   },


### PR DESCRIPTION
## Problem
`npm i -g dembrandt && dembrandt <url>` fails with `playwright not installed` — all heavy deps were optional peers, so nothing browser-related installs by default. The CLI's headline command is broken on first run.

## Why not just make `playwright` a dependency
Full `playwright`'s postinstall downloads ~150MB of browser binaries on **every** `npm install`, including Vercel deploys and consumers that import only `dembrandt/drift`. That re-creates the bloat DEM-74 avoided — bad for pipelines.

## Fix
- `playwright-core` (lean driver, ~10MB, **no** browser postinstall) → regular `dependency`, so the import resolves cheaply everywhere.
- Full `playwright` → stays an optional peer.
- Browser binary stays on-demand (`npx playwright install chromium`), so only actual extractors download it.

Net: lean installs for libraries/Vercel/CI; CLI import works; browser is opt-in per the existing install-browser flow.

Verified: `npm install` pulls no browsers, 197 tests pass, build clean. 0.19.3.