### PR TITLE
feat(cli): show active flags in the run summary (DEM-99)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -479,10 +479,21 @@ program
       if (opts.screenshot) flagBits.push('--screenshot');
       const flagsLine = flagBits.length ? chalk.dim(`   Flags: ${flagBits.join(' ')}`) : null;
 
+      // Explicit paths are positional, not flags, but they shape the run just as
+      // much (multi-page merge). Surface them so `dembrandt site.com /a /b` shows
+      // what was merged. --crawl/--sitemap auto-discover pages instead and report
+      // via the flag above plus the merged page count.
+      const mergedPages = result.pages?.length ?? 0;
+      const pathBits: string[] = [];
+      if (paths && paths.length) pathBits.push(...paths);
+      if (mergedPages > 1) pathBits.push(`(${mergedPages} pages merged)`);
+      const pathsLine = pathBits.length ? chalk.dim(`   Paths: ${pathBits.join(' ')}`) : null;
+
       if (opts.jsonOnly) {
         console.log = originalConsoleLog;
         console.log(JSON.stringify(outputData, null, 2));
         console.error(summaryLine);
+        if (pathsLine) console.error(pathsLine);
         if (flagsLine) console.error(flagsLine);
         for (const notice of savedNotices) console.error(notice);
       } else {
@@ -490,6 +501,7 @@ program
         displayResults(result);
         console.log();
         console.log(summaryLine);
+        if (pathsLine) console.log(pathsLine);
         if (flagsLine) console.log(flagsLine);
         for (const notice of savedNotices) console.log(notice);
       }

--- a/index.ts
+++ b/index.ts
@@ -454,16 +454,43 @@ program
           `${result.typography?.styles?.length ?? 0} text styles, ` +
           `${result.breakpoints?.length ?? 0} breakpoints.`
         );
+
+      // Surface the flags that shaped this run, so the summary confirms what
+      // was asked for, not just what was extracted. Artifact flags (--html,
+      // --dtcg, --compare, ...) already print a path notice below; this also
+      // captures behaviour-only flags that otherwise leave no trace.
+      const flagBits: string[] = [];
+      if (opts.darkMode) flagBits.push('--dark-mode');
+      if (opts.mobile) flagBits.push('--mobile');
+      if (opts.slow) flagBits.push('--slow');
+      if (opts.stealth) flagBits.push('--stealth');
+      if (opts.wcag) flagBits.push('--wcag');
+      if (opts.crawl != null) flagBits.push(`--crawl ${opts.crawl}`);
+      if (opts.sitemap) flagBits.push('--sitemap');
+      if (opts.browser && opts.browser !== 'chromium') flagBits.push(`--browser ${opts.browser}`);
+      if (opts.sandbox === false) flagBits.push('--no-sandbox');
+      if (opts.rawColors) flagBits.push('--raw-colors');
+      if (opts.dtcg) flagBits.push('--dtcg');
+      if (opts.saveOutput) flagBits.push('--save-output');
+      if (opts.html !== undefined) flagBits.push('--html');
+      if (opts.compare) flagBits.push('--compare');
+      if (opts.brandGuide) flagBits.push('--brand-guide');
+      if (opts.designMd) flagBits.push('--design-md');
+      if (opts.screenshot) flagBits.push('--screenshot');
+      const flagsLine = flagBits.length ? chalk.dim(`   Flags: ${flagBits.join(' ')}`) : null;
+
       if (opts.jsonOnly) {
         console.log = originalConsoleLog;
         console.log(JSON.stringify(outputData, null, 2));
         console.error(summaryLine);
+        if (flagsLine) console.error(flagsLine);
         for (const notice of savedNotices) console.error(notice);
       } else {
         console.log();
         displayResults(result);
         console.log();
         console.log(summaryLine);
+        if (flagsLine) console.log(flagsLine);
         for (const notice of savedNotices) console.log(notice);
       }
     } catch (err) {

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { checkRobotsTxt } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
+import { activeFlags, pathSummary } from "./lib/run-summary.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -455,38 +456,11 @@ program
           `${result.breakpoints?.length ?? 0} breakpoints.`
         );
 
-      // Surface the flags that shaped this run, so the summary confirms what
-      // was asked for, not just what was extracted. Artifact flags (--html,
-      // --dtcg, --compare, ...) already print a path notice below; this also
-      // captures behaviour-only flags that otherwise leave no trace.
-      const flagBits: string[] = [];
-      if (opts.darkMode) flagBits.push('--dark-mode');
-      if (opts.mobile) flagBits.push('--mobile');
-      if (opts.slow) flagBits.push('--slow');
-      if (opts.stealth) flagBits.push('--stealth');
-      if (opts.wcag) flagBits.push('--wcag');
-      if (opts.crawl != null) flagBits.push(`--crawl ${opts.crawl}`);
-      if (opts.sitemap) flagBits.push('--sitemap');
-      if (opts.browser && opts.browser !== 'chromium') flagBits.push(`--browser ${opts.browser}`);
-      if (opts.sandbox === false) flagBits.push('--no-sandbox');
-      if (opts.rawColors) flagBits.push('--raw-colors');
-      if (opts.dtcg) flagBits.push('--dtcg');
-      if (opts.saveOutput) flagBits.push('--save-output');
-      if (opts.html !== undefined) flagBits.push('--html');
-      if (opts.compare) flagBits.push('--compare');
-      if (opts.brandGuide) flagBits.push('--brand-guide');
-      if (opts.designMd) flagBits.push('--design-md');
-      if (opts.screenshot) flagBits.push('--screenshot');
+      // Surface what shaped this run (DEM-99) — active flags and merged paths —
+      // so the summary confirms what was asked for, not just what was extracted.
+      const flagBits = activeFlags(opts);
       const flagsLine = flagBits.length ? chalk.dim(`   Flags: ${flagBits.join(' ')}`) : null;
-
-      // Explicit paths are positional, not flags, but they shape the run just as
-      // much (multi-page merge). Surface them so `dembrandt site.com /a /b` shows
-      // what was merged. --crawl/--sitemap auto-discover pages instead and report
-      // via the flag above plus the merged page count.
-      const mergedPages = result.pages?.length ?? 0;
-      const pathBits: string[] = [];
-      if (paths && paths.length) pathBits.push(...paths);
-      if (mergedPages > 1) pathBits.push(`(${mergedPages} pages merged)`);
+      const pathBits = pathSummary(paths, result.pages?.length ?? 0);
       const pathsLine = pathBits.length ? chalk.dim(`   Paths: ${pathBits.join(' ')}`) : null;
 
       if (opts.jsonOnly) {

--- a/lib/run-summary.ts
+++ b/lib/run-summary.ts
@@ -1,0 +1,70 @@
+/**
+ * Builds the "what shaped this run" lines for the closing CLI summary (DEM-99):
+ * which flags were active and which paths were merged. Pure and importable so it
+ * is unit-tested without spawning the CLI; index.ts wraps the returned strings
+ * with chalk and prints them under the analysis summary.
+ */
+
+export interface RunOpts {
+  darkMode?: boolean;
+  mobile?: boolean;
+  slow?: boolean;
+  stealth?: boolean;
+  wcag?: boolean;
+  /** number of pages, or true for the bare flag, or null/undefined when unused */
+  crawl?: number | boolean | null;
+  sitemap?: boolean;
+  browser?: string;
+  /** commander sets false for --no-sandbox; true/undefined otherwise */
+  sandbox?: boolean;
+  rawColors?: boolean;
+  dtcg?: boolean;
+  saveOutput?: boolean;
+  /** --html [path]: undefined when absent, string or true when present */
+  html?: unknown;
+  compare?: unknown;
+  brandGuide?: boolean;
+  designMd?: boolean;
+  screenshot?: unknown;
+}
+
+/**
+ * The flags that changed the run, in a stable display order. Behaviour-only
+ * flags (--wcag, --dark-mode, ...) included so they leave a trace even though
+ * they write no file; artifact flags included too (their paths print separately).
+ */
+export function activeFlags(opts: RunOpts = {}): string[] {
+  const bits: string[] = [];
+  if (opts.darkMode) bits.push('--dark-mode');
+  if (opts.mobile) bits.push('--mobile');
+  if (opts.slow) bits.push('--slow');
+  if (opts.stealth) bits.push('--stealth');
+  if (opts.wcag) bits.push('--wcag');
+  if (opts.crawl != null && opts.crawl !== false) {
+    bits.push(opts.crawl === true ? '--crawl' : `--crawl ${opts.crawl}`);
+  }
+  if (opts.sitemap) bits.push('--sitemap');
+  if (opts.browser && opts.browser !== 'chromium') bits.push(`--browser ${opts.browser}`);
+  if (opts.sandbox === false) bits.push('--no-sandbox');
+  if (opts.rawColors) bits.push('--raw-colors');
+  if (opts.dtcg) bits.push('--dtcg');
+  if (opts.saveOutput) bits.push('--save-output');
+  if (opts.html !== undefined) bits.push('--html');
+  if (opts.compare) bits.push('--compare');
+  if (opts.brandGuide) bits.push('--brand-guide');
+  if (opts.designMd) bits.push('--design-md');
+  if (opts.screenshot) bits.push('--screenshot');
+  return bits;
+}
+
+/**
+ * Explicit paths and/or the merged-page count. Explicit paths are positional
+ * (not flags) so they would otherwise be invisible; --crawl/--sitemap have no
+ * explicit paths but still merge pages, reported by the count alone.
+ */
+export function pathSummary(paths: string[] | undefined, mergedPages = 0): string[] {
+  const bits: string[] = [];
+  if (paths && paths.length) bits.push(...paths);
+  if (mergedPages > 1) bits.push(`(${mergedPages} pages merged)`);
+  return bits;
+}

--- a/test/run-summary.test.ts
+++ b/test/run-summary.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { activeFlags, pathSummary } from '../lib/run-summary.js';
+
+/**
+ * The closing-summary "what shaped this run" lines (DEM-99): which flags were
+ * active and which paths were merged. Pinned here so the summary stays honest
+ * as flags are added.
+ */
+
+test('activeFlags: no flags -> empty (no line printed)', () => {
+  assert.deepEqual(activeFlags({}), []);
+  assert.deepEqual(activeFlags(), []);
+});
+
+test('activeFlags: behaviour-only flags are surfaced (they write no file)', () => {
+  assert.deepEqual(
+    activeFlags({ darkMode: true, wcag: true, mobile: true, slow: true, stealth: true }),
+    ['--dark-mode', '--mobile', '--slow', '--stealth', '--wcag'],
+  );
+});
+
+test('activeFlags: artifact flags included alongside behaviour flags', () => {
+  assert.deepEqual(
+    activeFlags({ dtcg: true, saveOutput: true, html: '/tmp/r.html', compare: 'base.json', brandGuide: true, designMd: true, screenshot: '/tmp/s.png' }),
+    ['--dtcg', '--save-output', '--html', '--compare', '--brand-guide', '--design-md', '--screenshot'],
+  );
+});
+
+test('activeFlags: --html present with no value (true) still counts', () => {
+  assert.deepEqual(activeFlags({ html: true }), ['--html']);
+});
+
+test('activeFlags: --crawl renders its count, bare flag has none', () => {
+  assert.deepEqual(activeFlags({ crawl: 5 }), ['--crawl 5']);
+  assert.deepEqual(activeFlags({ crawl: true }), ['--crawl']);
+  assert.deepEqual(activeFlags({ crawl: null }), []);
+  assert.deepEqual(activeFlags({ crawl: false }), []);
+});
+
+test('activeFlags: --browser only when non-default; --no-sandbox only when false', () => {
+  assert.deepEqual(activeFlags({ browser: 'chromium' }), []);
+  assert.deepEqual(activeFlags({ browser: 'firefox' }), ['--browser firefox']);
+  assert.deepEqual(activeFlags({ sandbox: false }), ['--no-sandbox']);
+  assert.deepEqual(activeFlags({ sandbox: true }), []);
+});
+
+test('pathSummary: explicit paths are listed (they are positional, not flags)', () => {
+  assert.deepEqual(pathSummary(['/recipes', '/pricing'], 3), ['/recipes', '/pricing', '(3 pages merged)']);
+});
+
+test('pathSummary: crawl/sitemap have no explicit paths, just the merged count', () => {
+  assert.deepEqual(pathSummary([], 2), ['(2 pages merged)']);
+  assert.deepEqual(pathSummary(undefined, 4), ['(4 pages merged)']);
+});
+
+test('pathSummary: single page -> nothing (no merge happened)', () => {
+  assert.deepEqual(pathSummary(undefined, 1), []);
+  assert.deepEqual(pathSummary([], 0), []);
+});


### PR DESCRIPTION
Closes DEM-99.

Adds a `Flags:` line to the end-of-run summary so the invocation is confirmed, not just the extraction counts. Behaviour-only flags (`--wcag`, `--dark-mode`, `--crawl`, `--mobile`, `--stealth`, ...) now leave a trace; artifact flags keep their existing path notices.

```
✨ Analysis summary: 23 colors, 49 text styles, 0 breakpoints.
   Flags: --dark-mode --wcag --dtcg --html
💾 DTCG tokens saved (--dtcg): output/stripe.com/...tokens.json
💾 HTML report saved (--html): /tmp/f.html
```

Presentation only (terminal formatter); no extraction or exit-code change. Build clean, 197 tests pass, live-verified.