### PR TITLE
fix(extract): deterministic self-hosted font ordering

### DIFF
--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1172,6 +1172,13 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
       }
     }
 
+    // Self-hosted font files, deduped and sorted. fontRequests is a Set filled
+    // in network-arrival order, which varies run-to-run; sorting keeps the
+    // extraction deterministic so the drift gate doesn't report phantom changes.
+    const fontFiles = [...new Set(
+      [...fontRequests].map(u => u.split('/').pop().split('?')[0])
+    )].sort();
+
     const result: any = {
       url: page.url(),
       extractedAt: new Date().toISOString(),
@@ -1200,10 +1207,12 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
         ...typography,
         sources: {
           ...typography.sources,
-          selfHostedFonts: [...fontRequests].map(u => u.split('/').pop().split('?')[0]),
+          // Sort: fontRequests is filled in network-arrival order, which differs
+          // run-to-run and otherwise surfaces as phantom drift.
+          selfHostedFonts: fontFiles,
           customFonts: typography.sources?.customFonts?.length
-            ? typography.sources.customFonts
-            : fontRequests.size > 0 ? [...fontRequests].map(u => u.split('/').pop().split('?')[0]) : [],
+            ? [...typography.sources.customFonts].sort()
+            : fontFiles,
         }
       },
       spacing,


### PR DESCRIPTION
## Problem
Two extractions of the same page differed only in font order, which the drift comparator counts as real change — phantom drift. Root cause: `fontRequests` is a `Set` filled by the network `response` handler in arrival order, spread straight into `selfHostedFonts`/`customFonts`.

## Fix
Dedupe and sort both font arrays before output.

## Verification
- 3 back-to-back extractions of the same URL now byte-identical (minus `extractedAt`)
- 206/206 tests pass

Surfaced while dogfooding the drift gate on dembrandt-next: `home` reported drift 17 on an empty (no-op) preview.