### PR TITLE
feat(ci): GitHub Actions annotations for the drift gate (DEM-83)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import { generatePDF } from "./lib/formatters/pdf.js";
 import { generateDesignMd } from "./lib/formatters/markdown.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
 import { resolveCompare } from "./lib/compare.js";
+import { emitDriftAnnotations } from "./lib/ci-annotations.js";
 import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
@@ -460,6 +461,11 @@ program
             // CI gate: drift fails the run, but the report still writes first.
             process.exitCode = EXIT.DRIFT;
           }
+          // Under GitHub Actions, surface a failing drift gate inline on the PR
+          // via workflow-command annotations (DEM-83). No-op locally. Gated on
+          // the gate actually failing, so an --approve'd local baseline (which
+          // passes despite a drift report) emits nothing.
+          if (process.exitCode === EXIT.DRIFT) emitDriftAnnotations(report);
         } catch (err) {
           console.log(color.warning(`! Could not compare against baseline: ${err.message}`));
         }

--- a/lib/ci-annotations.ts
+++ b/lib/ci-annotations.ts
@@ -1,0 +1,90 @@
+/**
+ * GitHub Actions workflow-command annotations for the drift gate (DEM-83).
+ *
+ * When `dembrandt --compare` runs inside GitHub Actions and detects drift, emit
+ * `::error::`/`::warning::` workflow commands so the failure renders inline on
+ * the PR's Checks tab instead of being buried in log text. The status check
+ * (pass/fail) is already carried by the process exit code (EXIT.DRIFT), so this
+ * module only adds the inline annotations.
+ *
+ * Severity maps from the drift change kind: a baseline token that drifted
+ * (`changed`) or vanished (`removed`) is a violation against the brand baseline
+ * -> error; a token that newly appeared (`added`) is review-worthy but not
+ * itself a breach -> warning. This mirrors the example in the ticket ("color is
+ * off-palette" -> error, "new colours appeared" -> warning).
+ *
+ * Not yet wired: `file=`/`line=` source locations (needs the drift source-scan,
+ * DEM-33) and assertion-driven severity (DEM-81). Both become extra inputs here
+ * without changing the command syntax below.
+ */
+
+import type { DriftReport, DriftChange } from "./drift.js";
+
+/** GitHub Actions sets GITHUB_ACTIONS=true on every step. Only there do workflow
+ * commands render; emitting them anywhere else is noise. */
+export function isGitHubActions(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.GITHUB_ACTIONS === "true";
+}
+
+// Workflow-command escaping (per actions/toolkit). Message data and property
+// values escape different character sets; applying the wrong one lets a value
+// containing a comma or newline corrupt the command.
+function escapeData(s: string): string {
+  return s.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function escapeProperty(s: string): string {
+  return s
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
+type Severity = "error" | "warning";
+
+function severityForKind(kind: DriftChange["kind"]): Severity {
+  return kind === "added" ? "warning" : "error";
+}
+
+function changeMessage(c: DriftChange): string {
+  const move =
+    c.before && c.after ? ` ${c.before} -> ${c.after}`
+    : c.before ? ` ${c.before} removed`
+    : c.after ? ` ${c.after} new`
+    : "";
+  const delta = typeof c.delta === "number" ? `, delta ${Math.round(c.delta * 10) / 10}` : "";
+  return `${c.label}${move} (token-drift:${c.category}${delta})`;
+}
+
+/**
+ * Build the workflow-command lines for a failing drift report. Pure: returns the
+ * lines; the caller prints them to stdout (workflow commands are read from
+ * stdout). Returns an empty array for a stable report.
+ */
+export function driftAnnotations(report: DriftReport): string[] {
+  if (report.status !== "drift") return [];
+  const lines: string[] = [];
+  const title = `Design drift ${report.score} exceeds threshold ${report.threshold}`;
+  const summary = `${report.summary.changed} changed, ${report.summary.added} added, ${report.summary.removed} removed`;
+  lines.push(`::error title=${escapeProperty(title)}::${escapeData(summary)}`);
+  for (const c of report.changes) {
+    lines.push(`::${severityForKind(c.kind)}::${escapeData(changeMessage(c))}`);
+  }
+  return lines;
+}
+
+/**
+ * Emit drift annotations to stdout when running under GitHub Actions. No-op
+ * otherwise (plain CLI output already covers local runs). `log`/`env` are
+ * injectable for tests.
+ */
+export function emitDriftAnnotations(
+  report: DriftReport,
+  log: (line: string) => void = console.log,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!isGitHubActions(env)) return;
+  for (const line of driftAnnotations(report)) log(line);
+}

--- a/test/ci-annotations.test.ts
+++ b/test/ci-annotations.test.ts
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isGitHubActions, driftAnnotations, emitDriftAnnotations } from '../lib/ci-annotations.js';
+import type { DriftReport } from '../lib/drift.js';
+
+function report(partial: Partial<DriftReport> = {}): DriftReport {
+  return {
+    score: 42,
+    status: 'drift',
+    threshold: 20,
+    summary: { changed: 1, added: 1, removed: 1 },
+    categories: [],
+    changes: [
+      { category: 'color', kind: 'changed', label: '#2564ea', before: '#2564ea', after: '#1050d0', delta: 6.2 },
+      { category: 'color', kind: 'added', label: '#00a2e1', after: '#00a2e1' },
+      { category: 'typography', kind: 'removed', label: 'body', before: 'Inter 16px' },
+    ],
+    ...partial,
+  };
+}
+
+test('isGitHubActions reads GITHUB_ACTIONS=true exactly', () => {
+  assert.equal(isGitHubActions({ GITHUB_ACTIONS: 'true' }), true);
+  assert.equal(isGitHubActions({ GITHUB_ACTIONS: 'false' }), false);
+  assert.equal(isGitHubActions({}), false);
+});
+
+test('driftAnnotations emits nothing for a stable report', () => {
+  assert.deepEqual(driftAnnotations(report({ status: 'stable' })), []);
+});
+
+test('driftAnnotations leads with an error summary carrying score + threshold', () => {
+  const lines = driftAnnotations(report());
+  assert.match(lines[0], /^::error title=Design drift 42 exceeds threshold 20::/);
+  assert.match(lines[0], /1 changed, 1 added, 1 removed/);
+});
+
+test('driftAnnotations maps changed/removed to error and added to warning', () => {
+  const lines = driftAnnotations(report()).slice(1);
+  assert.match(lines[0], /^::error::#2564ea #2564ea -> #1050d0 \(token-drift:color, delta 6.2\)/);
+  assert.match(lines[1], /^::warning::#00a2e1 #00a2e1 new \(token-drift:color\)/);
+  assert.match(lines[2], /^::error::body Inter 16px removed \(token-drift:typography\)/);
+});
+
+test('driftAnnotations escapes commas and colons in the title property', () => {
+  const lines = driftAnnotations(report({ threshold: 20 }));
+  // title contains no comma/colon here, but the summary (data) keeps its commas
+  // raw — only the title property is property-escaped. Guard the contract: no
+  // raw comma leaks into the property segment before the second ::.
+  const prop = lines[0].slice('::error '.length, lines[0].indexOf('::', 2));
+  assert.ok(!prop.includes(','), `property segment must not contain a raw comma: ${prop}`);
+});
+
+test('emitDriftAnnotations prints under GitHub Actions, no-op otherwise', () => {
+  const out: string[] = [];
+  emitDriftAnnotations(report(), (l) => out.push(l), { GITHUB_ACTIONS: 'true' });
+  assert.equal(out.length, 4); // summary + 3 changes
+  const out2: string[] = [];
+  emitDriftAnnotations(report(), (l) => out2.push(l), {});
+  assert.equal(out2.length, 0);
+});


### PR DESCRIPTION
Closes DEM-83. When `dembrandt --compare` detects drift inside GitHub Actions, emit `::error::`/`::warning::` workflow-command annotations so the failure renders inline on the PR Checks tab instead of being buried in log text. The pass/fail status check is already carried by the `EXIT.DRIFT` exit code; this PR adds the inline annotations.

## What it does

```
::error title=Design drift 85 exceeds threshold 10::29 changed, 15 added, 75 removed
::error::#2564ea #2564ea -> #1050d0 (token-drift:color, delta 6.2)
::warning::#00a2e1 #00a2e1 new (token-drift:color)
```

- `lib/ci-annotations.ts` (new, pure/testable):
  - `isGitHubActions(env)` gates on `GITHUB_ACTIONS=true` — annotations only emit there, plain output everywhere else.
  - `driftAnnotations(report)` builds the command lines with correct data vs property escaping (a comma/colon in a value can't corrupt the command).
  - `emitDriftAnnotations(report, log, env)` prints them; `log`/`env` injectable for tests.
- Severity maps from the drift change kind: `changed`/`removed` (a baseline token drifted or vanished) → error; `added` (a new token appeared) → warning. Mirrors the ticket's "off-palette → error / new colours → warning" example.
- Wired into `index.ts` `--compare`, gated on `process.exitCode === EXIT.DRIFT` so an `--approve`'d local baseline (which passes despite a drift report) emits nothing.

## Scope honesty

Per the ticket, two inputs are deferred because they depend on unbuilt tickets:
- `file=`/`line=` source locations need the drift source-scan (**DEM-33**) — not in this tree.
- Assertion-driven severity needs **DEM-81** — not built. Severity here derives from the drift report's change kinds instead.

Both slot in as extra inputs to `driftAnnotations` later without changing the command syntax.

## Verification

- 299/299 tests pass; new unit tests cover GA detection, the stable-report no-op, severity mapping, property escaping, and the emit gate.
- End-to-end: `GITHUB_ACTIONS=true dembrandt apple.com --compare <baseline>` emitted the summary + per-change annotations to stdout and exited 1 (gate fails). Without `GITHUB_ACTIONS`, plain output only.

Independent of the color/typography PR (#109); branches off `main`, touches only `index.ts` + the new module/test.