### PR TITLE
feat(ci): official GitHub Action for the drift gate (DEM-151)

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,31 @@
+# Dogfood for action.yml: run the published composite action against our own
+# site. No baseline — this verifies the action mechanics (browser install,
+# CLI invocation, report output), not the drift verdict, so extraction churn
+# can't make it flaky.
+name: action-smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the action against dembrandt.com
+        id: gate
+        uses: ./
+        with:
+          url: https://www.dembrandt.com
+
+      - name: Assert report exists and is valid JSON
+        run: |
+          test -s "${{ steps.gate.outputs.report }}"
+          jq -e '.url' "${{ steps.gate.outputs.report }}" > /dev/null
+          echo "report OK: $(wc -c < "${{ steps.gate.outputs.report }}") bytes"

--- a/README.md
+++ b/README.md
@@ -245,6 +245,47 @@ dembrandt dembrandt.com --brand-guide
 
 ## Continuous integration
 
+### GitHub Action
+
+The official action wraps extract → compare → gate into one step: it installs a matching Chromium, runs a pinned CLI version, fails the job on drift, and renders the drifted tokens as inline annotations on the PR.
+
+```yaml
+- uses: dembrandt/dembrandt@v1
+  with:
+    url: https://preview.example.com
+    baseline: .dembrandt/baseline.json
+```
+
+Gating a Vercel preview needs no extra wiring — trigger on the deployment event and pass its URL:
+
+```yaml
+on:
+  deployment_status:
+
+jobs:
+  drift:
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dembrandt/dembrandt@v1
+        with:
+          url: ${{ github.event.deployment_status.environment_url }}
+          baseline: .dembrandt/baseline.json
+          key: ${{ secrets.DEMBRANDT_KEY }}
+```
+
+| Input | Required | Description |
+|---|---|---|
+| `url` | yes | URL to extract — typically the PR's preview deployment |
+| `baseline` | no | Committed baseline JSON path, or an App baseline id. Omit to extract without gating |
+| `key` | no | API key for cloud snapshot sync ([dembrandt.com/app/api-keys](https://www.dembrandt.com/app/api-keys)) |
+| `args` | no | Extra CLI flags, e.g. `--wcag` or `--pages 3` |
+
+Outputs: `report` (path to the drift/extraction JSON) and `score` (drift score, empty without a baseline). The action pins the CLI version per release, so a `@v1` gate never changes behavior under you. For a fully hand-rolled workflow (per-page PR comment, preview vs production, report artifact), see [`examples/drift-gate.yml`](examples/drift-gate.yml).
+
+### Running the CLI directly
+
 Dembrandt drives a real browser, so the browser revision must match `playwright-core`.
 
 If you are not using the Playwright container image, install the browser revision that matches `playwright-core`:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,91 @@
+name: "Dembrandt Drift Gate"
+author: "Dembrandt"
+description: "Extract a site's design system and fail the build on design drift against a baseline — colors, typography, spacing, radii, shadows from the real rendered DOM."
+branding:
+  icon: "eye"
+  color: "purple"
+
+inputs:
+  url:
+    description: "URL to extract — typically the PR's preview deployment."
+    required: true
+  baseline:
+    description: "Drift baseline: path to a committed baseline JSON, or an App baseline id. Omit to extract without gating."
+    required: false
+    default: ""
+  key:
+    description: "Dembrandt API key (dembrandt.com/app/api-keys) — uploads the snapshot to your account for drift history. Pass a secret."
+    required: false
+    default: ""
+  args:
+    description: 'Extra dembrandt CLI flags, e.g. "--wcag" or "--pages 3".'
+    required: false
+    default: ""
+  node-version:
+    description: "Node.js version used to run the CLI."
+    required: false
+    default: "24"
+
+outputs:
+  report:
+    description: "Path to the machine-readable report JSON (drift details under the `drift` key when a baseline was given)."
+    value: ${{ steps.gate.outputs.report }}
+  score:
+    description: "Drift score from the report (empty when no baseline was given)."
+    value: ${{ steps.gate.outputs.score }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Cache Playwright Chromium
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        # DEMBRANDT_CLI_VERSION below pins playwright-core transitively; bump
+        # the cache key together with the version pin.
+        key: dembrandt-chromium-${{ runner.os }}-0.22.0
+
+    - name: Install Chromium matching playwright-core
+      shell: bash
+      run: npx --yes playwright@1.60.0 install chromium --with-deps
+
+    - name: Extract and gate
+      id: gate
+      shell: bash
+      env:
+        # Inputs flow through env, never inline into the script, so a crafted
+        # input value cannot inject shell into this step.
+        DEMBRANDT_URL: ${{ inputs.url }}
+        DEMBRANDT_BASELINE: ${{ inputs.baseline }}
+        DEMBRANDT_KEY: ${{ inputs.key }}
+        DEMBRANDT_EXTRA_ARGS: ${{ inputs.args }}
+        # Pinned so a vX tag of this action always runs the same CLI. Keep in
+        # sync with package.json "version" and the cache key above on release.
+        DEMBRANDT_CLI_VERSION: "0.22.0"
+      run: |
+        args=("$DEMBRANDT_URL" --json-only)
+        if [ -n "$DEMBRANDT_BASELINE" ]; then
+          args+=(--compare "$DEMBRANDT_BASELINE")
+        fi
+        extra=()
+        if [ -n "$DEMBRANDT_EXTRA_ARGS" ]; then
+          read -r -a extra <<< "$DEMBRANDT_EXTRA_ARGS"
+        fi
+        # DEMBRANDT_KEY is picked up by the CLI itself as the --key fallback.
+        set +e
+        npx --yes "dembrandt@$DEMBRANDT_CLI_VERSION" "${args[@]}" "${extra[@]}" > dembrandt-report.json
+        rc=$?
+        set -e
+        echo "report=dembrandt-report.json" >> "$GITHUB_OUTPUT"
+        score=$(jq -r '.drift.score // empty' dembrandt-report.json 2>/dev/null || true)
+        echo "score=$score" >> "$GITHUB_OUTPUT"
+        # Exit code carries the verdict: 0 stable, 1 drift, 2/67 extraction
+        # problems (see README "Exit codes"). Drift annotations render on the
+        # PR automatically — the CLI emits workflow commands under
+        # GITHUB_ACTIONS.
+        exit $rc


### PR DESCRIPTION
Closes DEM-151 (Action half; Vercel preview integration is covered as the `deployment_status` recipe in the README rather than code).

## What

- **`action.yml`** — composite action at repo root:
  - CLI version pinned (`dembrandt@0.22.0`) so a `@v1` gate never changes behavior between npm releases; bump together with `package.json` on release (noted inline)
  - Chromium install matching `playwright-core` 1.60.0, cached via `actions/cache`
  - Inputs flow through `env`, never inline-interpolated into the script (script-injection hardening)
  - `key` input rides the CLI's own `DEMBRANDT_KEY` env fallback — never appears on the command line
  - Outputs: `report` (JSON path), `score` (from `.drift.score`)
  - Exit code carries the verdict (0 stable / 1 drift / 2 extraction / 67 timeout); drift annotations render automatically because the CLI emits workflow commands under `GITHUB_ACTIONS` (DEM-83). In `--json-only` mode they land on stderr (console.log redirect, index.ts:101), which the runner also parses — stdout JSON stays clean
- **`.github/workflows/action-smoke.yml`** — dogfood: runs `uses: ./` against www.dembrandt.com **without a baseline**, asserting only that the report is valid JSON. Deliberately not a drift assertion, so extraction churn (open issue) cannot flake CI
- **README** — GitHub Action section under Continuous integration: minimal usage, Vercel `deployment_status` recipe, inputs/outputs table; hand-rolled `examples/drift-gate.yml` kept as the advanced reference

## Out of scope (v1.1 candidates)

- PR comment with the drift table rendered from `report` (annotations cover v1)
- Marketplace publish: after merge, cut a `v1` release tag and tick "Publish this Action to the GitHub Marketplace" — mechanical, no code

## Test plan

- `action-smoke` workflow triggers on this PR (path filter matches `action.yml`) and exercises the full composite: Node setup → Chromium cache+install → npx run → report assert