### PR TITLE
fix(sync): bump package-lock.json with package.json in sync-next

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -79,6 +79,10 @@ jobs:
           cd dembrandt-next
           VERSION="${DEMBRANDT_VERSION#v}"
           npm pkg set dependencies.dembrandt="${VERSION}"
+          # Keep package-lock.json in sync with package.json. Without this the
+          # lock still pins the old version and `npm ci` (CI, the drift gate)
+          # fails before anyone can run `npm install`.
+          npm install --package-lock-only
           # schema.org softwareVersion always tracks the CLI version (deterministic)
           sed -i "s/\"softwareVersion\": \"[0-9][0-9.]*\"/\"softwareVersion\": \"${VERSION}\"/" app/layout.tsx
 
@@ -93,7 +97,7 @@ jobs:
           body: |
             Automated bump triggered by [dembrandt ${{ github.event.release.tag_name || github.event.inputs.tag }}](${{ github.event.release.html_url || 'manual trigger' }}).
 
-            Updates `dembrandt` npm dependency to latest release and bumps `app/layout.tsx` schema.org `softwareVersion`. Run `npm install` after merging.
+            Updates `dembrandt` npm dependency to latest release (package.json + package-lock.json) and bumps `app/layout.tsx` schema.org `softwareVersion`.
 
             **⚠ Manual check required before merging**
             This automation bumps the npm version in `package.json` and the schema.org `softwareVersion`. If this release added or changed CLI flags, update these manually before merging:


### PR DESCRIPTION
## Problem
The `sync-next` job bumps `package.json` (`npm pkg set dependencies.dembrandt`) but never updates `package-lock.json`. Every automated bump PR (0.19.4, 0.19.5, ...) landed an out-of-sync lock, so `npm ci` — which the drift gate runs — failed with *"lock file's dembrandt@X does not satisfy dembrandt@Y"* until someone regenerated the lock by hand.

## Fix
Add `npm install --package-lock-only` right after the version bump, so the lock is updated in the same step. Also drop the now-stale "Run npm install after merging" note from the PR body.

dembrandt-skills is unaffected (it bumps its own version + edits SKILL.md text; it doesn't pin dembrandt as a dependency).