### PR TITLE
feat(cli): emit drift report in --json-only output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -456,7 +456,12 @@ program
         );
       if (opts.jsonOnly) {
         console.log = originalConsoleLog;
-        console.log(JSON.stringify(outputData, null, 2));
+        // Attach the drift report to the JSON stream (only here, so --save-output
+        // and baseline files stay pure extractions). Lets consumers — e.g. a CI
+        // gate posting a PR comment — read the per-token changes machine-readably
+        // instead of scraping the HTML report.
+        const jsonOut = driftReport ? { ...outputData, drift: driftReport } : outputData;
+        console.log(JSON.stringify(jsonOut, null, 2));
         console.error(summaryLine);
         for (const notice of savedNotices) console.error(notice);
       } else {


### PR DESCRIPTION
## What
With `--compare <baseline> --json-only`, attach the full `DriftReport` under a `drift` key in the JSON stream: `score`, `status`, `summary`, and per-token `changes[]` (`kind`, `category`, `label`, `before`, `after`, `delta`).

## Why
The per-token diff already exists internally but was only summarised to one line or rendered into HTML. Consumers (e.g. the dembrandt-next drift gate posting a PR comment) had no machine-readable way to show *what* drifted. Now they can `jq .drift.changes`.

## Scope
- Only the `--json-only` stream carries `drift`. `--save-output` and baseline files stay pure extractions (verified).
- No `drift` key without `--compare`.

## Verified
- `changes[]` populated for changed/added/removed
- baseline (no --compare) has no drift key
- 206/206 tests pass