### PR TITLE
fix(compare): fail closed when the baseline cannot be evaluated

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -467,7 +467,11 @@ program
           // passes despite a drift report) emits nothing.
           if (process.exitCode === EXIT.DRIFT) emitDriftAnnotations(report);
         } catch (err) {
+          // A gate that cannot evaluate its baseline must not pass: exit RUNTIME
+          // ("check broke, investigate") so CI distinguishes this from stable (0)
+          // and from real drift (1). See lib/exit-codes.ts.
           console.log(color.warning(`! Could not compare against baseline: ${err.message}`));
+          process.exitCode = EXIT.RUNTIME;
         }
       }
 

--- a/lib/compare.ts
+++ b/lib/compare.ts
@@ -43,8 +43,23 @@ export async function resolveCompare(
   const readFile = deps.readFile ?? (readFileSync as (p: string, enc: "utf-8") => string);
 
   if (isFile(arg)) {
-    const baseline = JSON.parse(readFile(arg, "utf-8")) as BrandingResult;
+    let baseline: BrandingResult;
+    try {
+      baseline = JSON.parse(readFile(arg, "utf-8")) as BrandingResult;
+    } catch (err) {
+      throw new Error(
+        `baseline ${arg} is not a dembrandt JSON extraction ` +
+        `(${(err as Error).message}) — create one with --save-output or --json-only`,
+        { cause: err }
+      );
+    }
     return { report: computeDrift(baseline, candidate), source: arg, mode: "local" };
+  }
+
+  // A path-looking argument that is not a file is a typo, not a baseline id —
+  // shipping it to the App would surface a confusing platform error instead.
+  if (arg.includes("/") || arg.includes("\\") || /\.(json|md)$/i.test(arg)) {
+    throw new Error(`baseline file not found: ${arg}`);
   }
 
   // Not a local file → treat as a platform baseline id.

--- a/test/compare.test.ts
+++ b/test/compare.test.ts
@@ -57,6 +57,28 @@ test('baseline id path: POSTs candidate to the App and returns its report', asyn
   assert.equal(r.report.score, 7);
 });
 
+test('local file path: unparseable baseline rejects with a clear error, not a bare SyntaxError', async () => {
+  await assert.rejects(
+    () => resolveCompare('DESIGN.md', fixture(), {
+      isFile: () => true,
+      readFile: () => '---\nname: not json\n---',
+    }),
+    /baseline DESIGN\.md is not a dembrandt JSON extraction .*--save-output/,
+  );
+});
+
+test('path-looking argument that is not a file rejects instead of POSTing to the App', async () => {
+  let fetched = false;
+  const fetchFn = (async () => { fetched = true; return { ok: true, json: async () => ({}) }; }) as any;
+  for (const typo of ['output/missing.json', 'baselines\\win.json', 'baseline.JSON', 'DESIGN.md']) {
+    await assert.rejects(
+      () => resolveCompare(typo, fixture(), { isFile: () => false, fetchFn }),
+      /baseline file not found/,
+    );
+  }
+  assert.equal(fetched, false, 'never hits the network for a path-looking typo');
+});
+
 test('baseline id path: surfaces a platform error', async () => {
   const fetchFn = (async () => ({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({ error: 'baseline not found: nope' }) })) as any;
   await assert.rejects(


### PR DESCRIPTION
A `--compare` failure (unparseable baseline, typo'd path, platform error) printed a warning and exited 0. In CI that means a misconfigured drift gate silently passes forever — the worst failure mode for a gate.

## Changes

- **index.ts**: the compare catch now sets `process.exitCode = EXIT.RUNTIME` (2). Per the exit-code contract in `lib/exit-codes.ts`, 2 already means "the check broke, investigate" — no new code, no breaking change to the gate.
- **lib/compare.ts**: a path-looking argument (contains a slash or ends in `.json`/`.md`) that is not an existing file rejects with `baseline file not found` instead of being shipped to the App as a platform baseline id, which produced a confusing platform error for a local typo.
- **lib/compare.ts**: an unparseable baseline file (e.g. a DESIGN.md handed to `--compare`, truncated JSON) rejects with a message naming the file and pointing at `--save-output`/`--json-only`, instead of a bare `SyntaxError`.

## Verification

- 309/309 unit tests (2 new: unparseable-baseline error shape; path-looking typo rejects without a network call).
- Lint 0 errors.
- E2E: `dembrandt dembrandt.com --compare output/typo.json` exits 2 with `! Could not compare against baseline: baseline file not found: output/typo.json`. Real drift still exits 1, stable still 0 (verified earlier on this tree).

Bare baseline ids (`--compare 42`) still route to the platform unchanged.