### PR TITLE
fix(drift): ignore low-confidence tokens in drift comparison

### DIFF
--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -10,7 +10,7 @@
  * to compare against. Two-baseline workflows just call this twice.
  */
 
-import type { BrandingResult as ExtractionResult, TypographyStyle } from "./types.js";
+import type { BrandingResult as ExtractionResult, TypographyStyle, Confidence } from "./types.js";
 
 export interface DriftConfig {
   /** ΔE at or below this: colors treated as identical. */
@@ -399,6 +399,14 @@ function isSupportedShadow(s: string): boolean {
   return Boolean(s) && !s.includes("oklab(") && !s.includes("oklch(") && !s.includes("color(");
 }
 
+/** Low-confidence tokens are single-use, margin-of-detection elements the
+ * extractor itself is unsure about. They surface inconsistently between two
+ * extractions of the same design, so counting them produces phantom drift.
+ * Only compare tokens the extractor is reasonably sure are real. */
+function notLowConfidence(t: { confidence?: Confidence }): boolean {
+  return t.confidence !== "low";
+}
+
 export function computeDrift(
   baseline: ExtractionResult,
   candidate: ExtractionResult,
@@ -424,16 +432,16 @@ export function computeDrift(
     {
       ...compareDimensions(
         "radius",
-        (baseline.borderRadius?.values ?? []).map((r) => r.value).filter(isRealisticDimension),
-        (candidate.borderRadius?.values ?? []).map((r) => r.value).filter(isRealisticDimension),
+        (baseline.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension),
+        (candidate.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension),
         cfg
       ),
       w: cfg.weights.radius,
     },
     {
       ...compareShadows(
-        (baseline.shadows ?? []).map((s) => s.shadow).filter(isSupportedShadow),
-        (candidate.shadows ?? []).map((s) => s.shadow).filter(isSupportedShadow)
+        (baseline.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow),
+        (candidate.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow)
       ),
       w: cfg.weights.shadow,
     },

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeDrift } from '../lib/drift.js';
+
+/**
+ * Low-confidence tokens are single-use, margin-of-detection elements the
+ * extractor is unsure about; they surface inconsistently between two
+ * extractions of the same design. computeDrift must ignore them so they never
+ * produce phantom drift.
+ */
+
+function fixture(overrides: any = {}): any {
+  return {
+    url: 'https://example.com/',
+    extractedAt: 't',
+    colors: { palette: [{ normalized: '#133174', count: 40, confidence: 'high' }], semantic: { primary: '#133174' }, cssVariables: {} },
+    typography: { styles: [], sources: {} },
+    spacing: { scaleType: 'base-8', commonValues: [] },
+    borderRadius: { values: [] },
+    borders: {}, shadows: [],
+    components: { buttons: [], inputs: [], links: [], badges: [] },
+    breakpoints: [], iconSystem: [], frameworks: [],
+    ...overrides,
+  };
+}
+
+test('a low-confidence shadow present in one extraction but not the other is not drift', () => {
+  const withShadow = fixture({
+    shadows: [{ shadow: 'rgb(128, 128, 128) 0px 0px 5px 0px', count: 1, confidence: 'low' }],
+  });
+  const without = fixture({ shadows: [] });
+
+  const report = computeDrift(withShadow, without);
+  assert.equal(report.status, 'stable');
+  assert.equal(report.summary.removed, 0);
+  assert.equal(report.changes.filter((c) => c.category === 'shadow').length, 0);
+});
+
+test('a low-confidence radius present in one extraction but not the other is not drift', () => {
+  const withRadius = fixture({
+    borderRadius: { values: [{ value: '2px', count: 1, confidence: 'low' }] },
+  });
+  const without = fixture({ borderRadius: { values: [] } });
+
+  const report = computeDrift(withRadius, without);
+  assert.equal(report.status, 'stable');
+  assert.equal(report.changes.filter((c) => c.category === 'radius').length, 0);
+});
+
+test('a high-confidence radius change is still real drift', () => {
+  const base = fixture({
+    borderRadius: { values: [{ value: '4px', count: 20, confidence: 'high' }] },
+  });
+  const changed = fixture({
+    borderRadius: { values: [{ value: '12px', count: 20, confidence: 'high' }] },
+  });
+
+  const report = computeDrift(base, changed);
+  assert.ok(report.changes.some((c) => c.category === 'radius'), 'high-confidence radius change must be reported');
+});


### PR DESCRIPTION
## Problem
The design-drift gate reported phantom drift on `home` even on an unchanged preview: a `count:1, confidence:'low'` shadow (`rgb(128,128,128) 0 0 5px`) and a `count:1, confidence:'low'` `2px` badge radius were captured in production but not the preview deployment (margin-of-detection elements).

## Fix
`computeDrift` now drops `confidence:'low'` radius and shadow tokens before comparison. They are single-use elements the extractor itself is unsure about, so counting them produces noise, not signal.

## Verified
- low-confidence shadow/radius present on one side only → **stable** (was drift)
- high-confidence radius change → still reported (guard test)
- 209/209 tests pass (3 new)

Found while dogfooding the gate on dembrandt-next (the residual `home` flake after the 0.19.4 font-ordering fix).