### PR TITLE
docs: drop hardcoded MCP tool count from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Or add to your project's `.mcp.json`:
 }
 ```
 
-7 tools available: `get_design_tokens`, `get_color_palette`, `get_typography`, `get_component_styles`, `get_surfaces`, `get_spacing`, `get_brand_identity`.
+Available tools include `get_design_tokens`, `get_color_palette`, `get_typography`, `get_component_styles`, `get_surfaces`, `get_spacing`, and `get_brand_identity`, plus drift, report, and job-control tools.
 
 Pair with **[dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** to give your agent UX intelligence on top of extracted tokens — hierarchy, accessibility, interaction states, and a full 6-stage design pipeline orchestrator.
 


### PR DESCRIPTION
README claimed '7 tools available' and listed 7, but the MCP server exposes 11 (the drift/report/job tools were omitted). Both the count and an exhaustive list go stale whenever a tool is added. Reworded to describe the toolset without pinning a number.

Matches the same cleanup in dembrandt-next (mcp + getting-started pages).