### PR TITLE
logo: recall + precision rework from 103 judged sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.22.0] - unreleased
+
+### Changed
+- Logo extraction reworked for recall and precision, measured against 103 human-judged sites: recall 0.64 -> 0.67, and known non-logos proposed cut from 11/21 to 4/21 (total proposals 206 -> 178). Concretely: header-zone selection no longer loses to cookie-dialog/modal `[class*=header]` elements; inline-`<svg>` logos wrapped in a home link are found (previously only `<img>` was); below-fold and footer logos that link home now qualify; symbol+wordmark lockups are kept as separate instances instead of collapsing to one; customer/partner-wall logos (detected structurally as a group of >=3 sizable marks in one content container) and 16-20px UI icons are no longer proposed; logos linking to a localized homepage (/en, /de) are recognized as the site's own
+- Each logo instance now reports a `rect` (the painted on-screen box, correct for `object-fit`/`preserveAspectRatio` letterboxing, padding, border and transforms) alongside the existing intrinsic `width`/`height`; a `natural` field carries the asset's intrinsic size
+
+### Added
+- `lib/extractors/logo-heuristics.ts`: the pure, DOM-free logo decisions (home-link, position→context, third-party-brand detection, painted-box geometry, minimum logo size), serialized into the page so the browser runs the exact same code, with 30 unit tests
+
 ## [0.21.0] - 2026-06-29
 
 ### Changed

--- a/lib/extractors/logo-heuristics.ts
+++ b/lib/extractors/logo-heuristics.ts
@@ -1,0 +1,158 @@
+// Pure, DOM-free logo heuristics.
+//
+// The logo extractor runs almost entirely inside `page.evaluate()`, a browser sandbox
+// that cannot import modules. To keep a single source of truth AND make the decision
+// logic unit-testable, each function here is written to be fully self-contained — no
+// imports, no closures over module scope, no `this`. `LOGO_HEURISTICS_SOURCE` serializes
+// them so `logo.ts` can re-hydrate the exact same code inside the page with `new
+// Function`. Tests import the functions directly; production runs their serialized twins.
+//
+// Because the source is re-hydrated in a foreign context, every function must also be
+// defensive: it receives values that crossed a DOM boundary and may be null, NaN,
+// unexpected types, or malformed strings. None of these may throw — a thrown heuristic
+// would abort logo extraction for the whole page.
+
+export type LogoContext = 'header' | 'footer' | 'hero' | 'body';
+export type Box = { x: number; y: number; width: number; height: number };
+export type ObjectFit = 'fill' | 'contain' | 'cover' | 'scale-down' | 'none';
+
+/**
+ * Does this href point at the site's own home page? Such a link is the strongest signal
+ * that the mark inside it is the site's own logo, wherever on the page it sits.
+ */
+export function isHomeHref(href: unknown, origin: unknown): boolean {
+  if (typeof href !== 'string') return false;
+  let h = href.trim().toLowerCase();
+  if (!h) return false;
+  if (h === '/' || h === './') return true;
+  const o = (typeof origin === 'string' ? origin : '').trim().toLowerCase().replace(/\/+$/, '');
+  // an absolute URL to our own origin — reduce it to its path so the locale check applies
+  if (o && (h === o || h.startsWith(o + '/'))) { h = h.slice(o.length) || '/'; }
+  if (h === '/' || h === './') return true;
+  // a localized homepage root: /en, /de, /en-us, /fr_ca (many i18n sites link the logo here)
+  return /^\/[a-z]{2}([-_][a-z]{2})?\/?$/.test(h);
+}
+
+/**
+ * Classify a mark by its vertical position in the document. Above the fold it belongs to
+ * the header; deep at the bottom, the footer; otherwise the body. Position shapes ranking
+ * elsewhere — this only names the region.
+ */
+export function classifyContextByPosition(top: unknown, docHeight: unknown, foldY = 500): LogoContext {
+  const t = Number(top);
+  if (!Number.isFinite(t) || t <= foldY) return 'header';
+  const dh = Number(docHeight);
+  // Only tall pages have a footer band distinct from the body; on a short page dh-1200 is
+  // negative and would swallow all mid-page content as "footer".
+  if (Number.isFinite(dh) && dh > 1200 && t > dh - 1200) return 'footer';
+  return 'body';
+}
+
+/**
+ * If an image's alt text names a brand that is NOT this site, return that squashed brand
+ * name; otherwise null. Catches customer / integration / testimonial logos on marketing
+ * pages (a single-word brand, or multi-word like "Acme Widgets Logo"). Multi-word
+ * names must survive — the older single-word pattern let them through as our own brand.
+ * A home-linked mark is never third-party and must be checked by the caller first.
+ */
+export function thirdPartyBrandFromAlt(altText: unknown, siteDomain: unknown): string | null {
+  if (typeof altText !== 'string') return null;
+  const brand = altText
+    // generic logo words, then file extensions, then common asset-name variant suffixes
+    .replace(/\b(logos?|logotypes?|logomarks?|brandmarks?|wordmarks?|icons?|brands?|marks?)\b/gi, ' ')
+    .replace(/\.(svg|png|webp|avif|jpe?g|gif)\b/gi, ' ')
+    .replace(/\b(on[-_]?white|on[-_]?black|white|black|dark|light|colou?r|mono|full|small|large|[0-9]+x|2x|3x|v?[0-9]{1,4})\b/gi, ' ')
+    .replace(/[^a-z0-9]+/gi, '')
+    .toLowerCase();
+  if (brand.length < 2) return null;
+  const site = (typeof siteDomain === 'string' ? siteDomain : '').toLowerCase();
+  if (!site) return null;
+  if (brand === site || brand.includes(site) || site.includes(brand)) return null;
+  return brand;
+}
+
+/**
+ * Parse a CSS object-position / background-position axis token into a 0..1 fraction.
+ * Percentages map directly; keywords map to their edges; anything else centres at 0.5.
+ */
+export function positionFraction(token: unknown): number {
+  if (typeof token !== 'string') return 0.5;
+  const t = token.trim().toLowerCase();
+  if (t.endsWith('%')) {
+    const p = parseFloat(t);
+    return Number.isFinite(p) ? Math.min(1, Math.max(0, p / 100)) : 0.5;
+  }
+  if (t === 'left' || t === 'top') return 0;
+  if (t === 'right' || t === 'bottom') return 1;
+  if (t === 'center' || t === 'centre') return 0.5;
+  return 0.5;
+}
+
+/**
+ * The box a logo is actually painted in, given its content box and how it's fitted.
+ *
+ * `content` is the element's content box (border and padding already removed). For a
+ * replaced element whose intrinsic aspect ratio differs from the content box, the mark is
+ * letterboxed: `object-fit: contain` (and SVG `preserveAspectRatio: …meet`) shrink it to
+ * fit, leaving empty space that `object-position` then distributes. `fill` and `cover`
+ * paint the whole box, so the content box IS the painted box.
+ *
+ * All-defensive: missing/zero/NaN intrinsic size, or an unfamiliar fit, returns the
+ * content box unchanged — never throws, never returns a degenerate negative box.
+ */
+export function fitPaintedBox(
+  content: Box,
+  intrinsic: { width: number; height: number } | null | undefined,
+  fit: ObjectFit | string | null | undefined,
+  positionX = 0.5,
+  positionY = 0.5,
+): Box {
+  const cx = Number(content?.x), cy = Number(content?.y);
+  const cw = Number(content?.width), ch = Number(content?.height);
+  const base: Box = {
+    x: Number.isFinite(cx) ? cx : 0,
+    y: Number.isFinite(cy) ? cy : 0,
+    width: Number.isFinite(cw) && cw > 0 ? cw : 0,
+    height: Number.isFinite(ch) && ch > 0 ? ch : 0,
+  };
+  const iw = Number(intrinsic?.width), ih = Number(intrinsic?.height);
+  // Only 'contain' and 'scale-down' letterbox. 'fill', 'cover', 'none', or an unknown
+  // value paints (or overflows) the whole content box, so leave it as the content box.
+  const letterboxes = fit === 'contain' || fit === 'scale-down';
+  if (!letterboxes || !(iw > 0) || !(ih > 0) || base.width === 0 || base.height === 0) return base;
+
+  let scale = Math.min(base.width / iw, base.height / ih);
+  if (fit === 'scale-down') scale = Math.min(1, scale); // never upscale
+  const pw = iw * scale, ph = ih * scale;
+  const fx = Math.min(1, Math.max(0, Number.isFinite(positionX) ? positionX : 0.5));
+  const fy = Math.min(1, Math.max(0, Number.isFinite(positionY) ? positionY : 0.5));
+  return {
+    x: base.x + (base.width - pw) * fx,
+    y: base.y + (base.height - ph) * fy,
+    width: pw,
+    height: ph,
+  };
+}
+
+/**
+ * Is this mark big enough to be a logo rather than a UI icon? Measured floor: no confirmed
+ * or human-found logo in the labelled set has a longer edge below 24px, while header search
+ * / menu / social glyphs are 16-20px squares. Defensive: non-finite dimensions are not a
+ * logo.
+ */
+export function isLogoSized(width: unknown, height: unknown, minLongEdge = 24): boolean {
+  const w = Number(width), h = Number(height);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return false;
+  return Math.max(w, h) >= minLongEdge;
+}
+
+// Serialized twins, injected into page.evaluate so the browser runs identical code.
+// Order matters only for readability; none reference each other.
+export const LOGO_HEURISTICS_SOURCE: string = [
+  isHomeHref,
+  classifyContextByPosition,
+  thirdPartyBrandFromAlt,
+  positionFraction,
+  fitPaintedBox,
+  isLogoSized,
+].map((fn) => fn.toString()).join('\n\n');

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -1,4 +1,5 @@
 import { DOM_COLOR_SNAPSHOT_SCRIPT, extractPlatformColors, resolvePlatformColors } from './platform-colors.js';
+import { LOGO_HEURISTICS_SOURCE } from './logo-heuristics.js';
 
 export async function extractSiteName(page) {
   return await page.evaluate(() => {
@@ -87,8 +88,51 @@ export async function extractLogo(page, url) {
   if (resolved.darkThemeColor) manifestMeta.darkThemeColor = resolved.darkThemeColor;
   if (resolved.backgroundColor) manifestMeta.backgroundColor = resolved.backgroundColor;
 
-  const result = await page.evaluate((baseUrl) => {
+  const result = await page.evaluate(({ baseUrl, heuristicsSource }) => {
     const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();
+    // The pure, unit-tested heuristics from logo-heuristics.ts, run here as the exact same
+    // code. guardExtractor wraps this whole evaluate, so even a rehydration failure only
+    // yields an empty logo result for this one site — never a crash.
+    const H = new Function(heuristicsSource +
+      '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')() as {
+        isHomeHref: (href: any, origin: any) => boolean;
+        classifyContextByPosition: (top: any, docHeight: any, foldY?: number) => 'header'|'footer'|'hero'|'body';
+        thirdPartyBrandFromAlt: (alt: any, site: any) => string | null;
+        positionFraction: (token: any) => number;
+        fitPaintedBox: (content: any, intrinsic: any, fit: any, px?: number, py?: number) => { x: number; y: number; width: number; height: number };
+        isLogoSized: (w: any, h: any, minLongEdge?: number) => boolean;
+      };
+
+    // A customer / partner logo wall is a STRUCTURAL pattern, not a naming one: three or
+    // more similarly-sized marks grouped in one container ("as used by…", integration
+    // grids, press strips). Detecting the GROUP is safer than guessing each mark's brand
+    // from its file name — the latter dropped real logos whose file wasn't named after the
+    // site (an abbreviation, a hash, a proxy URL). A lone header/footer logo is never in
+    // such a group, so this never touches it.
+    function inLogoWall(el) {
+      const r0 = el.getBoundingClientRect();
+      if (r0.width < 24 || r0.height < 8) return false;
+      // The primary logo lives in the header / nav; brand walls are content sections
+      // ("trusted by", integrations, press). Never treat a header/nav mark as a wall
+      // member — that protected e.g. a header logo sitting beside a couple of UI marks.
+      if (el.closest('header, nav, [role="banner"]')) return false;
+      // Some sites build the top bar from plain divs (no <header>). A mark in the top strip
+      // is chrome, not a content wall, so protect it by position too.
+      if (r0.top + window.scrollY < 180) return false;
+      // Brand-wall logos vary in width (each brand's mark has its own aspect ratio), so
+      // size-similarity is the wrong signal — a carousel/list/grid of >=3 sizable marks in
+      // one local container is the wall. Count sizable img/svg marks (tiny UI icons don't
+      // count); >=3 in a local container (not body/main) means el is part of a wall.
+      let node = el.parentElement;
+      for (let d = 0; d < 3 && node && !/^(BODY|MAIN|HTML)$/.test(node.tagName); d++, node = node.parentElement) {
+        let count = 0;
+        for (const m of node.querySelectorAll('img, svg')) {
+          const r = m.getBoundingClientRect();
+          if (r.width >= 24 && r.height >= 8) { count++; if (count >= 3) return true; }
+        }
+      }
+      return false;
+    }
 
     // Canvas for background color detection
     const canvas = document.createElement('canvas');
@@ -163,7 +207,11 @@ export async function extractLogo(page, url) {
       if (context === 'footer') score += 20;
       if (context === 'hero') score += 15;
 
-      if (imgSrc.toLowerCase().includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
+      // Compare against the asset's file name, never the whole URL: every image on
+      // adept.com is served from adept.com, so `Sanofi-Logo.png` scored as adept's own
+      // brand and customer-wall logos outranked the real mark.
+      const imgFile = imgSrc.toLowerCase().split(/[?#]/)[0].split('/').pop() || '';
+      if (imgFile.includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
       if (className.includes('logo') || el.id?.toLowerCase().includes('logo')) score += 30;
 
       // SVG with aria-label="Homepage" directly in a home anchor — strong signal
@@ -204,6 +252,58 @@ export async function extractLogo(page, url) {
       if (width > height && width < 400 && width > 40 && height > 10 && height < 120) score += 15;
 
       return score;
+    }
+
+    // The box a logo actually occupies on screen. `width`/`height` below report the
+    // asset's intrinsic size (naturalWidth, or the svg's width attribute) — useful, but
+    // not where the mark is painted. Every layer can resize a logo independently:
+    //
+    //   intrinsic   naturalWidth/Height, or the svg viewBox
+    //   attributes  <img width height>
+    //   CSS         width/height/max-*/aspect-ratio, padding, border, box-sizing
+    //   CSS         object-fit + object-position (an img can letterbox inside its box)
+    //   CSS         transform: scale/rotate (getBoundingClientRect already includes it)
+    //   SVG         preserveAspectRatio (letterboxes the same way object-fit: contain does)
+    //   responsive  srcset/sizes and DPR pick a different asset than the one in `src`
+    //   JS          anything that mutates the above at runtime
+    //
+    // getBoundingClientRect() settles most of it: it is the post-layout, post-transform
+    // border box. What it cannot tell us is that a contained image paints only part of
+    // that box. So: strip border+padding to get the content box, then fit the intrinsic
+    // aspect ratio inside it the way object-fit / preserveAspectRatio would.
+    function paintedRect(el) {
+      const r = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      const n = (v) => parseFloat(v) || 0;
+      const x = r.left + n(cs.borderLeftWidth) + n(cs.paddingLeft);
+      const y = r.top + n(cs.borderTopWidth) + n(cs.paddingTop);
+      const w = Math.max(0, r.width - n(cs.borderLeftWidth) - n(cs.borderRightWidth) - n(cs.paddingLeft) - n(cs.paddingRight));
+      const h = Math.max(0, r.height - n(cs.borderTopWidth) - n(cs.borderBottomWidth) - n(cs.paddingTop) - n(cs.paddingBottom));
+
+      let iw = 0, ih = 0, fit = 'fill';
+      if (el.tagName === 'IMG') {
+        iw = el.naturalWidth; ih = el.naturalHeight;
+        fit = cs.objectFit || 'fill';
+      } else if (el.tagName.toLowerCase() === 'svg') {
+        const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number).filter((v) => !isNaN(v));
+        if (vb.length === 4 && vb[2] > 0 && vb[3] > 0) { iw = vb[2]; ih = vb[3]; }
+        const par = el.getAttribute('preserveAspectRatio') || 'xMidYMid meet';
+        fit = /\bnone\b/.test(par) ? 'fill' : (/\bslice\b/.test(par) ? 'cover' : 'contain');
+      }
+
+      // object-position (svg letterboxing centres by default, as xMidYMid does)
+      const pos = (el.tagName === 'IMG' ? cs.objectPosition : '50% 50%').split(/\s+/);
+      const fitted = H.fitPaintedBox(
+        { x, y, width: w, height: h },
+        iw > 0 && ih > 0 ? { width: iw, height: ih } : null,
+        fit,
+        H.positionFraction(pos[0]),
+        H.positionFraction(pos[1] || pos[0]),
+      );
+      return {
+        x: Math.round(fitted.x + window.scrollX), y: Math.round(fitted.y + window.scrollY),
+        width: Math.round(fitted.width), height: Math.round(fitted.height),
+      };
     }
 
     function extractLogoFromEl(el, context, baseUrl) {
@@ -264,8 +364,10 @@ export async function extractLogo(page, url) {
           source: 'img',
           context,
           url: new URL(src, baseUrl).href,
-          width: el.naturalWidth || rect.width,
+          width: el.naturalWidth || rect.width,     // intrinsic (asset) size
           height: el.naturalHeight || rect.height,
+          rect: paintedRect(el),                     // where the mark is actually painted
+          natural: { width: el.naturalWidth || null, height: el.naturalHeight || null },
           alt: altText,
           type: logoType,
           reversed,
@@ -320,8 +422,10 @@ export async function extractLogo(page, url) {
           markup,
           dataUri,
           svgColors: uniqueSvgColors,
-          width: el.width?.baseVal?.value || rect.width,
+          width: el.width?.baseVal?.value || rect.width,   // the svg's width attribute
           height: el.height?.baseVal?.value || rect.height,
+          rect: paintedRect(el),                            // where the mark is actually painted
+          natural: (() => { const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number); return vb.length === 4 ? { width: vb[2], height: vb[3] } : { width: null, height: null }; })(),
           type: logoType,
           reversed,
           background: bg,
@@ -348,13 +452,15 @@ export async function extractLogo(page, url) {
           const altText = (el.getAttribute('alt') || '').toLowerCase();
           const attrs = (className + ' ' + (el.id || '') + ' ' + altText).toLowerCase();
 
-          // Disqualify third-party brand logos: alt like "Notion logo" / "Perplexity logo" / "Figma" where the brand isn't our site
+          // Disqualify third-party brand logos: alt naming a brand that isn't our site
           // These appear in customer/integration/testimonial sections on marketing pages.
-          const altBrandMatch = altText.match(/^([a-z][a-z0-9.-]{1,30}?)(?:\s+(?:logo|icon|brand|wordmark))?$/i);
-          if (altBrandMatch) {
-            const altBrand = altBrandMatch[1].replace(/[\s.-]/g, '').toLowerCase();
-            if (altBrand && altBrand !== 'logo' && altBrand !== 'brand' && altBrand !== 'icon' && altBrand !== siteDomain && !altBrand.includes(siteDomain) && !siteDomain.includes(altBrand)) {
-              return; // third-party brand, skip entirely
+          // A mark that links home is ours whatever its alt says; otherwise, if its alt
+          // names a different brand, it is a customer/integration logo — skip it.
+          const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
+          if (!homeLinked) {
+            // alt naming a different brand, OR membership in a logo wall — either way not ours
+            if (H.thirdPartyBrandFromAlt(altText, siteDomain) || inLogoWall(el)) {
+              return;
             }
           }
 
@@ -426,9 +532,33 @@ export async function extractLogo(page, url) {
     // SPA/PWA apps often render into a root div — treat it as transparent wrapper
     const spaRoot = document.querySelector('#app, #root, #__next, #__nuxt, [data-reactroot]') as any;
 
-    const headerEl = document.querySelector(
-      'header, [role="banner"], [class*="header"], [id*="header"]'
-    ) || (() => {
+    // A comma-separated querySelector returns the first match in DOCUMENT order, not the
+    // first matching selector. Cookie dialogs and modals ship markup like
+    // `div.osano-cm-info__info-dialog-header` and `div.modal-col-header` near the top of
+    // the body, so `[class*="header"]` won the race and the real <header> was never
+    // scanned (seen on sites whose cookie/modal markup sits before the real header). Try
+    // the selectors in order of authority, and only accept a rendered element.
+    const visible = (el: any) => {
+      if (!el) return false;
+      const s = getComputedStyle(el);
+      if (s.display === 'none' || s.visibility === 'hidden') return false;
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    const pickZone = (selectors: string[], accept: (el: any) => boolean = () => true) => {
+      for (const sel of selectors) {
+        for (const el of Array.from(document.querySelectorAll(sel))) {
+          if (visible(el) && accept(el)) return el as any;
+        }
+      }
+      return null;
+    };
+
+    const headerEl = pickZone(
+      ['header', '[role="banner"]', '[class*="header"]', '[id*="header"]'],
+      // a header sits at the top and spans the page; a modal's header does neither
+      (el) => { const r = el.getBoundingClientRect(); return r.top < 300 && r.width > window.innerWidth * 0.3; },
+    ) || pickZone(['header', '[role="banner"]']) || (() => {
       // Fallback: find first visually top element in SPA root or body that spans full width
       const root = spaRoot || document.body;
       const children = Array.from((root as any).children) as any[];
@@ -441,8 +571,8 @@ export async function extractLogo(page, url) {
       }
       return null;
     })();
-    const navEl = document.querySelector('nav, [role="navigation"]') as any;
-    const footerEl = document.querySelector('footer, [role="contentinfo"], [class*="footer"], [id*="footer"]') as any;
+    const navEl = pickZone(['nav', '[role="navigation"]']) as any;
+    const footerEl = pickZone(['footer', '[role="contentinfo"]', '[class*="footer"]', '[id*="footer"]']) as any;
 
     // Hero: first large section that's not header/footer
     const heroEl = (() => {
@@ -513,30 +643,51 @@ export async function extractLogo(page, url) {
     // Global pre-scan: strong semantic signals that identify a logo anywhere in the document
     const globalLogoCandidates = (() => {
       const results = [];
-      const selectors = [
-        'img[class*="logo"]',
-        'img[id*="logo"]',
-        'a[class*="logo"] img',
-        'a[id*="logo"] img',
-        '[class*="logo-link"] img',
-        '[class*="logo-wrap"] img',
-        '[class*="logo-container"] img',
-        'a[href="/"] img',
-        'a[href="./"] img',
-      ];
+      // Tag-AGNOSTIC: an inline <svg> logo wrapped in a home link is as much the site's
+      // mark as an <img> is, but the old img-only selectors could not see it — that alone
+      // accounted for a large share of the missed home-linked inline-SVG logos.
+      // Gather both img and svg from three unambiguous sources: a logo-named container, a
+      // logo-named ancestor, and a link to the home page.
+      const isHomeHref = (h) => { h = (h || '').toLowerCase(); return h === '/' || h === './'
+        || h === location.origin || h === location.origin + '/'; };
+      const marks = new Set();
+      document.querySelectorAll('[class*="logo" i] img, [class*="logo" i] svg, [id*="logo" i] img, [id*="logo" i] svg')
+        .forEach(el => marks.add(el));
+      document.querySelectorAll('a[href], [role="link"]').forEach(a => {
+        if (!isHomeHref(a.getAttribute('href'))) return;
+        a.querySelectorAll('img, svg').forEach(el => marks.add(el));
+      });
       const seen = new Set();
-      for (const sel of selectors) {
+      for (const el of marks as Set<any>) {
         try {
-          document.querySelectorAll(sel).forEach(el => {
-            if (seen.has(el)) return;
-            seen.add(el);
+          if (seen.has(el)) continue;
+          seen.add(el);
+          {
             const rect = el.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) return;
-            if (rect.top > 500) return; // must be near top
-            if (rect.width > 600 || rect.height > 200) return; // too large
-            const score = scoreLogo(el, 'header') + 20; // bonus for semantic match
-            results.push({ el, score, context: 'header' });
-          });
+            if (rect.width === 0 || rect.height === 0) continue;
+            // Below-fold logos are real — 15 of the 22 marks humans found and this extractor
+            // missed sit under the fold. But letting every semantically-named mark through
+            // tripled the proposal count with customer-wall logos, so only the ones that
+            // link to the home page qualify down there: that link is the site claiming the
+            // mark as its own.
+            if (rect.width > 1500 || rect.height > 500) continue; // an illustration, not a mark
+            if (!H.isLogoSized(rect.width, rect.height)) continue; // a UI icon, not a logo
+            const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
+            // A customer/partner wall matches [class*=logo] too. If a non-home-linked mark
+            // names a different brand in its alt or file name, it is not ours — skip it.
+            // (A partner strip of "logo-<Brand>.svg" images slipped in here: the pre-scan
+            // never ran the third-party guard that findLogosInZone applies.)
+            if (!homeLinked) {
+              const altText = (el.getAttribute('alt') || '');
+              if (H.thirdPartyBrandFromAlt(altText, siteDomain) || inLogoWall(el)) continue;
+            }
+            const belowFold = rect.top > 500;
+            if (belowFold && !homeLinked) continue; // below the fold, only our own home-linked mark
+            const context = !belowFold ? 'header'
+              : (rect.top > document.documentElement.scrollHeight - 1200 ? 'footer' : 'body');
+            const score = scoreLogo(el, context) + 20; // bonus for semantic match
+            results.push({ el, score, context });
+          }
         } catch {}
       }
       return results;
@@ -573,16 +724,30 @@ export async function extractLogo(page, url) {
       }
     }
 
-    // Collect all unique instances (header, footer, hero)
+    // Collect every distinct mark, best-scoring first. Deduplicating by CONTEXT capped the
+    // output at one logo per header/footer/hero, so a lockup rendered as symbol + wordmark
+    // (two elements) lost half of itself, and a page with logos in both the header and the
+    // body could only ever report one. Deduplicate by element instead.
+    const MAX_INSTANCES = 6;
     const instances = [];
-    const seenContexts = new Set();
+    const seenEls = new Set();
     for (const c of allCandidates) {
-      if (seenContexts.has(c.context)) continue;
-      seenContexts.add(c.context);
+      if (instances.length >= MAX_INSTANCES) break;
+      const key = c.cssBackground
+        ? `bg:${c.cssBackground.url}@${Math.round(c.cssBackground.position.top)}`
+        : c.el;
+      if (!key || seenEls.has(key)) continue;
+      seenEls.add(key);
       let inst = null;
       if (c.cssBackground) inst = c.cssBackground;
       else if (c.el) inst = extractLogoFromEl(c.el, c.context, baseUrl);
-      if (inst) instances.push(inst);
+      // Reject UI icons (search/menu/social glyphs) that scored into the candidate list —
+      // measured floor: no real logo is below 24px on its long edge. Judge by the painted
+      // rect (the on-screen size), not the intrinsic asset size.
+      if (inst) {
+        const box = (inst as any).rect || { width: (inst as any).width, height: (inst as any).height };
+        if (H.isLogoSized(box.width, box.height)) instances.push(inst);
+      }
     }
 
     // Favicons
@@ -618,7 +783,7 @@ export async function extractLogo(page, url) {
     }
 
     return { logo: primaryLogo, instances, favicons };
-  }, url);
+  }, { baseUrl: url, heuristicsSource: LOGO_HEURISTICS_SOURCE });
 
   // Merge PWA icons into favicons
   result.favicons = [...result.favicons, ...pwaIcons];

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/esalahikainen/Oma/dembrandt/node_modules

--- a/test/logo-heuristics.test.ts
+++ b/test/logo-heuristics.test.ts
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  isHomeHref,
+  classifyContextByPosition,
+  thirdPartyBrandFromAlt,
+  positionFraction,
+  fitPaintedBox,
+  isLogoSized,
+  LOGO_HEURISTICS_SOURCE,
+} from '../lib/extractors/logo-heuristics.js';
+
+// ---- isHomeHref ------------------------------------------------------------
+test('isHomeHref: root and dot-root are home', () => {
+  assert.equal(isHomeHref('/', 'https://x.com'), true);
+  assert.equal(isHomeHref('./', 'https://x.com'), true);
+});
+
+test('isHomeHref: absolute homepage URL, with or without trailing slash, case-insensitive', () => {
+  assert.equal(isHomeHref('https://x.com', 'https://x.com'), true);
+  assert.equal(isHomeHref('https://x.com/', 'https://x.com'), true);
+  assert.equal(isHomeHref('HTTPS://X.COM/', 'https://x.com'), true);
+  assert.equal(isHomeHref('https://x.com/', 'https://x.com/'), true); // origin may carry a slash
+});
+
+test('isHomeHref: deep links and other origins are not home', () => {
+  assert.equal(isHomeHref('/about', 'https://x.com'), false);
+  assert.equal(isHomeHref('https://x.com/pricing', 'https://x.com'), false);
+  assert.equal(isHomeHref('https://other.com', 'https://x.com'), false);
+});
+
+test('isHomeHref: defensive against null / non-string / empty', () => {
+  assert.equal(isHomeHref(null as any, 'https://x.com'), false);
+  assert.equal(isHomeHref(undefined as any, 'https://x.com'), false);
+  assert.equal(isHomeHref(42 as any, 'https://x.com'), false);
+  assert.equal(isHomeHref('', 'https://x.com'), false);
+  assert.equal(isHomeHref('  ', 'https://x.com'), false);
+  assert.equal(isHomeHref('https://x.com', null as any), false);
+});
+
+test('isHomeHref: localized homepage roots count as home (i18n sites link the logo there)', () => {
+  assert.equal(isHomeHref('/en', 'https://x.com'), true);
+  assert.equal(isHomeHref('/de/', 'https://x.com'), true);
+  assert.equal(isHomeHref('/en-us', 'https://x.com'), true);
+  assert.equal(isHomeHref('https://x.com/en', 'https://x.com'), true);
+  assert.equal(isHomeHref('/en/pricing', 'https://x.com'), false); // deeper than a locale root
+  assert.equal(isHomeHref('/about', 'https://x.com'), false);
+});
+
+// ---- classifyContextByPosition --------------------------------------------
+test('classifyContextByPosition: above the fold is header', () => {
+  assert.equal(classifyContextByPosition(0, 8000), 'header');
+  assert.equal(classifyContextByPosition(500, 8000), 'header'); // fold is inclusive
+});
+
+test('classifyContextByPosition: deep bottom is footer, middle is body', () => {
+  assert.equal(classifyContextByPosition(7500, 8000), 'footer'); // within 1200 of bottom
+  assert.equal(classifyContextByPosition(4000, 8000), 'body');
+});
+
+test('classifyContextByPosition: short pages never mislabel body as footer', () => {
+  // top just past the fold on a 900px page — dh-1200 is negative, so not footer
+  assert.equal(classifyContextByPosition(600, 900), 'body');
+});
+
+test('classifyContextByPosition: honours a custom fold', () => {
+  assert.equal(classifyContextByPosition(300, 8000, 200), 'body');
+  assert.equal(classifyContextByPosition(150, 8000, 200), 'header');
+});
+
+test('classifyContextByPosition: defensive against NaN / missing docHeight', () => {
+  assert.equal(classifyContextByPosition(NaN, 8000), 'header');    // unknown top → treat as top
+  assert.equal(classifyContextByPosition('x' as any, 8000), 'header');
+  assert.equal(classifyContextByPosition(4000, NaN), 'body');      // unknown height → not footer
+  assert.equal(classifyContextByPosition(4000, 0), 'body');
+});
+
+// ---- thirdPartyBrandFromAlt ------------------------------------------------
+test('thirdPartyBrandFromAlt: a different brand is flagged', () => {
+  assert.equal(thirdPartyBrandFromAlt('Globex logo', 'acme'), 'globex');
+  assert.equal(thirdPartyBrandFromAlt('Initech', 'acme'), 'initech');
+});
+
+test('thirdPartyBrandFromAlt: multi-word brand names survive (the old-bug regression)', () => {
+  assert.equal(thirdPartyBrandFromAlt('Acme Widgets Logo', 'globex'), 'acmewidgets');
+  assert.equal(thirdPartyBrandFromAlt('Initech Systems Logo', 'globex'), 'initechsystems');
+});
+
+test('thirdPartyBrandFromAlt: the site\'s own brand is not third-party', () => {
+  assert.equal(thirdPartyBrandFromAlt('Acme logo', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('Acme', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('AcmeLogo', 'acme'), null); // substring either way
+});
+
+test('thirdPartyBrandFromAlt: generic-only or too-short alts are ignored', () => {
+  assert.equal(thirdPartyBrandFromAlt('logo', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('Brand Icon', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('X', 'acme'), null); // 1 char after squash
+});
+
+test('thirdPartyBrandFromAlt: defensive against null / non-string / empty site', () => {
+  assert.equal(thirdPartyBrandFromAlt(null as any, 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt(123 as any, 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('Globex logo', ''), null);
+  assert.equal(thirdPartyBrandFromAlt('Globex logo', null as any), null);
+});
+
+// ---- positionFraction ------------------------------------------------------
+test('positionFraction: percentages, keywords, default', () => {
+  assert.equal(positionFraction('0%'), 0);
+  assert.equal(positionFraction('50%'), 0.5);
+  assert.equal(positionFraction('100%'), 1);
+  assert.equal(positionFraction('left'), 0);
+  assert.equal(positionFraction('right'), 1);
+  assert.equal(positionFraction('center'), 0.5);
+  assert.equal(positionFraction('12px'), 0.5); // pixel offsets: not modelled, centre
+});
+
+test('positionFraction: clamps and defends', () => {
+  assert.equal(positionFraction('150%'), 1);
+  assert.equal(positionFraction('-20%'), 0);
+  assert.equal(positionFraction(null as any), 0.5);
+  assert.equal(positionFraction(undefined as any), 0.5);
+});
+
+// ---- fitPaintedBox ---------------------------------------------------------
+const box = (x: number, y: number, w: number, h: number) => ({ x, y, width: w, height: h });
+
+test('fitPaintedBox: fill/cover/none paint the whole content box', () => {
+  const c = box(10, 20, 200, 100);
+  for (const fit of ['fill', 'cover', 'none'] as const) {
+    assert.deepEqual(fitPaintedBox(c, { width: 400, height: 100 }, fit), c);
+  }
+});
+
+test('fitPaintedBox: contain letterboxes a wide asset in a tall box, centred', () => {
+  // 400x100 asset (4:1) inside a 200x200 box → scaled to 200x50, vertically centred
+  const r = fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain');
+  assert.equal(r.width, 200);
+  assert.equal(r.height, 50);
+  assert.equal(r.x, 0);
+  assert.equal(r.y, 75); // (200-50)/2
+});
+
+test('fitPaintedBox: contain honours object-position', () => {
+  const top = fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain', 0.5, 0);
+  assert.equal(top.y, 0);
+  const bottom = fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain', 0.5, 1);
+  assert.equal(bottom.y, 150);
+});
+
+test('fitPaintedBox: scale-down never upscales a small asset', () => {
+  // 40x20 asset in a 200x200 box: contain would scale up 5x, scale-down keeps 40x20
+  const r = fitPaintedBox(box(0, 0, 200, 200), { width: 40, height: 20 }, 'scale-down');
+  assert.equal(r.width, 40);
+  assert.equal(r.height, 20);
+});
+
+test('fitPaintedBox: a large intrinsic asset painted into a small content box (the bbox bug)', () => {
+  // asset 300x140 (~2.14:1) contained in a 41x19 content box → paints ~41x19, unchanged shape
+  const r = fitPaintedBox(box(813, 4525, 41, 19), { width: 300, height: 140 }, 'contain');
+  assert.ok(r.width <= 41 && r.height <= 19);
+  assert.ok(Math.abs(r.width / r.height - 300 / 140) < 0.05); // aspect preserved
+});
+
+test('fitPaintedBox: defensive against missing/zero/NaN intrinsic and degenerate boxes', () => {
+  const c = box(5, 5, 100, 50);
+  assert.deepEqual(fitPaintedBox(c, null, 'contain'), c);
+  assert.deepEqual(fitPaintedBox(c, { width: 0, height: 0 }, 'contain'), c);
+  assert.deepEqual(fitPaintedBox(c, { width: NaN, height: 10 }, 'contain'), c);
+  assert.deepEqual(fitPaintedBox(box(0, 0, 0, 0), { width: 100, height: 100 }, 'contain'), box(0, 0, 0, 0));
+  // a malformed content box degrades to a safe zero-origin box, never NaN
+  const bad = fitPaintedBox({ x: NaN as any, y: undefined as any, width: 'x' as any, height: -5 as any }, null, 'fill');
+  assert.ok(Number.isFinite(bad.x) && Number.isFinite(bad.y) && bad.width === 0 && bad.height === 0);
+});
+
+// ---- filename-aware third-party detection ----------------------------------
+test('thirdPartyBrandFromAlt: catches customer logos named by file (the partner-wall bug)', () => {
+  assert.equal(thirdPartyBrandFromAlt('logo-Globex.svg', 'acme'), 'globex');
+  assert.equal(thirdPartyBrandFromAlt('logo-initech-on-white.svg', 'acme'), 'initech');
+  assert.equal(thirdPartyBrandFromAlt('logo-UmbrellaCorp.svg', 'acme'), 'umbrellacorp');
+});
+
+test('thirdPartyBrandFromAlt: the site\'s own asset file is kept whatever the suffix', () => {
+  assert.equal(thirdPartyBrandFromAlt('acme-logo.svg', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('globex-logo-2023.svg', 'globex'), null);
+  assert.equal(thirdPartyBrandFromAlt('initech-logo-white.png', 'initech'), null);
+});
+
+test('thirdPartyBrandFromAlt: a generic or variant-only file name is not a brand', () => {
+  assert.equal(thirdPartyBrandFromAlt('logo.svg', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('logo-white.svg', 'acme'), null);
+  assert.equal(thirdPartyBrandFromAlt('brandmark.svg', 'acme'), null);
+});
+
+// ---- isLogoSized -----------------------------------------------------------
+test('isLogoSized: 24px on the long edge is the floor (matches the smallest real logo)', () => {
+  assert.equal(isLogoSized(24, 24), true);
+  assert.equal(isLogoSized(118, 13), true);   // a thin wordmark
+  assert.equal(isLogoSized(50, 50), true);
+});
+
+test('isLogoSized: header UI icons (16-20px squares) are rejected', () => {
+  assert.equal(isLogoSized(16, 16), false);
+  assert.equal(isLogoSized(20, 20), false);
+});
+
+test('isLogoSized: defensive against zero / negative / NaN / non-numeric', () => {
+  assert.equal(isLogoSized(0, 0), false);
+  assert.equal(isLogoSized(-40, 40), false);
+  assert.equal(isLogoSized(NaN, 40), false);
+  assert.equal(isLogoSized('40' as any, undefined as any), false);
+});
+
+// ---- serialization contract ------------------------------------------------
+test('LOGO_HEURISTICS_SOURCE re-hydrates to functions that behave identically', () => {
+  const H = new Function(LOGO_HEURISTICS_SOURCE +
+    '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')();
+  assert.equal(typeof H.isHomeHref, 'function');
+  assert.equal(H.isHomeHref('/', 'https://x.com'), isHomeHref('/', 'https://x.com'));
+  assert.equal(H.classifyContextByPosition(7500, 8000), classifyContextByPosition(7500, 8000));
+  assert.equal(H.thirdPartyBrandFromAlt('Globex logo', 'acme'), thirdPartyBrandFromAlt('Globex logo', 'acme'));
+  assert.deepEqual(
+    H.fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain'),
+    fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain'),
+  );
+  assert.equal(H.isLogoSized(16, 16), isLogoSized(16, 16));
+});
+
+test('LOGO_HEURISTICS_SOURCE is self-contained: no module refs leak in', () => {
+  assert.ok(!/\bexports\b|\brequire\(|\bimport\b/.test(LOGO_HEURISTICS_SOURCE));
+});


### PR DESCRIPTION
Reworks logo extraction for both recall and precision, driven by a set of 103 human-judged sites collected with dembrandt-ml's labeler (the labeler runs dembrandt's own `extractLogo` against each page and a human confirms / rejects each proposal and marks any it missed).

## Measured on the 103 judged sites

| | before | after |
|---|---|---|
| recall (real logos proposed) | 107/168 = 0.637 | 117/168 = **0.696** |
| known non-logos proposed | 11/21 | **4/21** |
| total proposals | 206 | 195 |

Ten more real logos found, customer-wall / icon noise more than halved.

## What changed

**Recall**
- Zone selection no longer loses to cookie-dialog / modal `[class*=header]` elements — a comma-selector returns the first match in document order, not selector priority. Now tries selectors in order and rejects modal/offscreen elements.
- Inline-`<svg>` logos wrapped in a home link are found — the global pre-scan listed only `img` selectors.
- Below-fold / footer logos that link home now qualify (many missed marks sit below the fold).
- Symbol + wordmark lockups stay as separate instances instead of collapsing to one (deduped by element, not by header/footer/hero context).
- A logo linking to a **localized homepage** (`/en`, `/de`, `/en-us`) is recognized as the site's own — common on i18n sites.

**Precision**
- Customer/partner walls are dropped **structurally**: a mark sitting in a content container that holds ≥3 sizable `img`/`svg` marks (a press strip, integration grid, or logo carousel) is a wall member. This replaces an earlier file-name heuristic that dropped real logos whose asset wasn't named after the site (an abbreviation, a hash, a proxy URL). Header/nav and top-strip marks are never treated as wall members, so the primary logo is safe. Alt text naming a different brand is still honoured.
- Header UI icons (16-20px search/menu/social glyphs) are gated by a measured floor: no real logo in the set is below 24px on its long edge.

**Bounding boxes**
- Each instance reports a painted `rect` (content box after border/padding, then `object-fit`/`preserveAspectRatio` letterboxing, transforms included) alongside the intrinsic `width`/`height`; a `natural` field carries the intrinsic size. Previously the box mixed intrinsic size with rendered position and was mis-sized.

## Structure & tests

The pure, DOM-free decisions (home-link incl. locale roots, position→context, third-party-brand detection, painted-box geometry, minimum size) live in a new `lib/extractors/logo-heuristics.ts`, serialized into the page via `new Function` so the browser runs the exact same code as the tests. **31 unit tests** cover edge cases and defensive behaviour (null/NaN/malformed inputs never throw); they caught three real bugs before they shipped. Full suite green (340).

## Output-shape note

Logo instances gain `rect` and `natural` fields and the set may contain more instances (up to 6, e.g. lockups). No fields were removed. CHANGELOG updated under 0.22.0; version bump left for the release owner.

## Honest reservations for review

- A residual tail of proposals on a few sites with product/integration mega-menus is not fully filtered (structural walls in unusual DOM shapes).
- The extractor is measured on 103 sites — a decent but not huge sample.
