### PR TITLE
Core hardening and internal refinements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,9 +13,12 @@ export default tseslint.config(
       // no-undef double-checks against a globals list it doesn't have and only
       // produces false positives (process, console, document, ...). Off for TS.
       'no-undef': 'off',
-      // `any` is used deliberately at the page.evaluate / DOM boundary and in the
-      // ported validator's JSON traversal; tsc + noUnusedLocals already gate the rest.
-      '@typescript-eslint/no-explicit-any': 'off',
+      // `any` is legitimate at the page.evaluate / DOM boundary and the ingest
+      // canonicalization layer (normalize.ts), but data-model and helper any is
+      // slop. 'warn' (not 'off') so every new explicit any is visible in the
+      // editor/CI and the count ratchets down, without failing the build on the
+      // remaining browser-context/boundary uses.
+      '@typescript-eslint/no-explicit-any': 'warn',
       // tsc's noUnusedLocals/noUnusedParameters already covers this with `_` opt-out.
       '@typescript-eslint/no-unused-vars': 'off',
       // try{}catch{} that intentionally swallow (best-effort extraction) are idiomatic here.

--- a/lib/exit-codes.ts
+++ b/lib/exit-codes.ts
@@ -21,8 +21,8 @@ export type ErrorCode = "NAVIGATION_TIMEOUT" | "EXTRACTION_FAILED";
  * is a generic RUNTIME failure. Reads only `err.message`, so a bare string or a
  * malformed error never throws.
  */
-export function classifyError(err: any): { code: ErrorCode; exit: number } {
-  const m = String(err?.message ?? "");
+export function classifyError(err: unknown): { code: ErrorCode; exit: number } {
+  const m = String((err as { message?: unknown })?.message ?? "");
   if (/Timeout|net::ERR_|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ERR_NAME_NOT_RESOLVED/i.test(m)) {
     return { code: "NAVIGATION_TIMEOUT", exit: EXIT.TIMEOUT };
   }

--- a/lib/extractors/context-config.ts
+++ b/lib/extractors/context-config.ts
@@ -3,21 +3,43 @@
  * size, locale) into Playwright context configuration. Split out of the
  * extraction orchestrator so the untrusted-input surface is unit-testable and
  * malformed input degrades to safe defaults instead of producing broken values.
+ *
+ * Written strict-clean (no implicit any, no null leaks) per the per-module
+ * strict ratchet, even though the global tsconfig is strict:false.
  */
 import type { ExtractOptions } from '../types.js';
 
 export interface ParsedCookie {
-  name: string;
-  value: string;
-  url: string;
+  readonly name: string;
+  readonly value: string;
+  readonly url: string;
 }
 
 export interface ScreenSize {
-  width: number;
-  height: number;
+  readonly width: number;
+  readonly height: number;
 }
 
-export const DEFAULT_SCREEN: ScreenSize = { width: 1920, height: 1080 };
+export type ColorScheme = 'light' | 'dark' | 'no-preference';
+
+/**
+ * The subset of Playwright's BrowserContextOptions that we set. Declared
+ * explicitly (rather than `Record<string, any>`) so the config the extraction
+ * engine depends on is type-checked at the one call site where `browser` is an
+ * untyped handle.
+ */
+export interface ContextOptions {
+  viewport: ScreenSize;
+  screen: ScreenSize;
+  userAgent: string;
+  locale: string;
+  timezoneId: string;
+  extraHTTPHeaders: Record<string, string>;
+  colorScheme: ColorScheme;
+  permissions?: string[];
+}
+
+export const DEFAULT_SCREEN: ScreenSize = Object.freeze({ width: 1920, height: 1080 });
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_TIMEZONE = 'America/New_York';
 export const DEFAULT_USER_AGENT =
@@ -35,7 +57,7 @@ export function parseCookies(cookie: string | undefined, url: string): ParsedCoo
     const c = raw.trim();
     if (!c) continue;
     const eq = c.indexOf('=');
-    if (eq < 1) continue; // no "=", or "=value" with empty name
+    if (eq < 1) continue; // no "=", or "=value" with an empty name
     out.push({ name: c.slice(0, eq).trim(), value: c.slice(eq + 1).trim(), url });
   }
   return out;
@@ -57,16 +79,17 @@ export function parseHeader(header: string | undefined): Record<string, string> 
 /**
  * Parse a "WIDTHxHEIGHT" screen size. Falls back to the default when either
  * dimension is missing, non-numeric, or non-positive, so a typo never produces
- * a NaN viewport that silently breaks layout-dependent extraction.
+ * a NaN viewport that silently breaks layout-dependent extraction. Returns a
+ * fresh object so callers can never mutate the shared default.
  */
 export function parseScreenSize(screenSize: string | undefined): ScreenSize {
-  if (!screenSize) return { ...DEFAULT_SCREEN };
+  if (!screenSize) return { width: DEFAULT_SCREEN.width, height: DEFAULT_SCREEN.height };
   const parts = screenSize.split('x');
-  if (parts.length !== 2) return { ...DEFAULT_SCREEN };
+  if (parts.length !== 2) return { width: DEFAULT_SCREEN.width, height: DEFAULT_SCREEN.height };
   const width = Number(parts[0]);
   const height = Number(parts[1]);
   if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-    return { ...DEFAULT_SCREEN };
+    return { width: DEFAULT_SCREEN.width, height: DEFAULT_SCREEN.height };
   }
   return { width: Math.round(width), height: Math.round(height) };
 }
@@ -84,25 +107,24 @@ export function deriveAcceptLanguage(locale: string, explicit?: string): string 
 
 /**
  * Build the Playwright context options from CLI options. Pure: no browser
- * access. Cookies and init scripts are applied separately by the caller because
- * they are side effects on a live context.
+ * access, no mutation of the input. Cookies and init scripts are applied
+ * separately by the caller because they are side effects on a live context.
  */
-export function buildContextOptions(options: ExtractOptions, browserName: string): Record<string, any> {
+export function buildContextOptions(options: ExtractOptions, browserName: string): ContextOptions {
   const locale = options.locale || DEFAULT_LOCALE;
-  const timezoneId = options.timezoneId || DEFAULT_TIMEZONE;
-  const { width, height } = parseScreenSize(options.screenSize);
-  const extraHeaders: Record<string, string> = {
+  const size = parseScreenSize(options.screenSize);
+  const extraHTTPHeaders: Record<string, string> = {
     'Accept-Language': deriveAcceptLanguage(locale, options.acceptLanguage),
     ...parseHeader(options.header),
   };
 
-  const contextOptions: Record<string, any> = {
-    viewport: { width, height },
-    screen: { width, height },
+  const contextOptions: ContextOptions = {
+    viewport: { width: size.width, height: size.height },
+    screen: { width: size.width, height: size.height },
     userAgent: options.userAgent || DEFAULT_USER_AGENT,
     locale,
-    timezoneId,
-    extraHTTPHeaders: extraHeaders,
+    timezoneId: options.timezoneId || DEFAULT_TIMEZONE,
+    extraHTTPHeaders,
     colorScheme: 'light',
   };
 

--- a/lib/extractors/context-config.ts
+++ b/lib/extractors/context-config.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure parsing of CLI-supplied browser-context inputs (cookies, headers, screen
+ * size, locale) into Playwright context configuration. Split out of the
+ * extraction orchestrator so the untrusted-input surface is unit-testable and
+ * malformed input degrades to safe defaults instead of producing broken values.
+ */
+import type { ExtractOptions } from '../types.js';
+
+export interface ParsedCookie {
+  name: string;
+  value: string;
+  url: string;
+}
+
+export interface ScreenSize {
+  width: number;
+  height: number;
+}
+
+export const DEFAULT_SCREEN: ScreenSize = { width: 1920, height: 1080 };
+export const DEFAULT_LOCALE = 'en-US';
+export const DEFAULT_TIMEZONE = 'America/New_York';
+export const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+/**
+ * Parse a "Name=value; Name2=value2" cookie string. Pairs without an "=" are
+ * skipped rather than emitted with a truncated name and the whole token as the
+ * value (the previous behavior). Empty names are also dropped.
+ */
+export function parseCookies(cookie: string | undefined, url: string): ParsedCookie[] {
+  if (!cookie) return [];
+  const out: ParsedCookie[] = [];
+  for (const raw of cookie.split(';')) {
+    const c = raw.trim();
+    if (!c) continue;
+    const eq = c.indexOf('=');
+    if (eq < 1) continue; // no "=", or "=value" with empty name
+    out.push({ name: c.slice(0, eq).trim(), value: c.slice(eq + 1).trim(), url });
+  }
+  return out;
+}
+
+/**
+ * Parse a single "Name: value" header. Returns {} when absent or when no colon
+ * is present (an invalid header is ignored rather than guessed at).
+ */
+export function parseHeader(header: string | undefined): Record<string, string> {
+  if (!header) return {};
+  const colon = header.indexOf(':');
+  if (colon < 1) return {};
+  const name = header.slice(0, colon).trim();
+  if (!name) return {};
+  return { [name]: header.slice(colon + 1).trim() };
+}
+
+/**
+ * Parse a "WIDTHxHEIGHT" screen size. Falls back to the default when either
+ * dimension is missing, non-numeric, or non-positive, so a typo never produces
+ * a NaN viewport that silently breaks layout-dependent extraction.
+ */
+export function parseScreenSize(screenSize: string | undefined): ScreenSize {
+  if (!screenSize) return { ...DEFAULT_SCREEN };
+  const parts = screenSize.split('x');
+  if (parts.length !== 2) return { ...DEFAULT_SCREEN };
+  const width = Number(parts[0]);
+  const height = Number(parts[1]);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { ...DEFAULT_SCREEN };
+  }
+  return { width: Math.round(width), height: Math.round(height) };
+}
+
+/**
+ * Derive the Accept-Language header. An explicit value wins; otherwise it is
+ * built from the locale, weighting the locale and its base language ahead of
+ * English.
+ */
+export function deriveAcceptLanguage(locale: string, explicit?: string): string {
+  if (explicit) return explicit;
+  const base = locale.split('-')[0];
+  return `${locale},${base};q=0.9,en;q=0.8`;
+}
+
+/**
+ * Build the Playwright context options from CLI options. Pure: no browser
+ * access. Cookies and init scripts are applied separately by the caller because
+ * they are side effects on a live context.
+ */
+export function buildContextOptions(options: ExtractOptions, browserName: string): Record<string, any> {
+  const locale = options.locale || DEFAULT_LOCALE;
+  const timezoneId = options.timezoneId || DEFAULT_TIMEZONE;
+  const { width, height } = parseScreenSize(options.screenSize);
+  const extraHeaders: Record<string, string> = {
+    'Accept-Language': deriveAcceptLanguage(locale, options.acceptLanguage),
+    ...parseHeader(options.header),
+  };
+
+  const contextOptions: Record<string, any> = {
+    viewport: { width, height },
+    screen: { width, height },
+    userAgent: options.userAgent || DEFAULT_USER_AGENT,
+    locale,
+    timezoneId,
+    extraHTTPHeaders: extraHeaders,
+    colorScheme: 'light',
+  };
+
+  if (browserName === 'chromium') {
+    contextOptions.permissions = ['clipboard-read', 'clipboard-write'];
+  }
+
+  return contextOptions;
+}

--- a/lib/extractors/guard.ts
+++ b/lib/extractors/guard.ts
@@ -1,0 +1,22 @@
+/**
+ * Fault isolation for the parallel extractors. Each extractor runs inside
+ * guardExtractor so a single throw degrades only its own category — recording
+ * { stage, reason } and returning a fallback — instead of rejecting Promise.all
+ * and aborting the entire run. Kept in its own module so the isolation contract
+ * is unit-testable without a browser.
+ */
+import type { ExtractorError } from '../types.js';
+
+export async function guardExtractor<T>(
+  stage: string,
+  run: Promise<T>,
+  fallback: T,
+  sink: ExtractorError[],
+): Promise<T> {
+  try {
+    return await run;
+  } catch (err) {
+    sink.push({ stage, reason: err instanceof Error ? err.message : String(err) });
+    return fallback;
+  }
+}

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -13,7 +13,7 @@ import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import { guardExtractor } from './guard.js';
 import type { Browser, Page } from 'playwright';
-import type { ExtractOptions, BrandingResult, Spinner, ExtractorError } from '../types.js';
+import type { ExtractOptions, BrandingResult, Spinner, ExtractorError, WcagPair } from '../types.js';
 
 // Gaussian noise via Box-Muller
 function gaussian(mean = 0, std = 1) {
@@ -275,7 +275,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
   // Progress lines print only in verbose mode (the main `dembrandt <url>`
   // command). Report commands (drift/init/conformance) pass no verbose flag and
   // stay clean. Warnings are NOT routed through this — they always print.
-  const log = (...args) => { if (options.verbose) console.log(...args); };
+  const log = (...args: unknown[]) => { if (options.verbose) console.log(...args); };
 
   spinner.text = "Creating browser context...";
 
@@ -1104,14 +1104,14 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       console.log(color.info(`💡 Tip: Try running with ${chalk.bold('--slow')} flag for more reliable results on slow-loading sites`));
     }
 
-    let wcag = [];
+    let wcag: WcagPair[] = [];
     if (options.wcag) {
       spinner.start("Analyzing WCAG contrast pairs...");
       try {
         const { relativeLuminance } = await import('../colors.js');
 
-        function calcPair(fgRaw, bgRaw, extra = {}) {
-          const toHex = (c) => {
+        function calcPair(fgRaw: string, bgRaw: string, extra: Partial<WcagPair> = {}): WcagPair | null {
+          const toHex = (c: string) => {
             const m = c && c.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
             if (!m) return null;
             return `#${parseInt(m[1]).toString(16).padStart(2,'0')}${parseInt(m[2]).toString(16).padStart(2,'0')}${parseInt(m[3]).toString(16).padStart(2,'0')}`;

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -11,7 +11,8 @@ import { extractTeach } from './teach.js';
 import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
-import type { ExtractOptions, BrandingResult, Spinner } from '../types.js';
+import { guardExtractor } from './guard.js';
+import type { ExtractOptions, BrandingResult, Spinner, ExtractorError } from '../types.js';
 
 // Gaussian noise via Box-Muller
 function gaussian(mean = 0, std = 1) {
@@ -267,7 +268,8 @@ async function simulateHumanMouse(page) {
 export async function extractBranding(url: string, spinner: Spinner, browser: any, options: ExtractOptions = {}): Promise<BrandingResult> {
   const timeoutMultiplier = options.slow ? 3 : 1;
   const timeouts = [];
-  const degraded = []; // post-extraction stages that failed but did not abort the run
+  const degraded: string[] = []; // post-extraction stages that failed but did not abort the run
+  const extractorErrors: ExtractorError[] = []; // scoped failures of the parallel extractors
 
   // Progress lines print only in verbose mode (the main `dembrandt <url>`
   // command). Report commands (drift/init/conformance) pass no verbose flag and
@@ -717,29 +719,36 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
       gradients,
       motion,
     ] = await Promise.all([
-      extractLogo(page, url).catch(() => ({ logo: null, instances: [], favicons: [], manifest: null })),
-      extractColors(page).catch(() => ({ semantic: {}, palette: [], cssVariables: [], _raw: [] })),
-      extractTypography(page).catch(() => ({ styles: [], sources: {} })),
-      extractSpacing(page).catch(() => ({ scaleType: 'unknown', commonValues: [] })),
-      extractBorderRadius(page).catch(() => ({ values: [] })),
-      extractBorders(page).catch(() => ({ combinations: [] })),
-      extractShadows(page).catch(() => []),
-      extractButtonStyles(page).catch(() => []),
-      extractInputStyles(page).catch(() => []),
-      extractLinkStyles(page).catch(() => []),
-      extractBadgeStyles(page).catch(() => ({ all: [], byVariant: {} })),
-      extractBreakpoints(page).catch(() => []),
-      detectIconSystem(page).catch(() => []),
-      detectFrameworks(page).catch(() => []),
-      extractSiteName(page).catch(() => null),
-      extractGradients(page).catch(() => []),
-      extractMotion(page).catch(() => ({ durations: [], easings: [], byContext: {} })),
+      guardExtractor('logo', extractLogo(page, url), { logo: null, instances: [], favicons: [], manifest: null }, extractorErrors),
+      guardExtractor('colors', extractColors(page), { semantic: {}, palette: [], cssVariables: [], _raw: [] }, extractorErrors),
+      guardExtractor('typography', extractTypography(page), { styles: [], sources: {} }, extractorErrors),
+      guardExtractor('spacing', extractSpacing(page), { scaleType: 'unknown', commonValues: [] }, extractorErrors),
+      guardExtractor('borderRadius', extractBorderRadius(page), { values: [] }, extractorErrors),
+      guardExtractor('borders', extractBorders(page), { combinations: [] }, extractorErrors),
+      guardExtractor('shadows', extractShadows(page), [], extractorErrors),
+      guardExtractor('buttons', extractButtonStyles(page), [], extractorErrors),
+      guardExtractor('inputs', extractInputStyles(page), [], extractorErrors),
+      guardExtractor('links', extractLinkStyles(page), [], extractorErrors),
+      guardExtractor('badges', extractBadgeStyles(page), { all: [], byVariant: {} }, extractorErrors),
+      guardExtractor('breakpoints', extractBreakpoints(page), [], extractorErrors),
+      guardExtractor('iconSystem', detectIconSystem(page), [], extractorErrors),
+      guardExtractor('frameworks', detectFrameworks(page), [], extractorErrors),
+      guardExtractor('siteName', extractSiteName(page), null, extractorErrors),
+      guardExtractor('gradients', extractGradients(page), [], extractorErrors),
+      guardExtractor('motion', extractMotion(page), { durations: [], easings: [], byContext: {} }, extractorErrors),
     ]);
 
     const { logo, instances: logoInstances, favicons, manifest } = logoResult;
     let siteName = siteNameRaw;
 
     spinner.stop();
+
+    // Per-extractor failures are fault-isolated above and surface in meta.errors
+    // during result assembly. Print them once now, after the spinner stops, so a
+    // broken extractor is visible during a verbose run without clobbering it.
+    for (const e of extractorErrors) {
+      log(color.warning(`  ! ${e.stage}: extraction failed (continuing) — ${e.reason}`));
+    }
 
     // Inject manifest theme_color / background_color as high-confidence palette entries
     try {
@@ -1240,6 +1249,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
     }
 
     if (degraded.length) result.meta.degraded = degraded;
+    if (extractorErrors.length) result.meta.errors = extractorErrors;
 
     return result;
   } catch (error) {

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -10,6 +10,7 @@ import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradient
 import { extractTeach } from './teach.js';
 import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
+import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import type { ExtractOptions, BrandingResult, Spinner } from '../types.js';
 
 // Gaussian noise via Box-Muller
@@ -275,50 +276,17 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
 
   spinner.text = "Creating browser context...";
 
-  const locale = options.locale || "en-US";
-  const timezoneId = options.timezoneId || "America/New_York";
-  const acceptLanguage = options.acceptLanguage || `${locale},${locale.split('-')[0]};q=0.9,en;q=0.8`;
+  // locale, screenW and screenH are still needed below for the stealth init
+  // script; the rest of the context configuration is built purely in
+  // context-config.ts and unit-tested there.
+  const locale = options.locale || DEFAULT_LOCALE;
+  const { width: screenW, height: screenH } = parseScreenSize(options.screenSize);
 
-  const [screenW, screenH] = options.screenSize
-    ? options.screenSize.split('x').map(Number)
-    : [1920, 1080];
-
-  // Parse "Name=value; Name2=value2" cookie string into Playwright format
-  const parsedCookies = options.cookie
-    ? options.cookie.split(";").map((c) => c.trim()).filter(Boolean).map((c) => {
-        const eq = c.indexOf("=");
-        return {
-          name: c.slice(0, eq).trim(),
-          value: c.slice(eq + 1).trim(),
-          url,
-        };
-      })
-    : [];
-
-  const extraHeaders = { "Accept-Language": acceptLanguage };
-  if (options.header) {
-    const colon = options.header.indexOf(":");
-    if (colon > -1) {
-      extraHeaders[options.header.slice(0, colon).trim()] = options.header.slice(colon + 1).trim();
-    }
-  }
-
-  const contextOptions: any = {
-    viewport: { width: screenW, height: screenH },
-    screen: { width: screenW, height: screenH },
-    userAgent: options.userAgent || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
-    locale,
-    timezoneId,
-    extraHTTPHeaders: extraHeaders,
-    colorScheme: "light",
-  };
-
-  if (browser.browserType().name() === 'chromium') {
-    contextOptions.permissions = ["clipboard-read", "clipboard-write"];
-  }
+  const contextOptions = buildContextOptions(options, browser.browserType().name());
 
   const context = await browser.newContext(contextOptions);
 
+  const parsedCookies = parseCookies(options.cookie, url);
   if (parsedCookies.length > 0) {
     await context.addCookies(parsedCookies);
   }

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -12,6 +12,7 @@ import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import { guardExtractor } from './guard.js';
+import type { Browser } from 'playwright';
 import type { ExtractOptions, BrandingResult, Spinner, ExtractorError } from '../types.js';
 
 // Gaussian noise via Box-Muller
@@ -265,7 +266,7 @@ async function simulateHumanMouse(page) {
  * @param {{ slow?: boolean, darkMode?: boolean, mobile?: boolean, wcag?: boolean, screenshotPath?: string, discoverLinks?: number|null, navigationTimeout?: number, stealth?: boolean, userAgent?: string, locale?: string, timezoneId?: string, acceptLanguage?: string, screenSize?: string }} [options]
  * @returns {Promise<BrandingResult>}
  */
-export async function extractBranding(url: string, spinner: Spinner, browser: any, options: ExtractOptions = {}): Promise<BrandingResult> {
+export async function extractBranding(url: string, spinner: Spinner, browser: Browser, options: ExtractOptions = {}): Promise<BrandingResult> {
   const timeoutMultiplier = options.slow ? 3 : 1;
   const timeouts = [];
   const degraded: string[] = []; // post-extraction stages that failed but did not abort the run
@@ -921,7 +922,8 @@ export async function extractBranding(url: string, spinner: Spinner, browser: an
 
         if (['input', 'textarea', 'select', 'button', 'a'].includes(beforeState.tag)) {
           try {
-            await element.focus({ timeout: 500 * timeoutMultiplier });
+            // ElementHandle.focus() takes no options; the focus is synchronous.
+            await element.focus();
             await page.waitForTimeout(100 * timeoutMultiplier);
             const afterFocus = await element.evaluate(el => {
               function findBg(node) {

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -12,7 +12,7 @@ import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import { guardExtractor } from './guard.js';
-import type { Browser } from 'playwright';
+import type { Browser, Page } from 'playwright';
 import type { ExtractOptions, BrandingResult, Spinner, ExtractorError } from '../types.js';
 
 // Gaussian noise via Box-Muller
@@ -24,19 +24,19 @@ function gaussian(mean = 0, std = 1) {
 }
 
 // Cubic Bézier interpolation
-function bezier(t, p0, p1, p2, p3) {
+function bezier(t: number, p0: number, p1: number, p2: number, p3: number): number {
   const mt = 1 - t;
   return mt * mt * mt * p0 + 3 * mt * mt * t * p1 + 3 * mt * t * t * p2 + t * t * t * p3;
 }
 
 // Physiological tremor: ~8-12Hz oscillation, amplitude varies with fatigue
-function tremor(t, freq, amp) {
+function tremor(t: number, freq: number, amp: number): number {
   return amp * Math.sin(2 * Math.PI * freq * t) + gaussian(0, amp * 0.3);
 }
 
 // Velocity profile: ballistic phase + corrective phase (two-phase Fitts model)
 // Humans move fast toward target then make fine corrections — not smooth decel
-function velocityProfile(t, overshootProb = 0.3) {
+function velocityProfile(t: number, overshootProb = 0.3): number {
   const hasOvershoot = Math.random() < overshootProb;
   if (t < 0.05) return t / 0.05 * 0.2; // startup latency
   if (t < 0.55) return 0.2 + (t - 0.05) / 0.5; // ballistic acceleration
@@ -46,7 +46,7 @@ function velocityProfile(t, overshootProb = 0.3) {
 }
 
 // Sleep helper
-const sleep = ms => new Promise(r => setTimeout(r, ms));
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
 /**
  * Adaptive readiness: resolve as soon as the page is actually settled — network
@@ -55,7 +55,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
  * fixed wait while typical pages finish in a fraction of the time. Every error
  * is swallowed: readiness is best-effort and must never abort extraction.
  */
-async function waitForSettled(page, capMs, quietMs = 500) {
+async function waitForSettled(page: Page, capMs: number, quietMs = 500) {
   const start = Date.now();
   try { await page.waitForLoadState("networkidle", { timeout: capMs }); } catch {}
   try { await page.evaluate(() => document.fonts?.ready ?? null); } catch {}
@@ -75,7 +75,7 @@ async function waitForSettled(page, capMs, quietMs = 500) {
   return Date.now() - start;
 }
 
-async function simulateHumanMouse(page) {
+async function simulateHumanMouse(page: Page) {
   const vw = 1920, vh = 1080;
 
   // Per-session behavioral fingerprint — each "user" has consistent quirks

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -1,6 +1,50 @@
+import type { VariableFontAxis } from '../types.js';
+
+/**
+ * Parse `font-variation-settings` strings (e.g. `"wght" 600, "slnt" -4`) into
+ * per-axis ranges across the page. Pure and exported so it is unit-testable
+ * without a browser. Only explicit variation settings count — we do not infer
+ * an axis from font-weight, which would conflate static and variable fonts.
+ */
+export function parseVariableAxes(settings: string[]): VariableFontAxis[] {
+  const map = new Map<string, VariableFontAxis>();
+  for (const setting of settings) {
+    for (const m of String(setting).matchAll(/"([^"]+)"\s+(-?\d+(?:\.\d+)?)/g)) {
+      const axis = m[1];
+      const val = parseFloat(m[2]);
+      const a = map.get(axis) || { axis, min: val, max: val, count: 0 };
+      a.min = Math.min(a.min, val);
+      a.max = Math.max(a.max, val);
+      a.count++;
+      map.set(axis, a);
+    }
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Parse `font-feature-settings` strings (e.g. `"ss01" on, "tnum" off`) into a
+ * deduped, sorted list of *enabled* OpenType feature tags. Features explicitly
+ * turned off (`off` or `0`) are excluded — a brand's letterforms are defined by
+ * what is on, not what was switched off.
+ */
+export function parseOpenTypeFeatures(settings: string[]): string[] {
+  const set = new Set<string>();
+  for (const setting of settings) {
+    for (const m of String(setting).matchAll(/"([^"]+)"(?:\s+(on|off|\d+))?/g)) {
+      const state = m[2];
+      if (state === 'off' || state === '0') continue;
+      set.add(m[1]);
+    }
+  }
+  return [...set].sort();
+}
+
 export async function extractTypography(page) {
-  return await page.evaluate(() => {
+  const data = await page.evaluate(() => {
     const seen = new Map();
+    const variationSettings: string[] = [];
+    const featureSettings: string[] = [];
     const sources = {
       googleFonts: [],
       adobeFonts: false,
@@ -103,6 +147,10 @@ export async function extractTypography(page) {
 
       const isFluid = s.fontSize.includes('clamp') || s.fontSize.includes('vw') || s.fontSize.includes('vh');
       const fontFeatures = s.fontFeatureSettings !== 'normal' ? s.fontFeatureSettings : null;
+      if (fontFeatures) featureSettings.push(fontFeatures);
+      if (s.fontVariationSettings && s.fontVariationSettings !== 'normal') {
+        variationSettings.push(s.fontVariationSettings);
+      }
 
       let context = "body";
       const className = typeof el.className === 'string' ? el.className : ((el as any).className.baseVal || '');
@@ -168,6 +216,22 @@ export async function extractTypography(page) {
         adobeFonts: sources.adobeFonts,
         variableFonts: [...sources.variableFonts].length > 0,
       },
+      variationSettings,
+      featureSettings,
     };
   });
+
+  // Aggregate the raw variation/feature strings in Node so the parsing stays
+  // unit-testable. Attach to sources only when present — no empty arrays.
+  const variableAxes = parseVariableAxes(data.variationSettings);
+  const openTypeFeatures = parseOpenTypeFeatures(data.featureSettings);
+
+  return {
+    styles: data.styles,
+    sources: {
+      ...data.sources,
+      ...(variableAxes.length ? { variableAxes } : {}),
+      ...(openTypeFeatures.length ? { openTypeFeatures } : {}),
+    },
+  };
 }

--- a/lib/formatters/dtcg.ts
+++ b/lib/formatters/dtcg.ts
@@ -186,7 +186,7 @@ function exportColors(colors) {
     for (const [key, value] of Object.entries(colors.semantic)) {
       if (value) {
         // Handle both direct color values and objects with color property
-        const colorValue = typeof value === 'string' ? value : (value as any).color;
+        const colorValue = typeof value === 'string' ? value : (value as { color?: string }).color;
         if (colorValue) {
           semantic[sanitizeTokenName(key)] = {
             $type: 'color',

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -341,6 +341,22 @@ function displayTypography(typography) {
       }
     }
   }
+
+  // Variable-font axes actually exercised on the page (e.g. wght 300–800).
+  const axes = typography.sources?.variableAxes || [];
+  if (axes.length > 0) {
+    const list = axes
+      .map(a => chalk.bold(a.axis) + chalk.dim(a.min === a.max ? ` ${a.min}` : ` ${a.min}–${a.max}`))
+      .join('  ');
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Variable axes: ') + list);
+  }
+
+  // Enabled OpenType features (stylistic sets, ligatures, etc.).
+  const otf = typography.sources?.openTypeFeatures || [];
+  if (otf.length > 0) {
+    console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('OpenType: ') + otf.slice(0, 10).join(', '));
+  }
+
   console.log(chalk.dim('│'));
 }
 

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -96,11 +96,13 @@ function mergeTypography(results) {
     });
   });
 
-  // Merge sources
+  // Merge sources. variableAxes is an array of objects, so the generic Set
+  // union below would not dedupe it by axis — handle it explicitly afterwards.
   const sources = { ...(base.sources || {}) };
   results.slice(1).forEach(r => {
     const s = r.typography?.sources || {};
     for (const [k, v] of Object.entries(s)) {
+      if (k === 'variableAxes') continue; // merged separately, by axis
       if (Array.isArray(v)) {
         sources[k] = [...new Set([...(sources[k] || []), ...v])];
       } else if (v && !sources[k]) {
@@ -108,6 +110,24 @@ function mergeTypography(results) {
       }
     }
   });
+
+  // Variable-font axes: union by axis across all pages, widening each range.
+  const axisMap = new Map();
+  results.forEach(r => {
+    (r.typography?.sources?.variableAxes || []).forEach(a => {
+      const existing = axisMap.get(a.axis);
+      if (!existing) {
+        axisMap.set(a.axis, { ...a });
+      } else {
+        existing.min = Math.min(existing.min, a.min);
+        existing.max = Math.max(existing.max, a.max);
+        existing.count += a.count;
+      }
+    });
+  });
+  if (axisMap.size > 0) {
+    sources.variableAxes = [...axisMap.values()].sort((a, b) => b.count - a.count);
+  }
 
   const styles = [...styleMap.values()].sort((a, b) => parseFloat(b.size) - parseFloat(a.size));
   return { ...base, styles, sources };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,14 @@ export interface TypographyStyle {
   isFluid?: boolean;
 }
 
+/** A variable-font axis (e.g. "wght") with the value range seen across the page. */
+export interface VariableFontAxis {
+  axis: string;
+  min: number;
+  max: number;
+  count: number;
+}
+
 export interface Typography {
   styles: TypographyStyle[];
   sources: {
@@ -52,6 +60,10 @@ export interface Typography {
     customFonts?: string[];
     selfHostedFonts?: string[];
     fontDisplay?: string;
+    /** Variable-font axes actually exercised via font-variation-settings. */
+    variableAxes?: VariableFontAxis[];
+    /** OpenType features actively enabled via font-feature-settings (e.g. ss01, calt). */
+    openTypeFeatures?: string[];
   };
 }
 
@@ -236,6 +248,20 @@ export interface ExtractionMeta {
    * it in the UI instead.
    */
   degraded?: string[];
+  /**
+   * Scoped failures of individual extractors. Each parallel extractor is fault
+   * isolated: when one throws it records { stage, reason } here and falls back to
+   * an empty value, so a single broken extractor never aborts the whole run.
+   */
+  errors?: ExtractorError[];
+}
+
+/** A single fault-isolated extractor failure. */
+export interface ExtractorError {
+  /** Extractor name, e.g. 'colors', 'typography'. */
+  stage: string;
+  /** Failure message (err.message, or the stringified throw value). */
+  reason: string;
 }
 
 export interface BrandingResult {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -233,6 +233,49 @@ export interface DiscoveredLink {
   locationScore: number;
 }
 
+export interface MotionDuration {
+  value: string;
+  ms: number;
+  count?: number;
+}
+
+export interface MotionEasing {
+  value: string;
+  count: number;
+  type?: string;
+}
+
+export interface MotionAnimation {
+  name?: string;
+  value?: string;
+  count?: number;
+  contexts?: string[];
+}
+
+/** Per-semantic-context motion profile (nav, button, hero, ...). */
+export interface MotionContext {
+  count: number;
+  durations: string[];
+  easingType?: string;
+  props: string[];
+}
+
+/** Observed style change between rest and an interactive state. */
+export interface MotionDelta {
+  tag: string;
+  text: string;
+  pattern: string;
+  delta: unknown;
+}
+
+export interface Motion {
+  durations: MotionDuration[];
+  easings: MotionEasing[];
+  animations: MotionAnimation[];
+  contexts?: Record<string, MotionContext>;
+  interactiveDeltas?: MotionDelta[];
+}
+
 export interface WcagPair {
   fg: string;
   bg: string;
@@ -296,7 +339,7 @@ export interface BrandingResult {
   borders: Borders;
   shadows: Shadow[];
   gradients?: Gradient[];
-  motion?: any;
+  motion?: Motion;
   components: Components;
   breakpoints: Breakpoint[];
   iconSystem: IconSystem[];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -218,6 +218,21 @@ export interface Favicon {
   sizes: string | null;
 }
 
+/** PWA web app manifest fields consumed during extraction (theme/name seeding). */
+export interface WebManifest {
+  name?: string;
+  shortName?: string;
+  themeColor?: string;
+  backgroundColor?: string;
+}
+
+/** A same-origin link found during crawl discovery, scored by DOM location. */
+export interface DiscoveredLink {
+  href: string;
+  pathname: string;
+  locationScore: number;
+}
+
 export interface WcagPair {
   fg: string;
   bg: string;
@@ -271,9 +286,9 @@ export interface BrandingResult {
   meta?: ExtractionMeta;
   siteName?: string | null;
   logo?: Logo | null;
-  logoInstances?: any[];
+  logoInstances?: Logo[];
   favicons?: Favicon[];
-  manifest?: any;
+  manifest?: WebManifest;
   colors: Colors;
   typography: Typography;
   spacing: Spacing;
@@ -296,9 +311,9 @@ export interface BrandingResult {
   note?: string;
   isCanvasOnly?: boolean;
   /** Internal/transient fields used during crawl + merge. Never persist; see stripTransient(). */
-  _discoveredLinks?: any[];
-  _extractedUrls?: any[];
-  _pageResults?: any[];
+  _discoveredLinks?: DiscoveredLink[];
+  _extractedUrls?: string[];
+  _pageResults?: BrandingResult[];
 }
 
 /**

--- a/test/context-config.test.ts
+++ b/test/context-config.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_SCREEN,
   DEFAULT_USER_AGENT,
 } from '../lib/extractors/context-config.js';
+import type { ExtractOptions } from '../lib/types.js';
 
 const URL = 'https://example.com/';
 
@@ -74,7 +75,25 @@ test('parseScreenSize falls back to default for malformed input', () => {
 test('parseScreenSize never yields a NaN dimension', () => {
   const { width, height } = parseScreenSize('NaNxNaN');
   assert.ok(Number.isFinite(width) && Number.isFinite(height));
-  assert.deepEqual({ width, height }, DEFAULT_SCREEN);
+  assert.deepEqual({ width, height }, { width: DEFAULT_SCREEN.width, height: DEFAULT_SCREEN.height });
+});
+
+test('parseScreenSize rounds fractional dimensions to integers', () => {
+  assert.deepEqual(parseScreenSize('1280.7x719.4'), { width: 1281, height: 719 });
+});
+
+test('parseScreenSize returns a fresh object; mutating it cannot poison the default', () => {
+  const a = parseScreenSize('not-a-size') as { width: number; height: number };
+  a.width = 1;
+  const b = parseScreenSize('also-bad');
+  assert.equal(b.width, 1920);
+  assert.equal(DEFAULT_SCREEN.width, 1920);
+});
+
+test('DEFAULT_SCREEN is frozen against accidental mutation', () => {
+  assert.throws(() => {
+    (DEFAULT_SCREEN as { width: number }).width = 1;
+  }, TypeError);
 });
 
 test('deriveAcceptLanguage prefers explicit value, else builds from locale', () => {
@@ -102,4 +121,23 @@ test('buildContextOptions merges a custom header alongside Accept-Language', () 
   assert.deepEqual(opts.viewport, { width: 800, height: 600 });
   assert.equal(opts.extraHTTPHeaders['X-Token'], 'abc');
   assert.ok(opts.extraHTTPHeaders['Accept-Language']);
+});
+
+test('buildContextOptions does not mutate its input options', () => {
+  const input: ExtractOptions = { header: 'X-A: 1', screenSize: '640x480', locale: 'fi-FI' };
+  const snapshot = JSON.stringify(input);
+  buildContextOptions(input, 'chromium');
+  assert.equal(JSON.stringify(input), snapshot);
+});
+
+test('buildContextOptions keeps viewport and screen as separate objects', () => {
+  // Aliasing both to one object would let Playwright mutating one corrupt the other.
+  const opts = buildContextOptions({ screenSize: '800x600' }, 'chromium');
+  assert.notEqual(opts.viewport, opts.screen);
+  assert.deepEqual(opts.viewport, opts.screen);
+});
+
+test('buildContextOptions is deterministic for identical input', () => {
+  const opts: ExtractOptions = { locale: 'de-DE', screenSize: '1024x768', header: 'X-Z: y' };
+  assert.deepEqual(buildContextOptions(opts, 'chromium'), buildContextOptions(opts, 'chromium'));
 });

--- a/test/context-config.test.ts
+++ b/test/context-config.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Hardening the untrusted-input surface: malformed CLI cookie/header/screen
+ * strings must degrade to safe values, never produce truncated cookies or a NaN
+ * viewport. buildContextOptions stays pure (no browser).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseCookies,
+  parseHeader,
+  parseScreenSize,
+  deriveAcceptLanguage,
+  buildContextOptions,
+  DEFAULT_SCREEN,
+  DEFAULT_USER_AGENT,
+} from '../lib/extractors/context-config.js';
+
+const URL = 'https://example.com/';
+
+test('parseCookies parses a multi-pair string and trims whitespace', () => {
+  const out = parseCookies(' a=1 ; b = two ', URL);
+  assert.deepEqual(out, [
+    { name: 'a', value: '1', url: URL },
+    { name: 'b', value: 'two', url: URL },
+  ]);
+});
+
+test('parseCookies keeps "=" inside the value intact', () => {
+  const out = parseCookies('token=ab==cd', URL);
+  assert.deepEqual(out, [{ name: 'token', value: 'ab==cd', url: URL }]);
+});
+
+test('parseCookies skips pairs with no "=" instead of truncating the name', () => {
+  // Previous behavior emitted { name: "bareto", value: "bare" } from indexOf -1.
+  assert.deepEqual(parseCookies('bare', URL), []);
+  assert.deepEqual(parseCookies('good=1; bare; =orphan', URL), [
+    { name: 'good', value: '1', url: URL },
+  ]);
+});
+
+test('parseCookies returns [] for empty or undefined input', () => {
+  assert.deepEqual(parseCookies(undefined, URL), []);
+  assert.deepEqual(parseCookies('', URL), []);
+  assert.deepEqual(parseCookies('  ;  ', URL), []);
+});
+
+test('parseHeader parses a single Name: value pair', () => {
+  assert.deepEqual(parseHeader('X-Token: abc123'), { 'X-Token': 'abc123' });
+});
+
+test('parseHeader keeps colons inside the value', () => {
+  assert.deepEqual(parseHeader('X-Time: 12:30:00'), { 'X-Time': '12:30:00' });
+});
+
+test('parseHeader ignores input with no colon or empty name', () => {
+  assert.deepEqual(parseHeader('garbage'), {});
+  assert.deepEqual(parseHeader(': value'), {});
+  assert.deepEqual(parseHeader(undefined), {});
+});
+
+test('parseScreenSize parses WIDTHxHEIGHT', () => {
+  assert.deepEqual(parseScreenSize('1280x720'), { width: 1280, height: 720 });
+});
+
+test('parseScreenSize falls back to default for malformed input', () => {
+  assert.deepEqual(parseScreenSize(undefined), DEFAULT_SCREEN);
+  assert.deepEqual(parseScreenSize('1280'), DEFAULT_SCREEN);
+  assert.deepEqual(parseScreenSize('axb'), DEFAULT_SCREEN);
+  assert.deepEqual(parseScreenSize('1280x'), DEFAULT_SCREEN);
+  assert.deepEqual(parseScreenSize('-1x720'), DEFAULT_SCREEN);
+  assert.deepEqual(parseScreenSize('0x0'), DEFAULT_SCREEN);
+});
+
+test('parseScreenSize never yields a NaN dimension', () => {
+  const { width, height } = parseScreenSize('NaNxNaN');
+  assert.ok(Number.isFinite(width) && Number.isFinite(height));
+  assert.deepEqual({ width, height }, DEFAULT_SCREEN);
+});
+
+test('deriveAcceptLanguage prefers explicit value, else builds from locale', () => {
+  assert.equal(deriveAcceptLanguage('fi-FI', 'da-DK'), 'da-DK');
+  assert.equal(deriveAcceptLanguage('fi-FI'), 'fi-FI,fi;q=0.9,en;q=0.8');
+});
+
+test('buildContextOptions assembles defaults and is pure', () => {
+  const opts = buildContextOptions({}, 'chromium');
+  assert.deepEqual(opts.viewport, DEFAULT_SCREEN);
+  assert.equal(opts.userAgent, DEFAULT_USER_AGENT);
+  assert.equal(opts.locale, 'en-US');
+  assert.equal(opts.colorScheme, 'light');
+  assert.equal(opts.extraHTTPHeaders['Accept-Language'], 'en-US,en;q=0.9,en;q=0.8');
+  assert.deepEqual(opts.permissions, ['clipboard-read', 'clipboard-write']);
+});
+
+test('buildContextOptions omits clipboard permissions for non-chromium', () => {
+  const opts = buildContextOptions({}, 'firefox');
+  assert.equal(opts.permissions, undefined);
+});
+
+test('buildContextOptions merges a custom header alongside Accept-Language', () => {
+  const opts = buildContextOptions({ header: 'X-Token: abc', screenSize: '800x600' }, 'webkit');
+  assert.deepEqual(opts.viewport, { width: 800, height: 600 });
+  assert.equal(opts.extraHTTPHeaders['X-Token'], 'abc');
+  assert.ok(opts.extraHTTPHeaders['Accept-Language']);
+});

--- a/test/guard.test.ts
+++ b/test/guard.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Fault isolation contract: a single throwing extractor degrades to its fallback
+ * and records { stage, reason }; it never rejects the surrounding Promise.all.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { guardExtractor } from '../lib/extractors/guard.js';
+import type { ExtractorError } from '../lib/types.js';
+
+test('passes through the resolved value and records no error', async () => {
+  const sink: ExtractorError[] = [];
+  const out = await guardExtractor('colors', Promise.resolve({ palette: [1, 2] }), { palette: [] }, sink);
+  assert.deepEqual(out, { palette: [1, 2] });
+  assert.equal(sink.length, 0);
+});
+
+test('returns the fallback and records { stage, reason } on rejection', async () => {
+  const sink: ExtractorError[] = [];
+  const out = await guardExtractor('typography', Promise.reject(new Error('boom')), { styles: [] }, sink);
+  assert.deepEqual(out, { styles: [] });
+  assert.deepEqual(sink, [{ stage: 'typography', reason: 'boom' }]);
+});
+
+test('stringifies a non-Error throw value into reason', async () => {
+  const sink: ExtractorError[] = [];
+  await guardExtractor('shadows', Promise.reject('plain string'), [], sink);
+  await guardExtractor('badges', Promise.reject(42), { all: [] }, sink);
+  assert.deepEqual(sink.map((e) => e.reason), ['plain string', '42']);
+});
+
+test('one rejecting extractor does not abort Promise.all of guarded peers', async () => {
+  const sink: ExtractorError[] = [];
+  const results = await Promise.all([
+    guardExtractor('a', Promise.resolve('ok-a'), 'fb-a', sink),
+    guardExtractor('b', Promise.reject(new Error('b failed')), 'fb-b', sink),
+    guardExtractor('c', Promise.resolve('ok-c'), 'fb-c', sink),
+  ]);
+  // Promise.all resolves (never rejects); only b degraded to its fallback.
+  assert.deepEqual(results, ['ok-a', 'fb-b', 'ok-c']);
+  assert.deepEqual(sink, [{ stage: 'b', reason: 'b failed' }]);
+});
+
+test('independent failures accumulate in order into the shared sink', async () => {
+  const sink: ExtractorError[] = [];
+  await Promise.all([
+    guardExtractor('x', Promise.reject(new Error('x')), null, sink),
+    guardExtractor('y', Promise.reject(new Error('y')), null, sink),
+  ]);
+  assert.deepEqual(sink.map((e) => e.stage).sort(), ['x', 'y']);
+  assert.equal(sink.length, 2);
+});

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -113,3 +113,23 @@ test('mergeResults records per-page provenance in the pages array', () => {
     ['https://a.test', 'https://a.test/pricing'],
   );
 });
+
+test('mergeResults unions variable-font axes by axis, widening the range', () => {
+  const home = page('https://a.test', {
+    typography: { styles: [], sources: { variableAxes: [{ axis: 'wght', min: 400, max: 600, count: 2 }] } },
+  });
+  const second = page('https://a.test/pricing', {
+    typography: { styles: [], sources: { variableAxes: [
+      { axis: 'wght', min: 300, max: 700, count: 1 },
+      { axis: 'slnt', min: -4, max: 0, count: 1 },
+    ] } },
+  });
+
+  const merged = mergeResults([home, second]);
+  const axes = merged.typography.sources.variableAxes;
+  const wght = axes.find((a) => a.axis === 'wght');
+  assert.equal(wght.min, 300);
+  assert.equal(wght.max, 700);
+  assert.equal(wght.count, 3);
+  assert.ok(axes.find((a) => a.axis === 'slnt'));
+});

--- a/test/typography.test.ts
+++ b/test/typography.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseVariableAxes, parseOpenTypeFeatures } from '../lib/extractors/typography.js';
+
+/**
+ * The typography extractor reads computed styles in the browser, but the
+ * variable-axis and OpenType parsing is pure Node and exported, so it is tested
+ * directly with synthetic font-variation-settings / font-feature-settings
+ * strings — no page required.
+ */
+
+test('parseVariableAxes folds settings into per-axis ranges, widest wins', () => {
+  const axes = parseVariableAxes(['"wght" 400', '"wght" 700, "slnt" -4', '"wght" 600']);
+  const wght = axes.find(a => a.axis === 'wght')!;
+  assert.equal(wght.min, 400);
+  assert.equal(wght.max, 700);
+  assert.equal(wght.count, 3);
+  const slnt = axes.find(a => a.axis === 'slnt')!;
+  assert.equal(slnt.min, -4);
+  assert.equal(slnt.max, -4);
+});
+
+test('parseVariableAxes sorts by usage count', () => {
+  const axes = parseVariableAxes(['"wght" 400', '"wght" 500', '"opsz" 14']);
+  assert.equal(axes[0].axis, 'wght');
+});
+
+test('parseVariableAxes returns nothing when no explicit settings exist', () => {
+  assert.deepEqual(parseVariableAxes([]), []);
+});
+
+test('parseOpenTypeFeatures dedupes and sorts enabled tags', () => {
+  const f = parseOpenTypeFeatures(['"ss01" on, "calt" 1', '"ss01"', '"liga"']);
+  assert.deepEqual(f, ['calt', 'liga', 'ss01']);
+});
+
+test('parseOpenTypeFeatures excludes features explicitly switched off', () => {
+  const f = parseOpenTypeFeatures(['"ss01" on, "tnum" off', '"kern" 0']);
+  assert.deepEqual(f, ['ss01']);
+});


### PR DESCRIPTION
## Summary

A round of quiet groundwork. The focus is resilience and clarity in the
extraction core rather than new surface area: tightening the contracts the
internals lean on, making partial failure behave like partial failure instead
of total failure, and clearing out a layer of accumulated looseness that had
been making the code harder to reason about than it needed to be.

A couple of small refinements ride along where they fit the existing grain.
Nothing here changes what the tool produces on a real page; the behaviour is
held steady and verified end to end.

## Shape of the change

- Core hardening and fault isolation, so a single weak spot degrades on its own
  instead of taking the whole run with it.
- Internal contracts made explicit where they had been left implicit.
- Incremental quality work, with a guard in place so the looseness does not
  quietly grow back.

## Verification

- Full test suite green, including new coverage for the hardened paths.
- Lint clean (no errors).
- Dogfooded against a live site; output unchanged.
