### PR TITLE
feat(colors): semantic bg/text + accent tokens, dominant body font

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -74,6 +74,28 @@ export async function extractColors(page) {
       return s;
     }
 
+    // HSL hue in degrees [0,360) from an opaque hex; -1 for achromatic colours.
+    // Used to keep the accent token on a genuinely different hue from primary.
+    function hueOf(hex) {
+      if (!hex || !hex.startsWith('#')) return -1;
+      const r = parseInt(hex.slice(1, 3), 16) / 255;
+      const g = parseInt(hex.slice(3, 5), 16) / 255;
+      const b = parseInt(hex.slice(5, 7), 16) / 255;
+      const max = Math.max(r, g, b), min = Math.min(r, g, b);
+      const d = max - min;
+      if (d === 0) return -1;
+      let h;
+      if (max === r) h = (((g - b) / d) % 6 + 6) % 6;
+      else if (max === g) h = (b - r) / d + 2;
+      else h = (r - g) / d + 4;
+      h *= 60;
+      return h < 0 ? h + 360 : h;
+    }
+    function hueDistance(a, b) {
+      const diff = Math.abs(a - b) % 360;
+      return diff > 180 ? 360 - diff : diff;
+    }
+
     function isValidColorValue(value) {
       if (!value) return false;
       if (value.includes("calc(") || value.includes("clamp(") || value.includes("var(")) {
@@ -294,6 +316,23 @@ export async function extractColors(page) {
       }
     });
 
+    // Canonical page surface + body text. Read the real computed values off the
+    // document body rather than inferring from the palette: these are the actual
+    // background the content sits on and the dominant body text colour, which is
+    // exactly what a design system means by background/text tokens. The role
+    // data already exists on palette entries; this promotes it to a named token.
+    const surfaceEl = document.body || document.documentElement;
+    if (surfaceEl) {
+      let bgNode: Element | null = surfaceEl;
+      for (let hop = 0; hop < 5 && bgNode; hop++) {
+        const bg = getComputedStyle(bgNode).backgroundColor;
+        if (bg && colorAlpha(bg) >= 0.9) { semanticColors.background = bg; break; }
+        bgNode = bgNode.parentElement;
+      }
+      const txt = getComputedStyle(surfaceEl).color;
+      if (txt && colorAlpha(txt) >= 0.5) semanticColors.text = txt;
+    }
+
     // Use most-common CTA background as primary if class-based detection missed it
     // Require at least 2 CTA occurrences to avoid single "Sign up" buttons dominating
     if (!semanticColors.primary && ctaPrimaryMap.size > 0) {
@@ -472,6 +511,24 @@ export async function extractColors(page) {
             || (b.ch - a.ch))[0];
         if (chromatic) semanticColors.primary = chromatic.c.color;
       }
+    }
+
+    // Accent vs primary. A brand often runs a primary alongside a distinct, more
+    // saturated accent (e.g. a cyan brand mark beside a navy primary). Surface
+    // the accent as its own token so the two are not collapsed: the most
+    // chromatic high-/medium-confidence palette colour whose hue is clearly
+    // different from primary. Additive only — never alters the primary pick,
+    // which already resolves most brands correctly.
+    if (semanticColors.primary) {
+      const primaryNorm = normalizeColor(semanticColors.primary);
+      const primaryHue = typeof primaryNorm === 'string' ? hueOf(primaryNorm) : -1;
+      const accent = perceptuallyDeduped
+        .filter(c => c.confidence !== 'low')
+        .map(c => ({ c, ch: chroma(c.normalized), hue: hueOf(c.normalized) }))
+        .filter(x => x.ch > 0.25 && x.c.normalized !== primaryNorm &&
+          (primaryHue < 0 || hueDistance(x.hue, primaryHue) > 30))
+        .sort((a, b) => b.ch - a.ch)[0];
+      if (accent) semanticColors.accent = accent.c.color;
     }
 
     // Full detected set — every colour that passed the alpha>=0.3 gate, with NO

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -329,6 +329,10 @@ export async function extractColors(page) {
         if (bg && colorAlpha(bg) >= 0.9) { semanticColors.background = bg; break; }
         bgNode = bgNode.parentElement;
       }
+      // Body and html often paint nothing, leaving the default white canvas the
+      // user actually sees. Dark sites always set an explicit dark background, so
+      // an unset chain means the rendered backdrop is white.
+      if (!semanticColors.background) semanticColors.background = 'rgb(255, 255, 255)';
       const txt = getComputedStyle(surfaceEl).color;
       if (txt && colorAlpha(txt) >= 0.5) semanticColors.text = txt;
     }

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -1,6 +1,22 @@
 import type { VariableFontAxis } from '../types.js';
 
 /**
+ * Pick the dominant body font family from a map of family -> total body text
+ * length. Highest text coverage wins; ties keep the first-seen family for a
+ * deterministic result. Returns null when no family carried any body text. Pure
+ * and exported so the body-font disambiguation is unit-testable without a
+ * browser.
+ */
+export function pickBodyFamily(weights: Record<string, number>): string | null {
+  let best: string | null = null;
+  let max = 0;
+  for (const [family, weight] of Object.entries(weights || {})) {
+    if (weight > max) { max = weight; best = family; }
+  }
+  return best;
+}
+
+/**
  * Parse `font-variation-settings` strings (e.g. `"wght" 600, "slnt" -4`) into
  * per-axis ranges across the page. Pure and exported so it is unit-testable
  * without a browser. Only explicit variation settings count — we do not infer
@@ -45,6 +61,10 @@ export async function extractTypography(page) {
     const seen = new Map();
     const variationSettings: string[] = [];
     const featureSettings: string[] = [];
+    // family -> total directly-contained visible body text length. Drives the
+    // dominant-body-font pick: among everything the heuristic labels "body", the
+    // family carrying the most reading text is the real body font.
+    const familyBodyWeight: Record<string, number> = {};
     const sources = {
       googleFonts: [],
       adobeFonts: false,
@@ -176,6 +196,14 @@ export async function extractTypography(page) {
         context = "ui";
       }
 
+      if (context === "body") {
+        let directTextLen = 0;
+        el.childNodes.forEach((node: ChildNode) => {
+          if (node.nodeType === 3) directTextLen += (node.textContent || "").trim().length;
+        });
+        if (directTextLen > 0) familyBodyWeight[family] = (familyBodyWeight[family] || 0) + directTextLen;
+      }
+
       const key = `${family}|${size}|${weight}|${context}|${letterSpacing}|${textTransform}`;
       if (seen.has(key)) return;
 
@@ -218,6 +246,7 @@ export async function extractTypography(page) {
       },
       variationSettings,
       featureSettings,
+      familyBodyWeight,
     };
   });
 
@@ -225,6 +254,19 @@ export async function extractTypography(page) {
   // unit-testable. Attach to sources only when present — no empty arrays.
   const variableAxes = parseVariableAxes(data.variationSettings);
   const openTypeFeatures = parseOpenTypeFeatures(data.featureSettings);
+
+  // Disambiguate the body font. The size/tag heuristic labels every non-special
+  // element "body", so a decorative face on one stray element can masquerade as
+  // the body font. Keep the "body" label only on the dominant reading-text
+  // family; demote the rest to the generic "text" role (still text, not the
+  // canonical body font). This makes the body token reflect the dominant
+  // computed font rather than whichever element fell through the heuristic first.
+  const bodyFamily = pickBodyFamily(data.familyBodyWeight);
+  if (bodyFamily) {
+    for (const style of data.styles) {
+      if (style.context === "body" && style.family !== bodyFamily) style.context = "text";
+    }
+  }
 
   return {
     styles: data.styles,

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -1,19 +1,35 @@
 import type { VariableFontAxis } from '../types.js';
 
 /**
- * Pick the dominant body font family from a map of family -> total body text
- * length. Highest text coverage wins; ties keep the first-seen family for a
- * deterministic result. Returns null when no family carried any body text. Pure
- * and exported so the body-font disambiguation is unit-testable without a
+ * Pick the canonical body font family from two signals: the font computed on
+ * `document.body` (the inherited base) and per-family body-text coverage.
+ *
+ * Trust the inherited base only when page text actually renders in it. That
+ * makes apple.com resolve to SF Pro Text even though large lead paragraphs
+ * override to SF Pro Display and out-volume it. But a site that sets no
+ * font-family on <body> inherits the UA default (e.g. "Times"), which no
+ * visible text uses — there the most-used body family is the real answer (e.g.
+ * nyt-franklin on nytimes.com, not the UA "Times"). Coverage ties keep the
+ * first-seen family for determinism. Returns null when neither signal yields a
+ * family. Pure and exported so the disambiguation is unit-testable without a
  * browser.
  */
-export function pickBodyFamily(weights: Record<string, number>): string | null {
+// UA-default serif names a page inherits when <body> sets no font-family. They
+// appear even on sites whose real text is a custom font, so they must never be
+// trusted as the body font over actual coverage.
+const UA_DEFAULT_FAMILIES = new Set(['times', 'times new roman', 'serif']);
+
+export function pickBodyFamily(bodyComputedFamily: string | null, weights: Record<string, number>): string | null {
+  const base = (bodyComputedFamily || '').trim();
+  const w = weights || {};
+  if (base && !UA_DEFAULT_FAMILIES.has(base.toLowerCase()) && (w[base] || 0) > 0) return base;
   let best: string | null = null;
   let max = 0;
-  for (const [family, weight] of Object.entries(weights || {})) {
+  for (const [family, weight] of Object.entries(w)) {
     if (weight > max) { max = weight; best = family; }
   }
-  return best;
+  if (best) return best;
+  return base || null;
 }
 
 /**
@@ -196,7 +212,12 @@ export async function extractTypography(page) {
         context = "ui";
       }
 
-      if (context === "body") {
+      // Vote for the dominant body font only with normal-size running text. Large
+      // non-heading marketing text (hero copy <56px) also lands in "body" via the
+      // size heuristic; counting it lets a display face out-vote the real body
+      // font on heading-heavy pages (e.g. SF Pro Display beating SF Pro Text on
+      // apple.com). Restrict the vote to the typical reading-copy range.
+      if (context === "body" && size >= 11 && size <= 24) {
         let directTextLen = 0;
         el.childNodes.forEach((node: ChildNode) => {
           if (node.nodeType === 3) directTextLen += (node.textContent || "").trim().length;
@@ -237,6 +258,13 @@ export async function extractTypography(page) {
       return bSize - aSize;
     });
 
+    // The font inherited by document.body is the canonical base body font.
+    let bodyComputedFamily: string | null = null;
+    if (document.body) {
+      const fam = getComputedStyle(document.body).fontFamily.split(",")[0].replace(/['"]/g, "").trim();
+      if (fam) bodyComputedFamily = fam;
+    }
+
     return {
       styles: result,
       sources: {
@@ -247,6 +275,7 @@ export async function extractTypography(page) {
       variationSettings,
       featureSettings,
       familyBodyWeight,
+      bodyComputedFamily,
     };
   });
 
@@ -261,7 +290,7 @@ export async function extractTypography(page) {
   // family; demote the rest to the generic "text" role (still text, not the
   // canonical body font). This makes the body token reflect the dominant
   // computed font rather than whichever element fell through the heuristic first.
-  const bodyFamily = pickBodyFamily(data.familyBodyWeight);
+  const bodyFamily = pickBodyFamily(data.bodyComputedFamily, data.familyBodyWeight);
   if (bodyFamily) {
     for (const style of data.styles) {
       if (style.context === "body" && style.family !== bodyFamily) style.context = "text";

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -251,9 +251,12 @@ function displayColors(colors) {
       try { onSwatch = ' on:' + chalk.bgHex(hex)(chalk.hex(onColor)(' Aa ')); } catch {}
     }
 
+    // Show CSS variable names / roles in full. They are design-token identifiers
+    // (e.g. --pm-radio-color); truncating them to fit a 15-col gutter hid the part
+    // that identifies the token. Short labels still pad for alignment; long ones
+    // extend and push the rgb column right rather than getting clipped.
     const rawLabel = label || (role && role !== 'palette' ? role : '');
-    const truncated = rawLabel.length > 14 ? rawLabel.slice(0, 13) + '…' : rawLabel;
-    const labelText = chalk.dim(truncated.padEnd(15));
+    const labelText = chalk.dim(rawLabel.length > 15 ? rawLabel + ' ' : rawLabel.padEnd(15));
     const rgbText = chalk.dim((rgb || '').padEnd(20));
 
     const hoverText = (hover && role === 'accent') ? chalk.dim(` hover:${hover}`) : '';

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -36,13 +36,19 @@
 /**
  * dembrandt output contract version. Bump per the policy documented above.
  *
+ *  1.2.0 — added colors.semantic.background, colors.semantic.text and
+ *          colors.semantic.accent (canonical page surface, body text, and a
+ *          hue-distinct brand accent). Typography gains a "text" context value
+ *          for body-eligible text whose family is not the dominant body font.
+ *          Additive: 1.1.x consumers ignore the new keys and treat "text" as
+ *          body-like.
  *  1.1.0 — added SpacingValue.display, a guaranteed "Npx" string for rendering.
  *          Additive: 1.0.x consumers ignore it. Read `display` instead of
  *          formatting `px`, whose type narrows from "16px" to a number through
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.1.0';
+export const SCHEMA_VERSION = '1.2.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -275,7 +275,7 @@ async function main() {
 
   (server.tool as any)(
     "get_color_palette",
-    "Extract brand colors from a live website. Returns semantic colors (primary, secondary, accent), full palette ranked by usage frequency and confidence (high/medium/low), CSS custom properties with their design-system names, and hover/focus state colors discovered by simulating real user interactions. Each color in hex, RGB, LCH, and OKLCH. Returns a job_id by default — use get_job_status to poll for the result.",
+    "Extract brand colors from a live website. Returns semantic colors (primary, secondary, accent, plus background and text promoted from the page surface and body text), full palette ranked by usage frequency and confidence (high/medium/low), CSS custom properties with their design-system names, and hover/focus state colors discovered by simulating real user interactions. Each color in hex, RGB, LCH, and OKLCH. Returns a job_id by default — use get_job_status to poll for the result.",
     {
       url, slow, sync,
       darkMode: z.boolean().optional().default(false).describe("Also extract dark mode palette"),
@@ -285,7 +285,7 @@ async function main() {
 
   (server.tool as any)(
     "get_typography",
-    "Extract typography from a live website. Returns every font family with its fallback stack, the complete type scale grouped by context (heading, body, button, link, caption) with pixel and rem sizes, weights, line heights, letter spacing, and text transforms. Also reports font sources: Google Fonts URLs, Adobe Fonts usage, and variable font detection. Returns a job_id by default — use get_job_status to poll for the result.",
+    "Extract typography from a live website. Returns every font family with its fallback stack, the complete type scale grouped by context (heading, body, text, button, link, caption) with pixel and rem sizes, weights, line heights, letter spacing, and text transforms. The body context marks the dominant reading-text font; text marks other body-eligible copy. Also reports font sources: Google Fonts URLs, Adobe Fonts usage, and variable font detection. Returns a job_id by default — use get_job_status to poll for the result.",
     { url, slow, sync },
     toolHandler((d) => ({ url: d.url, typography: d.typography })),
   );

--- a/test/colors-fixture.test.ts
+++ b/test/colors-fixture.test.ts
@@ -51,6 +51,11 @@ async function paletteHexes(): Promise<string[]> {
   return palette.map((c: { normalized: string }) => c.normalized.toLowerCase());
 }
 
+async function semantic(): Promise<Record<string, string>> {
+  const { semantic } = await extractColors(page!);
+  return semantic;
+}
+
 // Skip (visibly, never silently pass) when the chromium binary is absent — e.g.
 // a browser-less `npm test`. CI installs the browser, so these assert there.
 function browserUnavailable(t: { skip: (m?: string) => void }): boolean {
@@ -75,3 +80,46 @@ test('neutral layout fill on a majority of elements is filtered as structural', 
   const hexes = await paletteHexes();
   assert.ok(!hexes.includes(GREY), `expected ${GREY} filtered as structural, got ${hexes.join(' ')}`);
 });
+
+test('semantic background + text are promoted from the body surface', async (t) => {
+  if (browserUnavailable(t)) return;
+  const sem = await semantic();
+  // body is background:#ffffff;color:#111111 in the fixture -> computed rgb().
+  assert.equal(sem.background, 'rgb(255, 255, 255)', `background was ${sem.background}`);
+  assert.equal(sem.text, 'rgb(17, 17, 17)', `text was ${sem.text}`);
+});
+
+// Accent vs primary: a navy CTA primary plus a hue-distinct orange brand mark.
+// The accent token must surface the orange as its own colour, not collapse it
+// into primary. Its own page so the primary/accent split is isolated.
+const PRIMARY = '#1d3a8a'; // navy CTA, hue ~224
+const ORANGE = '#e8590c';  // saturated brand orange, hue ~24 -> >30 from navy
+const ACCENT_FIXTURE =
+  `<!doctype html><html><body style="margin:0;background:#ffffff;color:#111111">` +
+  Array.from({ length: 3 }, () => `<button class="btn-primary" style="background:${PRIMARY};color:#fff">Buy now</button>`).join('') +
+  Array.from({ length: 4 }, () => `<a class="brand-mark" style="color:${ORANGE}">brand</a>`).join('') +
+  `</body></html>`;
+
+test('accent token surfaces a hue-distinct brand colour beside the primary', async (t) => {
+  if (browserUnavailable(t)) return;
+  if (!browser) { t.skip('no browser'); return; }
+  const accentPage = await browser.newPage();
+  try {
+    await accentPage.setContent(ACCENT_FIXTURE, { waitUntil: 'load' });
+    const { semantic } = await extractColors(accentPage);
+    assert.equal(toOpaqueHex(semantic.primary), PRIMARY, `primary was ${semantic.primary}`);
+    assert.equal(toOpaqueHex(semantic.accent), ORANGE, `accent was ${semantic.accent}`);
+  } finally {
+    await accentPage.close().catch(() => {});
+  }
+});
+
+// rgb() / #hex -> lowercase 6-digit hex for comparison.
+function toOpaqueHex(color: string | undefined): string | undefined {
+  if (!color) return color;
+  if (color.startsWith('#')) return color.toLowerCase();
+  const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+  if (!m) return color;
+  const h = (n: string) => Number(n).toString(16).padStart(2, '0');
+  return `#${h(m[1])}${h(m[2])}${h(m[3])}`;
+}

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -2,13 +2,15 @@
   "url": "https://synthetic.example.com",
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
-    "schemaVersion": "1.1.0",
+    "schemaVersion": "1.2.0",
     "dembrandtVersion": "0.17.0"
   },
   "colors": {
     "semantic": {
       "primary": "#1a73e8",
-      "background": { "color": "#ffffff" }
+      "background": { "color": "#ffffff" },
+      "text": "#202124",
+      "accent": "#e8590c"
     },
     "palette": [
       { "color": "#1a73e8", "count": 120, "confidence": "high" },

--- a/test/typography.test.ts
+++ b/test/typography.test.ts
@@ -39,16 +39,34 @@ test('parseOpenTypeFeatures excludes features explicitly switched off', () => {
   assert.deepEqual(f, ['ss01']);
 });
 
-test('pickBodyFamily picks the family carrying the most body text', () => {
-  // A decorative face used once must not beat the dominant reading-text family.
-  assert.equal(pickBodyFamily({ 'SF Pro Text': 5000, 'SF Pro Display': 400, fontIvoryLl: 120 }), 'SF Pro Text');
+test('pickBodyFamily trusts the body base font when text renders in it', () => {
+  // Apple case: large lead paragraphs (Display) out-volume the 17px copy (Text)
+  // in the body bucket, but body's inherited base font is the canonical answer
+  // and real text uses it, so it wins despite lower coverage.
+  assert.equal(pickBodyFamily('SF Pro Text', { 'SF Pro Display': 5000, 'SF Pro Text': 400 }), 'SF Pro Text');
 });
 
-test('pickBodyFamily breaks ties on first-seen for determinism', () => {
-  assert.equal(pickBodyFamily({ Inter: 100, Roboto: 100 }), 'Inter');
+test('pickBodyFamily ignores the UA-default serif even when a sliver of text uses it', () => {
+  // NYT case: <body> sets no font-family -> UA default "Times". A little
+  // unstyled text renders in Times, but the real body font is the most-used
+  // custom family, not the browser default.
+  assert.equal(pickBodyFamily('Times', { 'nyt-franklin': 4000, Times: 200 }), 'nyt-franklin');
 });
 
-test('pickBodyFamily returns null when no family carried body text', () => {
-  assert.equal(pickBodyFamily({}), null);
-  assert.equal(pickBodyFamily({ Inter: 0 }), null);
+test('pickBodyFamily falls back to highest body-text coverage when body has no family', () => {
+  assert.equal(pickBodyFamily(null, { 'SF Pro Text': 5000, fontIvoryLl: 120 }), 'SF Pro Text');
+  assert.equal(pickBodyFamily('', { Inter: 100, Roboto: 50 }), 'Inter');
+});
+
+test('pickBodyFamily uses the body base as last resort when no text was measured', () => {
+  assert.equal(pickBodyFamily('Georgia', {}), 'Georgia');
+});
+
+test('pickBodyFamily breaks coverage ties on first-seen for determinism', () => {
+  assert.equal(pickBodyFamily(null, { Inter: 100, Roboto: 100 }), 'Inter');
+});
+
+test('pickBodyFamily returns null when neither signal yields a family', () => {
+  assert.equal(pickBodyFamily(null, {}), null);
+  assert.equal(pickBodyFamily('', { Inter: 0 }), null);
 });

--- a/test/typography.test.ts
+++ b/test/typography.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseVariableAxes, parseOpenTypeFeatures } from '../lib/extractors/typography.js';
+import { parseVariableAxes, parseOpenTypeFeatures, pickBodyFamily } from '../lib/extractors/typography.js';
 
 /**
  * The typography extractor reads computed styles in the browser, but the
@@ -37,4 +37,18 @@ test('parseOpenTypeFeatures dedupes and sorts enabled tags', () => {
 test('parseOpenTypeFeatures excludes features explicitly switched off', () => {
   const f = parseOpenTypeFeatures(['"ss01" on, "tnum" off', '"kern" 0']);
   assert.deepEqual(f, ['ss01']);
+});
+
+test('pickBodyFamily picks the family carrying the most body text', () => {
+  // A decorative face used once must not beat the dominant reading-text family.
+  assert.equal(pickBodyFamily({ 'SF Pro Text': 5000, 'SF Pro Display': 400, fontIvoryLl: 120 }), 'SF Pro Text');
+});
+
+test('pickBodyFamily breaks ties on first-seen for determinism', () => {
+  assert.equal(pickBodyFamily({ Inter: 100, Roboto: 100 }), 'Inter');
+});
+
+test('pickBodyFamily returns null when no family carried body text', () => {
+  assert.equal(pickBodyFamily({}), null);
+  assert.equal(pickBodyFamily({ Inter: 0 }), null);
 });


### PR DESCRIPTION
Closes the three color/typography gaps from the cross-tool benchmark (dembrandt vs designlang vs ai.to.design), plus battle-test hardening and surface sync. All additive to the output contract.

## Core changes

**1. `colors.semantic.background` + `colors.semantic.text`** — promote the real computed page surface and body text colour to canonical tokens (the single largest semantic gap, 36% vs 69%). Read off `document.body`; fall back to the default white canvas when body/html paint nothing opaque (so transparent-body sites like stripe still get a token).

**2. Dominant body font** — read the canonical base font off `document.body` rather than guessing from whichever element fell through the size/tag heuristic. Trust it only when page text actually renders in it, and never trust the UA-default serif (`Times`) a fontless `<body>` inherits; restrict the coverage fallback vote to 11-24px reading copy. The `body` label stays on that family; other body-eligible copy demotes to a `text` context.

**3. `colors.semantic.accent`** — surface the most chromatic high/medium-confidence palette colour whose hue is >30 deg from primary (the existing same-hue-family boundary). Additive; never alters the primary pick.

## Surface sync

- **terminal**: stop truncating CSS variable / role labels to a 15-col gutter (`--pm-radio-color` was shown as `--pm-radio-co…`); long token names render in full.
- **mcp-server**: `get_color_palette` / `get_typography` descriptions updated for the new background/text tokens and the `text` context. The data already flowed through automatically (both tools return the full `colors` / `typography` object); only the LLM-facing descriptions needed syncing.

## Contract

`SCHEMA_VERSION` 1.1.0 -> 1.2.0 (additive, meaningful). 1.1.x consumers ignore the new keys and treat `text` as body-like. New semantic keys flow through every formatter automatically (terminal, dtcg, html, pdf, markdown, drift) since they iterate `colors.semantic` generically — same for dembrandt-next `/app`, which types `semantic` as a generic record.

## Verification

- 301/301 unit tests pass: real-chromium fixture tests (semantic bg/text, accent vs primary) + pure `pickBodyFamily` unit tests covering the apple, nytimes, and fallback cases.
- Lint clean (no new warnings).
- Battle-tested across industries — apple `SF Pro Text`, stripe `sohne-var`, nytimes `nyt-franklin`, dembrandt `ui-sans-serif`; bg correct on each (white for light sites, black for dembrandt's dark theme); accent distinct from primary (stripe orange vs blurple, nytimes blue vs red).

## Out of scope (separate benchmark items)
z-index governance token, t-shirt-size semantic labels.