### PR TITLE
feat(colors): extract fill/stroke colors from SVG logo elements (DEM-111)

### DIFF
--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -813,6 +813,27 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       log(color.success(`  ✓ Manifest: ${parts.join(', ')}`));
     }
     } catch (e) { degraded.push('manifest'); console.log(color.warning('  ! Manifest injection: failed (continuing)')); }
+
+    // Inject SVG logo fill/stroke colors as high-confidence palette entries
+    try {
+      if (logoResult.logoColors?.length > 0) {
+        const { convertColor } = await import('../colors.js');
+        for (const hex of logoResult.logoColors) {
+          const existing = colors.palette.find(c => c.normalized === hex);
+          if (existing) {
+            existing.confidence = 'high';
+            if (!existing.sources.includes('logo')) existing.sources.unshift('logo');
+          } else {
+            const converted = convertColor(hex);
+            const entry: any = { color: hex, normalized: hex, count: 10, confidence: 'high', sources: ['logo'] };
+            if (converted) { entry.lch = converted.lch; entry.oklch = converted.oklch; }
+            colors.palette.push(entry);
+          }
+        }
+        log(color.success(`  ✓ SVG logo colors: ${logoResult.logoColors.length} injected`));
+      }
+    } catch (e) { degraded.push('svg-logo-colors'); console.log(color.warning('  ! SVG logo color injection: failed (continuing)')); }
+
     console.log(colors.palette.length > 0 ? color.success(`  ✓ Colors: ${colors.palette.length} found`) : color.warning(`  ! Colors: 0 found`));
     console.log(typography.styles.length > 0 ? color.success(`  ✓ Typography: ${typography.styles.length} styles`) : color.warning(`  ! Typography: 0 styles`));
     console.log(spacing.commonValues.length > 0 ? color.success(`  ✓ Spacing: ${spacing.commonValues.length} values`) : color.warning(`  ! Spacing: 0 values`));

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -295,6 +295,20 @@ export async function extractLogo(page, url) {
           }
         } catch {}
 
+        // Collect fill/stroke attribute colors from all child elements
+        const svgColors: string[] = [];
+        el.querySelectorAll('*').forEach(child => {
+          (['fill', 'stroke'] as const).forEach(attr => {
+            const val = child.getAttribute(attr);
+            if (val && val !== 'none' && val !== 'currentColor' && val !== 'inherit') {
+              const hex = toHex(val);
+              if (hex && /^#[0-9a-f]{6}$/i.test(hex)) svgColors.push(hex);
+            }
+          });
+        });
+        // Deduplicate
+        const uniqueSvgColors = [...new Set(svgColors)];
+
         return {
           source: 'svg',
           context,
@@ -305,6 +319,7 @@ export async function extractLogo(page, url) {
           ariaLabel,
           markup,
           dataUri,
+          svgColors: uniqueSvgColors,
           width: el.width?.baseVal?.value || rect.width,
           height: el.height?.baseVal?.value || rect.height,
           type: logoType,
@@ -608,6 +623,75 @@ export async function extractLogo(page, url) {
   // Merge PWA icons into favicons
   result.favicons = [...result.favicons, ...pwaIcons];
   result.manifest = Object.keys(manifestMeta).length > 0 ? manifestMeta : null;
+
+  // Collect logo colors: inline SVG fill/stroke (already extracted above) + fetched img SVG
+  const inlineSvgColors: string[] = [
+    ...(result.logo?.svgColors ?? []),
+    ...result.instances.flatMap(i => i?.svgColors ?? []),
+  ];
+
+  // For <img src="*.svg"> logos, fetch the SVG and parse fill/stroke attributes
+  const svgImgColors: string[] = [];
+  const svgSrcUrls = new Set<string>();
+  for (const inst of [result.logo, ...result.instances]) {
+    if (inst?.source === 'img' && /\.svg(\?|$)/i.test(inst?.url ?? '')) {
+      svgSrcUrls.add(inst.url);
+    }
+  }
+  if (svgSrcUrls.size > 0) {
+    try {
+      const fetched = await page.evaluate(async (urls: string[]) => {
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 1;
+        const ctx = canvas.getContext('2d');
+
+        function toHex(val: string): string | null {
+          if (!val) return null;
+          if (/^#[0-9a-f]{6}$/i.test(val)) return val.toLowerCase();
+          if (/^#[0-9a-f]{3}$/i.test(val)) return `#${val[1]}${val[1]}${val[2]}${val[2]}${val[3]}${val[3]}`.toLowerCase();
+          if (/^#[0-9a-f]{8}$/i.test(val)) return val.toLowerCase().slice(0, 7);
+          const m = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+          if (m) return `#${parseInt(m[1]).toString(16).padStart(2,'0')}${parseInt(m[2]).toString(16).padStart(2,'0')}${parseInt(m[3]).toString(16).padStart(2,'0')}`;
+          if (ctx) {
+            try {
+              ctx.clearRect(0, 0, 1, 1);
+              ctx.fillStyle = 'rgba(0,0,0,0)';
+              ctx.fillStyle = val;
+              ctx.fillRect(0, 0, 1, 1);
+              const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+              if (a > 0) return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+            } catch {}
+          }
+          return null;
+        }
+
+        const colors: string[] = [];
+        for (const u of urls) {
+          try {
+            const resp = await fetch(u, { credentials: 'omit' });
+            if (!resp.ok) continue;
+            const text = await resp.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(text, 'image/svg+xml');
+            doc.querySelectorAll('*').forEach(el => {
+              (['fill', 'stroke'] as const).forEach(attr => {
+                const val = el.getAttribute(attr);
+                if (val && val !== 'none' && val !== 'currentColor' && val !== 'inherit') {
+                  const hex = toHex(val);
+                  if (hex) colors.push(hex);
+                }
+              });
+            });
+          } catch {}
+        }
+        return [...new Set(colors)].filter(c => /^#[0-9a-f]{6}$/i.test(c));
+      }, [...svgSrcUrls]);
+      svgImgColors.push(...fetched);
+    } catch {}
+  }
+
+  const allLogoColors = [...new Set([...inlineSvgColors, ...svgImgColors])].filter(c => /^#[0-9a-f]{6}$/i.test(c));
+  result.logoColors = allLogoColors;
 
   return result;
 }

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -634,7 +634,7 @@ export async function extractLogo(page, url) {
   const svgImgColors: string[] = [];
   const svgSrcUrls = new Set<string>();
   for (const inst of [result.logo, ...result.instances]) {
-    if (inst?.source === 'img' && /\.svg(\?|$)/i.test(inst?.url ?? '')) {
+    if (inst && inst.source === 'img' && inst.url && /\.svg(\?|$)/i.test(inst.url)) {
       svgSrcUrls.add(inst.url);
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -208,6 +208,7 @@ export interface Logo {
   ariaLabel?: string | null;
   markup?: string | null;
   dataUri?: string | null;
+  svgColors?: string[];
   safeZone?: { top: number; right: number; bottom: number; left: number };
   background?: string | null;
 }


### PR DESCRIPTION
## Problem

67% of analyzed domains had no palette entry with `source: "logo"`. Logo SVGs use `fill`/`stroke` attributes on child elements, not CSS `color`, so they were invisible to the existing CSS-based extractor.

## What this does

**Inline SVGs**: walks all child elements, collects `fill`/`stroke` attribute values, normalizes to hex via the existing canvas `toHex` helper, deduplicates with `Set`.

**`<img src="*.svg">` logos**: after the page evaluate, fetches each SVG URL inside the browser context using `fetch` + `DOMParser`, extracts fill/stroke the same way. Uses `credentials: 'omit'` for cross-origin requests.

**Injection**: collected colors are merged into `colors.palette` with `confidence: "high"` and `sources: ["logo"]`. Existing palette entries are upgraded in-place; new entries get `lch`/`oklch` via `convertColor`. All failure paths are caught and routed to the `degraded` list — never aborts extraction.

## Validation

figma.com: 5 brand colors extracted from SVG fill attributes, none previously in palette.

```
#24cb71  (green)
#ff7237  (orange)
#00b6ff  (blue)
#ff3737  (red)
#874fff  (purple)
```

stripe.com: SVG logo uses `currentColor` throughout — `svgColors: []`, correct. Stripe purple `#533afd` already in palette via CSS extraction.

## Type changes

`Logo.svgColors?: string[]` added to `lib/types.ts`.

Closes DEM-111