### PR TITLE
ci: wire eslint into smoke + release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
       - name: Publish to npm (skip if already published manually)
         run: |
           PKG=$(node -p "require('./package.json').name + '@' + require('./package.json').version")

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run unit tests
         run: npm test
 


### PR DESCRIPTION
eslint was an npm script that no workflow ran, so lint was never enforced in CI. Three intended quality gates (lint / drift / conformance) but only the test suite actually gated.

This wires the cheapest one:
- `smoke.yml` unit job: add `npm run lint` (next to `tsc --noEmit` and `npm test`)
- `release.yml`: add type-check + lint + tests before `npm publish` (previously published after only `npm ci`)

Lint passes today (0 errors, 199 pre-existing `any` warnings on the per-module ratchet — warnings don't fail eslint), so this gates future errors without blocking current work.

Not in scope (need committed golden baselines + determinism work first):
- `qa.mjs --diff --ci` value-regression gate (CI only runs `--baseline` today, so token drift passes silently)
- `gold:*` ML accuracy suite (fully manual)