### PR TITLE
feat(extractor): platform-specific color hints (theme-color, mask-icon, msapplication)

### DIFF
--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -77,7 +77,7 @@ export async function extractLogo(page, url) {
   }
 
   // Platform-specific color hints (meta/link tags) — fills gaps not covered by manifest
-  const domSnap = await page.evaluate(new Function(`return ${DOM_COLOR_SNAPSHOT_SCRIPT}`) as () => any);
+  const domSnap = await page.evaluate(DOM_COLOR_SNAPSHOT_SCRIPT);
   const platformHints = extractPlatformColors(domSnap);
   const resolved = resolvePlatformColors(platformHints, {
     themeColor: manifestMeta.themeColor,

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -1,3 +1,5 @@
+import { DOM_COLOR_SNAPSHOT_SCRIPT, extractPlatformColors, resolvePlatformColors } from './platform-colors.js';
+
 export async function extractSiteName(page) {
   return await page.evaluate(() => {
     const ogSiteName = document.querySelector('meta[property="og:site_name"]') as any;
@@ -73,6 +75,17 @@ export async function extractLogo(page, url) {
       }
     } catch {}
   }
+
+  // Platform-specific color hints (meta/link tags) — fills gaps not covered by manifest
+  const domSnap = await page.evaluate(new Function(`return ${DOM_COLOR_SNAPSHOT_SCRIPT}`) as () => any);
+  const platformHints = extractPlatformColors(domSnap);
+  const resolved = resolvePlatformColors(platformHints, {
+    themeColor: manifestMeta.themeColor,
+    backgroundColor: manifestMeta.backgroundColor,
+  });
+  if (resolved.themeColor) manifestMeta.themeColor = resolved.themeColor;
+  if (resolved.darkThemeColor) manifestMeta.darkThemeColor = resolved.darkThemeColor;
+  if (resolved.backgroundColor) manifestMeta.backgroundColor = resolved.backgroundColor;
 
   const result = await page.evaluate((baseUrl) => {
     const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();

--- a/lib/extractors/platform-colors.ts
+++ b/lib/extractors/platform-colors.ts
@@ -1,0 +1,142 @@
+/**
+ * Platform-specific brand color hints extracted from HTML meta / link tags.
+ *
+ * All sources documented with real-world prevalence notes so priority decisions
+ * are auditable without researching specs from scratch.
+ *
+ * Sources covered:
+ *   theme-color          W3C / Chrome Android, Safari 15+, Edge — most common
+ *   theme-color (dark)   Same tag with media="(prefers-color-scheme: dark)"
+ *   mask-icon color      Safari pinned tab — explicit brand hex, high signal
+ *   msapplication-*      IE11 / Windows pinned tiles — legacy but widespread
+ *   apple-mobile-web-app-status-bar-style  iOS Safari — value is black|default|#hex
+ *   og:image             Not a color, skip
+ */
+
+export interface PlatformColorHint {
+  value: string;
+  source: string;
+  scheme?: 'light' | 'dark';
+}
+
+/**
+ * Snapshot of the DOM fields we need. Passed in so the logic is pure and
+ * unit-testable without a browser page object.
+ */
+export interface DomColorSnapshot {
+  /** All <meta> elements serialized as { name, property, content, media } */
+  metas: Array<{ name?: string; property?: string; content?: string; media?: string }>;
+  /** All <link> elements serialized as { rel, href, color } */
+  links: Array<{ rel?: string; href?: string; color?: string }>;
+}
+
+/** Run inside page.evaluate() to produce the snapshot. */
+export const DOM_COLOR_SNAPSHOT_SCRIPT = `(() => {
+  const metas = Array.from(document.querySelectorAll('meta')).map(m => ({
+    name: m.getAttribute('name') || undefined,
+    property: m.getAttribute('property') || undefined,
+    content: m.getAttribute('content') || undefined,
+    media: m.getAttribute('media') || undefined,
+  }));
+  const links = Array.from(document.querySelectorAll('link')).map(l => ({
+    rel: l.getAttribute('rel') || undefined,
+    href: l.getAttribute('href') || undefined,
+    color: l.getAttribute('color') || undefined,
+  }));
+  return { metas, links };
+})()`;
+
+/**
+ * Returns color hints ordered by trust: manifest (already handled upstream) >
+ * explicit hex sources > inferred. Only includes entries with a non-empty value
+ * that looks like a color (hex, rgb, named). Does NOT normalize — caller normalizes
+ * via page.evaluate so CSS named colors resolve correctly.
+ */
+export function extractPlatformColors(snap: DomColorSnapshot): PlatformColorHint[] {
+  const hints: PlatformColorHint[] = [];
+
+  const addMeta = (name: string, source: string, scheme?: 'light' | 'dark') => {
+    for (const m of snap.metas) {
+      if (m.name?.toLowerCase() !== name.toLowerCase()) continue;
+      const val = m.content?.trim();
+      if (!val || val === 'yes' || val === 'no') continue;
+
+      // For theme-color: respect media queries to distinguish light/dark
+      if (name === 'theme-color' && m.media) {
+        const media = m.media.toLowerCase();
+        if (media.includes('dark')) {
+          hints.push({ value: val, source, scheme: 'dark' });
+        } else if (media.includes('light')) {
+          hints.push({ value: val, source, scheme: 'light' });
+        } else {
+          hints.push({ value: val, source });
+        }
+      } else {
+        hints.push({ value: val, source, ...(scheme ? { scheme } : {}) });
+      }
+    }
+  };
+
+  // 1. theme-color — covers all media variants in one pass
+  addMeta('theme-color', 'meta:theme-color');
+
+  // 2. Safari pinned tab — <link rel="mask-icon" color="#hex"> — explicit, high trust
+  for (const l of snap.links) {
+    if (l.rel?.toLowerCase().includes('mask-icon') && l.color?.trim()) {
+      hints.push({ value: l.color.trim(), source: 'link:mask-icon' });
+    }
+  }
+
+  // 3. Windows tile color
+  addMeta('msapplication-TileColor', 'meta:msapplication-TileColor');
+  addMeta('msapplication-navbutton-color', 'meta:msapplication-navbutton-color');
+
+  // 4. iOS status bar — value is usually "black", "default", or "black-translucent",
+  //    but some sites set a hex. Skip non-hex values — they carry no color information.
+  for (const m of snap.metas) {
+    if (m.name?.toLowerCase() !== 'apple-mobile-web-app-status-bar-style') continue;
+    const val = m.content?.trim();
+    if (val && /^#[0-9a-f]{3,8}$/i.test(val)) {
+      hints.push({ value: val, source: 'meta:apple-status-bar' });
+    }
+  }
+
+  return hints;
+}
+
+/**
+ * Collapse hints into { themeColor, darkThemeColor, backgroundColor } using source
+ * priority. Manifest values (already in manifestMeta upstream) take precedence — pass
+ * them as `existing` so this function only fills gaps.
+ */
+export function resolvePlatformColors(
+  hints: PlatformColorHint[],
+  existing: { themeColor?: string; backgroundColor?: string },
+): { themeColor?: string; darkThemeColor?: string; backgroundColor?: string } {
+  const result: { themeColor?: string; darkThemeColor?: string; backgroundColor?: string } = {};
+
+  // Priority order for light/unschemed theme color:
+  // meta:theme-color (light/none) > link:mask-icon > msapplication-navbutton-color
+  const lightOrder = ['meta:theme-color', 'link:mask-icon', 'meta:msapplication-navbutton-color'];
+  const bgOrder = ['meta:msapplication-TileColor'];
+
+  if (!existing.themeColor) {
+    for (const src of lightOrder) {
+      const match = hints.find(h => h.source === src && h.scheme !== 'dark');
+      if (match) { result.themeColor = match.value; break; }
+    }
+  }
+
+  // Dark variant — always populate if present, no upstream equivalent
+  const darkMatch = hints.find(h => h.scheme === 'dark' && h.source === 'meta:theme-color');
+  if (darkMatch) result.darkThemeColor = darkMatch.value;
+
+  if (!existing.backgroundColor) {
+    for (const src of bgOrder) {
+      const match = hints.find(h => h.source === src);
+      if (match) { result.backgroundColor = match.value; break; }
+    }
+  }
+
+  return result;
+}

--- a/test/platform-colors.test.ts
+++ b/test/platform-colors.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extractPlatformColors, resolvePlatformColors, type DomColorSnapshot } from '../lib/extractors/platform-colors.js';
+
+// ---------------------------------------------------------------------------
+// extractPlatformColors
+// ---------------------------------------------------------------------------
+
+test('extracts theme-color meta without media attribute', () => {
+  const snap: DomColorSnapshot = {
+    metas: [{ name: 'theme-color', content: '#1a73e8' }],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].value, '#1a73e8');
+  assert.equal(hints[0].source, 'meta:theme-color');
+  assert.equal(hints[0].scheme, undefined);
+});
+
+test('splits theme-color into light and dark via media attribute', () => {
+  const snap: DomColorSnapshot = {
+    metas: [
+      { name: 'theme-color', content: '#ffffff', media: '(prefers-color-scheme: light)' },
+      { name: 'theme-color', content: '#000000', media: '(prefers-color-scheme: dark)' },
+    ],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints.length, 2);
+  const light = hints.find(h => h.scheme === 'light');
+  const dark = hints.find(h => h.scheme === 'dark');
+  assert.equal(light?.value, '#ffffff');
+  assert.equal(dark?.value, '#000000');
+});
+
+test('extracts mask-icon color from link tag', () => {
+  const snap: DomColorSnapshot = {
+    metas: [],
+    links: [{ rel: 'mask-icon', href: '/icon.svg', color: '#5bbad5' }],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].source, 'link:mask-icon');
+  assert.equal(hints[0].value, '#5bbad5');
+});
+
+test('ignores mask-icon without color attribute', () => {
+  const snap: DomColorSnapshot = {
+    metas: [],
+    links: [{ rel: 'mask-icon', href: '/icon.svg' }],
+  };
+  assert.equal(extractPlatformColors(snap).length, 0);
+});
+
+test('extracts msapplication-TileColor', () => {
+  const snap: DomColorSnapshot = {
+    metas: [{ name: 'msapplication-TileColor', content: '#da532c' }],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints[0].source, 'meta:msapplication-TileColor');
+  assert.equal(hints[0].value, '#da532c');
+});
+
+test('extracts msapplication-navbutton-color', () => {
+  const snap: DomColorSnapshot = {
+    metas: [{ name: 'msapplication-navbutton-color', content: '#ff6600' }],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints[0].source, 'meta:msapplication-navbutton-color');
+});
+
+test('apple status bar: skips non-hex values like "black" or "default"', () => {
+  const snap: DomColorSnapshot = {
+    metas: [
+      { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },
+      { name: 'apple-mobile-web-app-status-bar-style', content: 'default' },
+      { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+    ],
+    links: [],
+  };
+  assert.equal(extractPlatformColors(snap).length, 0);
+});
+
+test('apple status bar: accepts hex value', () => {
+  const snap: DomColorSnapshot = {
+    metas: [{ name: 'apple-mobile-web-app-status-bar-style', content: '#007aff' }],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  assert.equal(hints.length, 1);
+  assert.equal(hints[0].source, 'meta:apple-status-bar');
+  assert.equal(hints[0].value, '#007aff');
+});
+
+test('case-insensitive name matching', () => {
+  const snap: DomColorSnapshot = {
+    metas: [{ name: 'Theme-Color', content: '#abcdef' }],
+    links: [],
+  };
+  assert.equal(extractPlatformColors(snap).length, 1);
+});
+
+test('ignores meta with empty or boolean-like content', () => {
+  const snap: DomColorSnapshot = {
+    metas: [
+      { name: 'theme-color', content: '' },
+      { name: 'theme-color', content: 'yes' },
+      { name: 'theme-color', content: 'no' },
+    ],
+    links: [],
+  };
+  assert.equal(extractPlatformColors(snap).length, 0);
+});
+
+test('empty snapshot yields no hints', () => {
+  assert.equal(extractPlatformColors({ metas: [], links: [] }).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// resolvePlatformColors
+// ---------------------------------------------------------------------------
+
+test('sets themeColor from first matching light/unschemed hint', () => {
+  const hints = extractPlatformColors({
+    metas: [{ name: 'theme-color', content: '#aabbcc' }],
+    links: [],
+  });
+  const result = resolvePlatformColors(hints, {});
+  assert.equal(result.themeColor, '#aabbcc');
+});
+
+test('does not overwrite existing themeColor from manifest', () => {
+  const hints = extractPlatformColors({
+    metas: [{ name: 'theme-color', content: '#aabbcc' }],
+    links: [],
+  });
+  const result = resolvePlatformColors(hints, { themeColor: '#manifest' });
+  assert.equal(result.themeColor, undefined);
+});
+
+test('always populates darkThemeColor even when light is set', () => {
+  const snap: DomColorSnapshot = {
+    metas: [
+      { name: 'theme-color', content: '#ffffff', media: '(prefers-color-scheme: light)' },
+      { name: 'theme-color', content: '#111111', media: '(prefers-color-scheme: dark)' },
+    ],
+    links: [],
+  };
+  const hints = extractPlatformColors(snap);
+  const result = resolvePlatformColors(hints, {});
+  assert.equal(result.themeColor, '#ffffff');
+  assert.equal(result.darkThemeColor, '#111111');
+});
+
+test('mask-icon used as themeColor fallback when no theme-color meta', () => {
+  const hints = extractPlatformColors({
+    metas: [],
+    links: [{ rel: 'mask-icon', color: '#5bbad5' }],
+  });
+  const result = resolvePlatformColors(hints, {});
+  assert.equal(result.themeColor, '#5bbad5');
+});
+
+test('theme-color meta takes priority over mask-icon', () => {
+  const hints = extractPlatformColors({
+    metas: [{ name: 'theme-color', content: '#ff0000' }],
+    links: [{ rel: 'mask-icon', color: '#00ff00' }],
+  });
+  const result = resolvePlatformColors(hints, {});
+  assert.equal(result.themeColor, '#ff0000');
+});
+
+test('msapplication-TileColor maps to backgroundColor', () => {
+  const hints = extractPlatformColors({
+    metas: [{ name: 'msapplication-TileColor', content: '#da532c' }],
+    links: [],
+  });
+  const result = resolvePlatformColors(hints, {});
+  assert.equal(result.backgroundColor, '#da532c');
+});
+
+test('does not overwrite existing backgroundColor from manifest', () => {
+  const hints = extractPlatformColors({
+    metas: [{ name: 'msapplication-TileColor', content: '#da532c' }],
+    links: [],
+  });
+  const result = resolvePlatformColors(hints, { backgroundColor: '#from-manifest' });
+  assert.equal(result.backgroundColor, undefined);
+});


### PR DESCRIPTION
## Summary

- Adds `lib/extractors/platform-colors.ts` — pure DOM-snapshot logic, no Playwright dependency, fully unit-testable
- Reads: `<meta name="theme-color">` (with light/dark `media` variants), `<link rel="mask-icon" color>`, `msapplication-TileColor`, `msapplication-navbutton-color`, `apple-mobile-web-app-status-bar-style` (hex only)
- `logo.ts` fills `manifestMeta` gaps via `extractPlatformColors` + `resolvePlatformColors`; manifest values always win
- New `darkThemeColor` field in manifest output when dark-scheme `theme-color` is present

## Test plan

- [x] 18 unit tests in `test/platform-colors.test.ts`, all passing
- [x] `npm test` — 265/265 pass
- [x] `tsc --noEmit` clean