### PR TITLE
feat: add --key flag for cloud sync

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,12 +82,16 @@ program
   .option("--locale <string>", "Browser locale for fingerprint, e.g. en-GB, fi-FI; affects content only if the site reacts to Accept-Language (default: en-US)")
   .option("--timezone <string>", "Browser timezone for fingerprint, e.g. Europe/Helsinki; affects content only if the site reacts to timezone (default: America/New_York)")
   .option("--accept-language <string>", "Custom Accept-Language header value")
+  .option("--key <string>", "Dembrandt API key for syncing extractions to your account (falls back to DEMBRANDT_KEY env var)")
   .option("--screen-size <WxH>", "Physical screen resolution to report, e.g. 1920x1080 (default: 1920x1080)")
   .action(async (input, paths, opts) => {
     let url = input;
     if (!url.startsWith("http://") && !url.startsWith("https://")) {
       url = "https://" + url;
     }
+
+    // Resolve API key: --key flag takes precedence over env var
+    const apiKey: string | undefined = opts.key ?? process.env.DEMBRANDT_KEY;
 
     if (opts.approve && !opts.compare) {
       console.error(color.warning("! --approve has no effect without --compare <file>."));
@@ -487,6 +491,35 @@ program
           );
         } catch (err) {
           console.log(color.warning(`! Could not write HTML report: ${err.message}`));
+        }
+      }
+
+      // Sync to cloud if --key / DEMBRANDT_KEY is set
+      if (apiKey) {
+        try {
+          const payload = JSON.stringify(result);
+          const byteSize = Buffer.byteLength(payload, "utf8");
+          const MAX_BYTES = 150_000;
+          if (byteSize > MAX_BYTES) {
+            console.error(color.warning(`! Extraction too large to sync (${byteSize} bytes > ${MAX_BYTES}). Skipping cloud upload.`));
+          } else {
+            const syncRes = await fetch("https://dembrandt.com/api/extractions", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+              },
+              body: payload,
+            });
+            if (syncRes.ok) {
+              savedNotices.push(chalk.dim(`☁  Synced to your account (--key)`));
+            } else {
+              const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
+              console.error(color.warning(`! Cloud sync failed: ${err.error ?? syncRes.statusText}`));
+            }
+          }
+        } catch (syncErr) {
+          console.error(color.warning(`! Cloud sync error: ${syncErr.message}`));
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.19.10",
+  "version": "0.20.0",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gold:tune": "node tools/gold-tune.mjs",
     "gold:cluster": "node tools/gold-cluster.mjs",
     "gold:analyze": "node tools/gold-analyze.mjs",
+    "dev": "tsc --watch",
     "build": "tsc && cp package.json dist/package.json && mkdir -p dist/lib/ml && cp lib/ml/model.onnx lib/ml/meta.json dist/lib/ml/",
     "lint": "eslint ."
   },


### PR DESCRIPTION
Adds `--key <string>` flag for syncing extractions to the user's Dembrandt account.

- Falls back to `DEMBRANDT_KEY` env var if flag is not passed
- Size-gated at 150KB before upload attempt
- Fails gracefully — sync errors print a warning but never block extraction output
- `/api/extractions` endpoint not yet live; sync will warn until it ships

Note: intentionally undocumented in --help description pending endpoint launch.