### PR TITLE
chore: add dev watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gold:tune": "node tools/gold-tune.mjs",
     "gold:cluster": "node tools/gold-cluster.mjs",
     "gold:analyze": "node tools/gold-analyze.mjs",
+    "dev": "tsc --watch",
     "build": "tsc && cp package.json dist/package.json && mkdir -p dist/lib/ml && cp lib/ml/model.onnx lib/ml/meta.json dist/lib/ml/",
     "lint": "eslint ."
   },


### PR DESCRIPTION
Adds `npm run dev` as a `tsc --watch` alias so core-lib changes reflect immediately during development without manual rebuilds.