### PR TITLE
Flag orthogonality: multi-page propagation, wcag merge, save/dtcg split, compatibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ dembrandt dembrandt.com --screen-size 2560x1440                  # Physical scre
 
 Default: formatted terminal display only. Use `--save-output` to persist results as JSON files. Browser automatically retries in visible mode if headless extraction fails.
 
+All flags combine unless noted otherwise: see [docs/FLAGS.md](docs/FLAGS.md) for the flag compatibility tables (interactions, ignored combinations, multi-page propagation).
+
 ### Multi-Page Extraction
 
 Analyze multiple pages to get a more complete picture of a site's design system. Results are merged into a single unified output with cross-page confidence boosting: tokens appearing on multiple pages get higher confidence scores.

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -1,0 +1,50 @@
+# Flag compatibility
+
+Default rule: every flag combines freely with every other flag. Extraction modifiers (`--dark-mode`, `--mobile`, `--slow`, `--stealth`, fingerprint flags) change what is extracted; export flags (`--save-output`, `--dtcg`, `--brand-guide`, `--design-md`, `--html`, `--screenshot`) each write their own artifact from the same result; analysis flags (`--wcag`, `--compare`, `--ai`) run on top. Stack as many as you want.
+
+The tables below list the only exceptions: combinations that change each other's behavior, combinations that are ignored, and flags that do not propagate to multi-page runs.
+
+## Combinations that change behavior
+
+| Combination | Behavior |
+|---|---|
+| `--compare` + `--approve` | Local baseline file: the current extraction overwrites the baseline and the run passes regardless of drift. App baseline id: `--approve` is ignored and drift still exits 1. |
+| `--compare` + `--html` | The drift report is embedded in the HTML report. |
+| `--compare` + `--json-only` | A `drift` object is attached to the stdout JSON. Saved files (`--save-output`, baselines) stay pure extractions. |
+| `--crawl` + `--sitemap` | Sitemap discovery is used, `--crawl N` sets the page limit (N pages total). `--sitemap` alone discovers up to 20 additional pages. |
+| `--dtcg` + `--save-output` | Two files: the raw extraction (`.json`, from `--save-output`) and the DTCG tokens (`.tokens.json`, from `--dtcg`), same timestamp. Each flag alone writes only its own file. |
+| `--json-only` + `--dtcg` | stdout is the DTCG document. `--wcag`, `--raw-colors`, and `pages` data exist only in the raw extraction: drop `--dtcg` or add `--save-output` to get them. |
+| `--json-only` + any export flag | Exports still write. All status output moves to stderr so stdout stays parseable JSON. |
+| `--ai` + `--compare` | ML overwrites `colors.semantic.primary` before the compare runs. Comparing an `--ai` run against a non-`--ai` baseline (or vice versa) can report false primary-color drift. Use the same flag on both sides. |
+| `--key` + `--crawl` / `--sitemap` / extra paths | Merged multi-page results can exceed the 150 KB sync cap; the upload is then skipped with a warning. |
+
+## Combinations that are ignored or fail
+
+| Combination | Behavior |
+|---|---|
+| `--approve` without `--compare` | No effect. A warning is printed. |
+| Explicit `[paths...]` arguments + `--crawl` or `--sitemap` | Explicit paths win; link and sitemap discovery are skipped entirely. |
+| `--no-sandbox` + `--browser firefox` | Ignored. Sandbox flags are Chromium-only. |
+| `BROWSER_CDP_ENDPOINT` (env) + `--browser firefox` | Error. CDP connect is Chromium-only. CDP mode also disables the visible-browser retry on navigation failure. |
+
+## Multi-page runs: which flags reach every page
+
+In a multi-page run (`--crawl`, `--sitemap`, or extra `[paths...]`), some flags apply to every extracted page and some apply only to the first page.
+
+| Applied to every page | First page only |
+|---|---|
+| `--dark-mode` | `--screenshot` |
+| `--mobile` | |
+| `--slow` | |
+| `--stealth` | |
+| `--cookie` | |
+| `--header` | |
+| `--user-agent` | |
+| `--locale` | |
+| `--timezone` | |
+| `--accept-language` | |
+| `--screen-size` | |
+| `--wcag` | |
+| `--raw-colors` | |
+
+`--wcag` results are merged across pages: static pairs are deduped order-insensitively by color pair with counts summed (top 50 kept), interactive state pairs appended after. `--raw-colors` stays per page by design, since it is a diagnostic view of the pre-filter color pipeline that runs before merge: each page's raw colors sit on its entry in the `pages` array, and `colors.rawColors` remains the first page's set for backward compatibility.

--- a/index.ts
+++ b/index.ts
@@ -242,6 +242,11 @@ program
                   reveal: !process.env.DEMBRANDT_DISABLE_REVEAL,
                   slow: opts.slow,
                   stealth: opts.stealth,
+                  cookie: opts.cookie,
+                  header: opts.header,
+                  screenSize: opts.screenSize,
+                  wcag: opts.wcag,
+                  includeRawColors: opts.rawColors,
                   userAgent: opts.userAgent,
                   locale: opts.locale,
                   timezoneId: opts.timezone,
@@ -347,21 +352,22 @@ program
           const outputDir = join(process.cwd(), "output", domain);
           mkdirSync(outputDir, { recursive: true });
 
-          const suffix = opts.dtcg ? '.tokens' : '';
-          const filename = `${timestamp}_v${version}${suffix}.json`;
-          const filepath = join(outputDir, filename);
-          writeFileSync(filepath, JSON.stringify(outputData, null, 2));
-
-          const jsonLabel = opts.dtcg
-            ? 'DTCG tokens saved (--dtcg)'
-            : 'JSON saved (--save-output)';
-          savedNotices.push(
-            chalk.dim(
-              `💾 ${jsonLabel}: ${color.info(
-                `output/${domain}/${filename}`
-              )}`
-            )
-          );
+          // The two flags are orthogonal: --save-output writes the raw
+          // extraction, --dtcg writes the tokens file. Both flags = both files.
+          const saves = [];
+          if (opts.saveOutput) saves.push({ data: result, suffix: '', label: 'JSON saved (--save-output)' });
+          if (opts.dtcg) saves.push({ data: outputData, suffix: '.tokens', label: 'DTCG tokens saved (--dtcg)' });
+          for (const { data, suffix, label } of saves) {
+            const filename = `${timestamp}_v${version}${suffix}.json`;
+            writeFileSync(join(outputDir, filename), JSON.stringify(data, null, 2));
+            savedNotices.push(
+              chalk.dim(
+                `💾 ${label}: ${color.info(
+                  `output/${domain}/${filename}`
+                )}`
+              )
+            );
+          }
         } catch (err) {
           console.log(
             color.warning(`! Could not save JSON file: ${err.message}`)

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -346,6 +346,36 @@ function mergeMotion(results) {
 }
 
 /**
+ * Union of WCAG pairs across pages. Identical pairs produce identical grades,
+ * so dedupe is by pair identity (order-insensitive fg/bg for static pairs,
+ * plus state/tag for interactive state pairs) with counts summed. Static pairs
+ * keep the single-page contract: sorted by count desc, capped at 50, state
+ * pairs appended after.
+ */
+function mergeWcag(results) {
+  const map = new Map();
+  for (const r of results) {
+    for (const p of r.wcag || []) {
+      const key = p.source === 'state'
+        ? `state|${p.state}|${p.tag}|${p.fg}|${p.bg}`
+        : `static|${[p.fg, p.bg].sort().join('/')}`;
+      const entry = map.get(key);
+      if (entry) {
+        if (p.count != null) entry.count = (entry.count ?? 0) + p.count;
+      } else {
+        map.set(key, { ...p });
+      }
+    }
+  }
+  const all = [...map.values()];
+  const statics = all
+    .filter(p => !p.source)
+    .sort((a, b) => (b.count ?? 0) - (a.count ?? 0))
+    .slice(0, 50);
+  return [...statics, ...all.filter(p => p.source === 'state')];
+}
+
+/**
  * Merge an array of per-page result objects into a single unified result.
  * @param {Object[]} results - Array of extractBranding() result objects
  * @returns {Object} Merged result with same shape as single-page result
@@ -379,6 +409,14 @@ export function mergeResults(results) {
     ].sort((a: any, b: any) => parseInt(b.px) - parseInt(a.px)),
     iconSystem: mergeByName(results, r => r.iconSystem),
     frameworks: mergeByName(results, r => r.frameworks),
-    pages: results.map(r => ({ url: r.url, extractedAt: r.extractedAt })),
+    ...(results.some(r => r.wcag) ? { wcag: mergeWcag(results) } : {}),
+    // rawColors are per-page filter diagnostics: merging them would destroy the
+    // page provenance they exist for, so each page keeps its own set here.
+    // colors.rawColors stays the first page's (via mergeColors) for back-compat.
+    pages: results.map(r => ({
+      url: r.url,
+      extractedAt: r.extractedAt,
+      ...(r.colors?.rawColors ? { rawColors: r.colors.rawColors } : {}),
+    })),
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -346,7 +346,7 @@ export interface BrandingResult {
   iconSystem: IconSystem[];
   frameworks: Framework[];
   wcag?: WcagPair[];
-  pages?: { url: string }[];
+  pages?: { url: string; extractedAt?: string; rawColors?: PaletteColor[] }[];
   /**
    * CLI-emitted note about the extraction itself (e.g. canvas-only sites). This is
    * NOT a user annotation — a user note belongs in the storage envelope around the

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -133,3 +133,51 @@ test('mergeResults unions variable-font axes by axis, widening the range', () =>
   assert.equal(wght.count, 3);
   assert.ok(axes.find((a) => a.axis === 'slnt'));
 });
+
+test('mergeResults unions wcag pairs, deduping order-insensitive static pairs and summing counts', () => {
+  const pair = (fg, bg, count) => ({ fg, bg, ratio: 4.6, aa: true, aaLarge: true, aaa: false, count });
+  const home = page('https://a.test', {
+    wcag: [pair('#000000', '#ffffff', 5), { fg: '#888888', bg: '#999999', ratio: 1.2, aa: false, aaLarge: false, aaa: false, state: 'hover', tag: 'a', source: 'state' }],
+  });
+  const second = page('https://a.test/pricing', {
+    // Same static pair with fg/bg swapped -> same pair, counts sum.
+    wcag: [pair('#ffffff', '#000000', 3), pair('#cc0000', '#ffffff', 2)],
+  });
+
+  const merged = mergeResults([home, second]);
+
+  const statics = merged.wcag.filter((p) => !p.source);
+  assert.equal(statics.length, 2);
+  const bw = statics.find((p) => [p.fg, p.bg].sort().join('/') === '#000000/#ffffff');
+  assert.equal(bw.count, 8);
+
+  // State pairs survive the merge, appended after static pairs.
+  const states = merged.wcag.filter((p) => p.source === 'state');
+  assert.equal(states.length, 1);
+  assert.equal(states[0].state, 'hover');
+});
+
+test('mergeResults omits wcag when no page ran the analysis', () => {
+  const merged = mergeResults([page('https://a.test'), page('https://a.test/pricing')]);
+  assert.equal('wcag' in merged, false);
+});
+
+test('mergeResults keeps rawColors per page in the pages array', () => {
+  const raw = (hex) => [{ normalized: hex, color: hex, count: 1 }];
+  const home = page('https://a.test', {
+    colors: { palette: [], semantic: {}, cssVariables: {}, rawColors: raw('#111111') },
+  });
+  const second = page('https://a.test/pricing', {
+    colors: { palette: [], semantic: {}, cssVariables: {}, rawColors: raw('#222222') },
+  });
+
+  const merged = mergeResults([home, second]);
+
+  assert.equal(merged.pages[0].rawColors[0].normalized, '#111111');
+  assert.equal(merged.pages[1].rawColors[0].normalized, '#222222');
+  // Back-compat: colors.rawColors stays the first page's set.
+  assert.equal(merged.colors.rawColors[0].normalized, '#111111');
+  // No leak when the flag was off: plain pages entries carry no rawColors key.
+  const plain = mergeResults([page('https://a.test'), page('https://a.test/x')]);
+  assert.equal('rawColors' in plain.pages[0], false);
+});


### PR DESCRIPTION
## Why

An audit of flag interactions in `index.ts` found three combinations that silently misbehaved:

1. `--cookie` / `--header` / `--screen-size` were passed only to the first page. Multi-page runs (`--crawl`, `--sitemap`, extra paths) extracted logged-out variants of every additional page, and the fingerprint changed mid-session.
2. `--wcag --crawl` ran the analysis on page 1 and then `mergeResults` dropped `result.wcag` entirely. The flag produced nothing in multi-page runs.
3. `--save-output --dtcg` wrote one file: `--save-output` was silently absorbed into the DTCG file.

## What

- Propagate `--cookie`, `--header`, `--screen-size`, `--wcag`, `--raw-colors` to every extracted page.
- `mergeWcag()`: union across pages, static pairs deduped order-insensitively by color pair with counts summed (top 50, matching the single-page contract), state pairs appended after.
- `--raw-colors` stays per page by design (it is a diagnostic of the pre-filter pipeline, which runs before merge): each page's set sits on `pages[n].rawColors`; `colors.rawColors` remains the first page's for backward compatibility.
- `--save-output` + `--dtcg` = two files, same timestamp. Each alone is unchanged.
- `docs/FLAGS.md`: compatibility tables (behavior-changing combos, ignored/failing combos, multi-page propagation), linked from README. Documents only exceptions; the default rule is that all flags combine.

## DevEx notes

- The guiding rule is flags stay orthogonal: any combination either composes or fails loudly, never silently drops one side.
- `--json-only --dtcg` stdout is the DTCG document, which carries no `wcag`/`rawColors`/`pages`; the table tells users to drop `--dtcg` or add `--save-output`. If that trips people up in practice, a follow-up could warn when those flags are combined.
- Not touched: `--screenshot` remains first-page-only (no per-page naming scheme exists yet); `--ai` + `--compare` baseline mixing is documented as a caveat rather than guarded.

## Verification

- 312 unit tests pass (3 new merge tests: wcag union + count summing, wcag omitted when unused, per-page rawColors with no leak when the flag is off).
- Live dogfood: `dembrandt.com /pricing --wcag --raw-colors --save-output --dtcg --json-only` → 42 merged wcag pairs (35 static, 7 state), `pages[0].rawColors` 8 / `pages[1].rawColors` 2, both output files written, exit 0.