### PR TITLE
feat(ci): official GitHub Action for the drift gate (DEM-151)

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,31 @@
+# Dogfood for action.yml: run the published composite action against our own
+# site. No baseline — this verifies the action mechanics (browser install,
+# CLI invocation, report output), not the drift verdict, so extraction churn
+# can't make it flaky.
+name: action-smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the action against dembrandt.com
+        id: gate
+        uses: ./
+        with:
+          url: https://www.dembrandt.com
+
+      - name: Assert report exists and is valid JSON
+        run: |
+          test -s "${{ steps.gate.outputs.report }}"
+          jq -e '.url' "${{ steps.gate.outputs.report }}" > /dev/null
+          echo "report OK: $(wc -c < "${{ steps.gate.outputs.report }}") bytes"

--- a/README.md
+++ b/README.md
@@ -245,6 +245,47 @@ dembrandt dembrandt.com --brand-guide
 
 ## Continuous integration
 
+### GitHub Action
+
+The official action wraps extract → compare → gate into one step: it installs a matching Chromium, runs a pinned CLI version, fails the job on drift, and renders the drifted tokens as inline annotations on the PR.
+
+```yaml
+- uses: dembrandt/dembrandt@v1
+  with:
+    url: https://preview.example.com
+    baseline: .dembrandt/baseline.json
+```
+
+Gating a Vercel preview needs no extra wiring — trigger on the deployment event and pass its URL:
+
+```yaml
+on:
+  deployment_status:
+
+jobs:
+  drift:
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dembrandt/dembrandt@v1
+        with:
+          url: ${{ github.event.deployment_status.environment_url }}
+          baseline: .dembrandt/baseline.json
+          key: ${{ secrets.DEMBRANDT_KEY }}
+```
+
+| Input | Required | Description |
+|---|---|---|
+| `url` | yes | URL to extract — typically the PR's preview deployment |
+| `baseline` | no | Committed baseline JSON path, or an App baseline id. Omit to extract without gating |
+| `key` | no | API key for cloud snapshot sync ([dembrandt.com/app/api-keys](https://www.dembrandt.com/app/api-keys)) |
+| `args` | no | Extra CLI flags, e.g. `--wcag` or `--pages 3` |
+
+Outputs: `report` (path to the drift/extraction JSON) and `score` (drift score, empty without a baseline). The action pins the CLI version per release, so a `@v1` gate never changes behavior under you. For a fully hand-rolled workflow (per-page PR comment, preview vs production, report artifact), see [`examples/drift-gate.yml`](examples/drift-gate.yml).
+
+### Running the CLI directly
+
 Dembrandt drives a real browser, so the browser revision must match `playwright-core`.
 
 If you are not using the Playwright container image, install the browser revision that matches `playwright-core`:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,91 @@
+name: "Dembrandt Drift Gate"
+author: "Dembrandt"
+description: "Extract a site's design system and fail the build on design drift against a baseline — colors, typography, spacing, radii, shadows from the real rendered DOM."
+branding:
+  icon: "eye"
+  color: "purple"
+
+inputs:
+  url:
+    description: "URL to extract — typically the PR's preview deployment."
+    required: true
+  baseline:
+    description: "Drift baseline: path to a committed baseline JSON, or an App baseline id. Omit to extract without gating."
+    required: false
+    default: ""
+  key:
+    description: "Dembrandt API key (dembrandt.com/app/api-keys) — uploads the snapshot to your account for drift history. Pass a secret."
+    required: false
+    default: ""
+  args:
+    description: 'Extra dembrandt CLI flags, e.g. "--wcag" or "--pages 3".'
+    required: false
+    default: ""
+  node-version:
+    description: "Node.js version used to run the CLI."
+    required: false
+    default: "24"
+
+outputs:
+  report:
+    description: "Path to the machine-readable report JSON (drift details under the `drift` key when a baseline was given)."
+    value: ${{ steps.gate.outputs.report }}
+  score:
+    description: "Drift score from the report (empty when no baseline was given)."
+    value: ${{ steps.gate.outputs.score }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Cache Playwright Chromium
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        # DEMBRANDT_CLI_VERSION below pins playwright-core transitively; bump
+        # the cache key together with the version pin.
+        key: dembrandt-chromium-${{ runner.os }}-0.22.0
+
+    - name: Install Chromium matching playwright-core
+      shell: bash
+      run: npx --yes playwright@1.60.0 install chromium --with-deps
+
+    - name: Extract and gate
+      id: gate
+      shell: bash
+      env:
+        # Inputs flow through env, never inline into the script, so a crafted
+        # input value cannot inject shell into this step.
+        DEMBRANDT_URL: ${{ inputs.url }}
+        DEMBRANDT_BASELINE: ${{ inputs.baseline }}
+        DEMBRANDT_KEY: ${{ inputs.key }}
+        DEMBRANDT_EXTRA_ARGS: ${{ inputs.args }}
+        # Pinned so a vX tag of this action always runs the same CLI. Keep in
+        # sync with package.json "version" and the cache key above on release.
+        DEMBRANDT_CLI_VERSION: "0.22.0"
+      run: |
+        args=("$DEMBRANDT_URL" --json-only)
+        if [ -n "$DEMBRANDT_BASELINE" ]; then
+          args+=(--compare "$DEMBRANDT_BASELINE")
+        fi
+        extra=()
+        if [ -n "$DEMBRANDT_EXTRA_ARGS" ]; then
+          read -r -a extra <<< "$DEMBRANDT_EXTRA_ARGS"
+        fi
+        # DEMBRANDT_KEY is picked up by the CLI itself as the --key fallback.
+        set +e
+        npx --yes "dembrandt@$DEMBRANDT_CLI_VERSION" "${args[@]}" "${extra[@]}" > dembrandt-report.json
+        rc=$?
+        set -e
+        echo "report=dembrandt-report.json" >> "$GITHUB_OUTPUT"
+        score=$(jq -r '.drift.score // empty' dembrandt-report.json 2>/dev/null || true)
+        echo "score=$score" >> "$GITHUB_OUTPUT"
+        # Exit code carries the verdict: 0 stable, 1 drift, 2/67 extraction
+        # problems (see README "Exit codes"). Drift annotations render on the
+        # PR automatically — the CLI emits workflow commands under
+        # GITHUB_ACTIONS.
+        exit $rc

--- a/action.yml
+++ b/action.yml
@@ -55,9 +55,16 @@ runs:
       # Global install, not npx: when the consuming checkout is itself an npm
       # package (like dembrandt's own repo), npx resolves the spec against the
       # local package.json and never fetches from the registry.
+      #
+      # The browser revision must match the playwright-core version that npm
+      # actually resolved for the CLI (its ranges float), so derive it from the
+      # installed tree instead of hardcoding — same rule as README "Continuous
+      # integration".
       run: |
         npm install -g dembrandt@0.22.0
-        npx --yes playwright@1.60.0 install chromium --with-deps
+        PW_VERSION=$(node -p "require('$(npm root -g)/dembrandt/node_modules/playwright-core/package.json').version")
+        echo "playwright-core resolved to $PW_VERSION"
+        npx --yes "playwright@$PW_VERSION" install chromium --with-deps
 
     - name: Extract and gate
       id: gate

--- a/action.yml
+++ b/action.yml
@@ -46,13 +46,18 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
-        # DEMBRANDT_CLI_VERSION below pins playwright-core transitively; bump
-        # the cache key together with the version pin.
+        # The CLI version pinned in the install step below fixes playwright-core
+        # transitively; bump this key together with that pin on release.
         key: dembrandt-chromium-${{ runner.os }}-0.22.0
 
-    - name: Install Chromium matching playwright-core
+    - name: Install dembrandt CLI and Chromium
       shell: bash
-      run: npx --yes playwright@1.60.0 install chromium --with-deps
+      # Global install, not npx: when the consuming checkout is itself an npm
+      # package (like dembrandt's own repo), npx resolves the spec against the
+      # local package.json and never fetches from the registry.
+      run: |
+        npm install -g dembrandt@0.22.0
+        npx --yes playwright@1.60.0 install chromium --with-deps
 
     - name: Extract and gate
       id: gate
@@ -64,9 +69,6 @@ runs:
         DEMBRANDT_BASELINE: ${{ inputs.baseline }}
         DEMBRANDT_KEY: ${{ inputs.key }}
         DEMBRANDT_EXTRA_ARGS: ${{ inputs.args }}
-        # Pinned so a vX tag of this action always runs the same CLI. Keep in
-        # sync with package.json "version" and the cache key above on release.
-        DEMBRANDT_CLI_VERSION: "0.22.0"
       run: |
         args=("$DEMBRANDT_URL" --json-only)
         if [ -n "$DEMBRANDT_BASELINE" ]; then
@@ -78,7 +80,7 @@ runs:
         fi
         # DEMBRANDT_KEY is picked up by the CLI itself as the --key fallback.
         set +e
-        npx --yes "dembrandt@$DEMBRANDT_CLI_VERSION" "${args[@]}" "${extra[@]}" > dembrandt-report.json
+        dembrandt "${args[@]}" "${extra[@]}" > dembrandt-report.json
         rc=$?
         set -e
         echo "report=dembrandt-report.json" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,12 @@ runs:
         dembrandt "${args[@]}" "${extra[@]}" > dembrandt-report.json
         rc=$?
         set -e
+        if [ "$rc" -ge 2 ]; then
+          # Extraction problem (not drift): surface the machine-readable error
+          # from the report, since --json-only keeps it off the console.
+          msg=$(jq -r '.error | "\(.code): \(.message)"' dembrandt-report.json 2>/dev/null || true)
+          echo "::error title=dembrandt extraction failed (exit $rc)::${msg:-see report output}"
+        fi
         echo "report=dembrandt-report.json" >> "$GITHUB_OUTPUT"
         score=$(jq -r '.drift.score // empty' dembrandt-report.json 2>/dev/null || true)
         echo "score=$score" >> "$GITHUB_OUTPUT"

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -1,4 +1,5 @@
 import { DOM_COLOR_SNAPSHOT_SCRIPT, extractPlatformColors, resolvePlatformColors } from './platform-colors.js';
+import { LOGO_HEURISTICS_SOURCE } from './logo-heuristics.js';
 
 export async function extractSiteName(page) {
   return await page.evaluate(() => {
@@ -87,8 +88,20 @@ export async function extractLogo(page, url) {
   if (resolved.darkThemeColor) manifestMeta.darkThemeColor = resolved.darkThemeColor;
   if (resolved.backgroundColor) manifestMeta.backgroundColor = resolved.backgroundColor;
 
-  const result = await page.evaluate((baseUrl) => {
+  const result = await page.evaluate(({ baseUrl, heuristicsSource }) => {
     const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();
+    // The pure, unit-tested heuristics from logo-heuristics.ts, run here as the exact same
+    // code. guardExtractor wraps this whole evaluate, so even a rehydration failure only
+    // yields an empty logo result for this one site — never a crash.
+    const H = new Function(heuristicsSource +
+      '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')() as {
+        isHomeHref: (href: any, origin: any) => boolean;
+        classifyContextByPosition: (top: any, docHeight: any, foldY?: number) => 'header'|'footer'|'hero'|'body';
+        thirdPartyBrandFromAlt: (alt: any, site: any) => string | null;
+        positionFraction: (token: any) => number;
+        fitPaintedBox: (content: any, intrinsic: any, fit: any, px?: number, py?: number) => { x: number; y: number; width: number; height: number };
+        isLogoSized: (w: any, h: any, minLongEdge?: number) => boolean;
+      };
 
     // Canvas for background color detection
     const canvas = document.createElement('canvas');
@@ -163,7 +176,11 @@ export async function extractLogo(page, url) {
       if (context === 'footer') score += 20;
       if (context === 'hero') score += 15;
 
-      if (imgSrc.toLowerCase().includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
+      // Compare against the asset's file name, never the whole URL: every image on
+      // adept.com is served from adept.com, so `Sanofi-Logo.png` scored as adept's own
+      // brand and customer-wall logos outranked the real mark.
+      const imgFile = imgSrc.toLowerCase().split(/[?#]/)[0].split('/').pop() || '';
+      if (imgFile.includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
       if (className.includes('logo') || el.id?.toLowerCase().includes('logo')) score += 30;
 
       // SVG with aria-label="Homepage" directly in a home anchor — strong signal
@@ -204,6 +221,58 @@ export async function extractLogo(page, url) {
       if (width > height && width < 400 && width > 40 && height > 10 && height < 120) score += 15;
 
       return score;
+    }
+
+    // The box a logo actually occupies on screen. `width`/`height` below report the
+    // asset's intrinsic size (naturalWidth, or the svg's width attribute) — useful, but
+    // not where the mark is painted. Every layer can resize a logo independently:
+    //
+    //   intrinsic   naturalWidth/Height, or the svg viewBox
+    //   attributes  <img width height>
+    //   CSS         width/height/max-*/aspect-ratio, padding, border, box-sizing
+    //   CSS         object-fit + object-position (an img can letterbox inside its box)
+    //   CSS         transform: scale/rotate (getBoundingClientRect already includes it)
+    //   SVG         preserveAspectRatio (letterboxes the same way object-fit: contain does)
+    //   responsive  srcset/sizes and DPR pick a different asset than the one in `src`
+    //   JS          anything that mutates the above at runtime
+    //
+    // getBoundingClientRect() settles most of it: it is the post-layout, post-transform
+    // border box. What it cannot tell us is that a contained image paints only part of
+    // that box. So: strip border+padding to get the content box, then fit the intrinsic
+    // aspect ratio inside it the way object-fit / preserveAspectRatio would.
+    function paintedRect(el) {
+      const r = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      const n = (v) => parseFloat(v) || 0;
+      const x = r.left + n(cs.borderLeftWidth) + n(cs.paddingLeft);
+      const y = r.top + n(cs.borderTopWidth) + n(cs.paddingTop);
+      const w = Math.max(0, r.width - n(cs.borderLeftWidth) - n(cs.borderRightWidth) - n(cs.paddingLeft) - n(cs.paddingRight));
+      const h = Math.max(0, r.height - n(cs.borderTopWidth) - n(cs.borderBottomWidth) - n(cs.paddingTop) - n(cs.paddingBottom));
+
+      let iw = 0, ih = 0, fit = 'fill';
+      if (el.tagName === 'IMG') {
+        iw = el.naturalWidth; ih = el.naturalHeight;
+        fit = cs.objectFit || 'fill';
+      } else if (el.tagName.toLowerCase() === 'svg') {
+        const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number).filter((v) => !isNaN(v));
+        if (vb.length === 4 && vb[2] > 0 && vb[3] > 0) { iw = vb[2]; ih = vb[3]; }
+        const par = el.getAttribute('preserveAspectRatio') || 'xMidYMid meet';
+        fit = /\bnone\b/.test(par) ? 'fill' : (/\bslice\b/.test(par) ? 'cover' : 'contain');
+      }
+
+      // object-position (svg letterboxing centres by default, as xMidYMid does)
+      const pos = (el.tagName === 'IMG' ? cs.objectPosition : '50% 50%').split(/\s+/);
+      const fitted = H.fitPaintedBox(
+        { x, y, width: w, height: h },
+        iw > 0 && ih > 0 ? { width: iw, height: ih } : null,
+        fit,
+        H.positionFraction(pos[0]),
+        H.positionFraction(pos[1] || pos[0]),
+      );
+      return {
+        x: Math.round(fitted.x + window.scrollX), y: Math.round(fitted.y + window.scrollY),
+        width: Math.round(fitted.width), height: Math.round(fitted.height),
+      };
     }
 
     function extractLogoFromEl(el, context, baseUrl) {
@@ -264,8 +333,10 @@ export async function extractLogo(page, url) {
           source: 'img',
           context,
           url: new URL(src, baseUrl).href,
-          width: el.naturalWidth || rect.width,
+          width: el.naturalWidth || rect.width,     // intrinsic (asset) size
           height: el.naturalHeight || rect.height,
+          rect: paintedRect(el),                     // where the mark is actually painted
+          natural: { width: el.naturalWidth || null, height: el.naturalHeight || null },
           alt: altText,
           type: logoType,
           reversed,
@@ -320,8 +391,10 @@ export async function extractLogo(page, url) {
           markup,
           dataUri,
           svgColors: uniqueSvgColors,
-          width: el.width?.baseVal?.value || rect.width,
+          width: el.width?.baseVal?.value || rect.width,   // the svg's width attribute
           height: el.height?.baseVal?.value || rect.height,
+          rect: paintedRect(el),                            // where the mark is actually painted
+          natural: (() => { const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number); return vb.length === 4 ? { width: vb[2], height: vb[3] } : { width: null, height: null }; })(),
           type: logoType,
           reversed,
           background: bg,
@@ -348,13 +421,16 @@ export async function extractLogo(page, url) {
           const altText = (el.getAttribute('alt') || '').toLowerCase();
           const attrs = (className + ' ' + (el.id || '') + ' ' + altText).toLowerCase();
 
-          // Disqualify third-party brand logos: alt like "Notion logo" / "Perplexity logo" / "Figma" where the brand isn't our site
+          // Disqualify third-party brand logos: alt naming a brand that isn't our site
           // These appear in customer/integration/testimonial sections on marketing pages.
-          const altBrandMatch = altText.match(/^([a-z][a-z0-9.-]{1,30}?)(?:\s+(?:logo|icon|brand|wordmark))?$/i);
-          if (altBrandMatch) {
-            const altBrand = altBrandMatch[1].replace(/[\s.-]/g, '').toLowerCase();
-            if (altBrand && altBrand !== 'logo' && altBrand !== 'brand' && altBrand !== 'icon' && altBrand !== siteDomain && !altBrand.includes(siteDomain) && !siteDomain.includes(altBrand)) {
-              return; // third-party brand, skip entirely
+          // A mark that links home is ours whatever its alt says; otherwise, if its alt
+          // names a different brand, it is a customer/integration logo — skip it.
+          const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
+          if (!homeLinked) {
+            const srcFile = (el.currentSrc || el.getAttribute('src') || '').split(/[?#]/)[0].split('/').pop() || '';
+            // alt OR the asset file name may name a different brand (customer/partner wall)
+            if (H.thirdPartyBrandFromAlt(altText, siteDomain) || H.thirdPartyBrandFromAlt(srcFile, siteDomain)) {
+              return; // a third party's brand, in its alt text or its file name
             }
           }
 
@@ -426,9 +502,33 @@ export async function extractLogo(page, url) {
     // SPA/PWA apps often render into a root div — treat it as transparent wrapper
     const spaRoot = document.querySelector('#app, #root, #__next, #__nuxt, [data-reactroot]') as any;
 
-    const headerEl = document.querySelector(
-      'header, [role="banner"], [class*="header"], [id*="header"]'
-    ) || (() => {
+    // A comma-separated querySelector returns the first match in DOCUMENT order, not the
+    // first matching selector. Cookie dialogs and modals ship markup like
+    // `div.osano-cm-info__info-dialog-header` and `div.modal-col-header` near the top of
+    // the body, so `[class*="header"]` won the race and the real <header> was never
+    // scanned (seen on sites whose cookie/modal markup sits before the real header). Try
+    // the selectors in order of authority, and only accept a rendered element.
+    const visible = (el: any) => {
+      if (!el) return false;
+      const s = getComputedStyle(el);
+      if (s.display === 'none' || s.visibility === 'hidden') return false;
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    const pickZone = (selectors: string[], accept: (el: any) => boolean = () => true) => {
+      for (const sel of selectors) {
+        for (const el of Array.from(document.querySelectorAll(sel))) {
+          if (visible(el) && accept(el)) return el as any;
+        }
+      }
+      return null;
+    };
+
+    const headerEl = pickZone(
+      ['header', '[role="banner"]', '[class*="header"]', '[id*="header"]'],
+      // a header sits at the top and spans the page; a modal's header does neither
+      (el) => { const r = el.getBoundingClientRect(); return r.top < 300 && r.width > window.innerWidth * 0.3; },
+    ) || pickZone(['header', '[role="banner"]']) || (() => {
       // Fallback: find first visually top element in SPA root or body that spans full width
       const root = spaRoot || document.body;
       const children = Array.from((root as any).children) as any[];
@@ -441,8 +541,8 @@ export async function extractLogo(page, url) {
       }
       return null;
     })();
-    const navEl = document.querySelector('nav, [role="navigation"]') as any;
-    const footerEl = document.querySelector('footer, [role="contentinfo"], [class*="footer"], [id*="footer"]') as any;
+    const navEl = pickZone(['nav', '[role="navigation"]']) as any;
+    const footerEl = pickZone(['footer', '[role="contentinfo"]', '[class*="footer"]', '[id*="footer"]']) as any;
 
     // Hero: first large section that's not header/footer
     const heroEl = (() => {
@@ -513,30 +613,52 @@ export async function extractLogo(page, url) {
     // Global pre-scan: strong semantic signals that identify a logo anywhere in the document
     const globalLogoCandidates = (() => {
       const results = [];
-      const selectors = [
-        'img[class*="logo"]',
-        'img[id*="logo"]',
-        'a[class*="logo"] img',
-        'a[id*="logo"] img',
-        '[class*="logo-link"] img',
-        '[class*="logo-wrap"] img',
-        '[class*="logo-container"] img',
-        'a[href="/"] img',
-        'a[href="./"] img',
-      ];
+      // Tag-AGNOSTIC: an inline <svg> logo wrapped in a home link is as much the site's
+      // mark as an <img> is, but the old img-only selectors could not see it — that alone
+      // accounted for a large share of the missed home-linked inline-SVG logos.
+      // Gather both img and svg from three unambiguous sources: a logo-named container, a
+      // logo-named ancestor, and a link to the home page.
+      const isHomeHref = (h) => { h = (h || '').toLowerCase(); return h === '/' || h === './'
+        || h === location.origin || h === location.origin + '/'; };
+      const marks = new Set();
+      document.querySelectorAll('[class*="logo" i] img, [class*="logo" i] svg, [id*="logo" i] img, [id*="logo" i] svg')
+        .forEach(el => marks.add(el));
+      document.querySelectorAll('a[href], [role="link"]').forEach(a => {
+        if (!isHomeHref(a.getAttribute('href'))) return;
+        a.querySelectorAll('img, svg').forEach(el => marks.add(el));
+      });
       const seen = new Set();
-      for (const sel of selectors) {
+      for (const el of marks as Set<any>) {
         try {
-          document.querySelectorAll(sel).forEach(el => {
-            if (seen.has(el)) return;
-            seen.add(el);
+          if (seen.has(el)) continue;
+          seen.add(el);
+          {
             const rect = el.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) return;
-            if (rect.top > 500) return; // must be near top
-            if (rect.width > 600 || rect.height > 200) return; // too large
-            const score = scoreLogo(el, 'header') + 20; // bonus for semantic match
-            results.push({ el, score, context: 'header' });
-          });
+            if (rect.width === 0 || rect.height === 0) continue;
+            // Below-fold logos are real — 15 of the 22 marks humans found and this extractor
+            // missed sit under the fold. But letting every semantically-named mark through
+            // tripled the proposal count with customer-wall logos, so only the ones that
+            // link to the home page qualify down there: that link is the site claiming the
+            // mark as its own.
+            if (rect.width > 1500 || rect.height > 500) continue; // an illustration, not a mark
+            if (!H.isLogoSized(rect.width, rect.height)) continue; // a UI icon, not a logo
+            const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
+            // A customer/partner wall matches [class*=logo] too. If a non-home-linked mark
+            // names a different brand in its alt or file name, it is not ours — skip it.
+            // (A partner strip of "logo-<Brand>.svg" images slipped in here: the pre-scan
+            // never ran the third-party guard that findLogosInZone applies.)
+            if (!homeLinked) {
+              const altText = (el.getAttribute('alt') || '');
+              const srcFile = (el.currentSrc || el.getAttribute('src') || '').split(/[?#]/)[0].split('/').pop() || '';
+              if (H.thirdPartyBrandFromAlt(altText, siteDomain) || H.thirdPartyBrandFromAlt(srcFile, siteDomain)) continue;
+            }
+            const belowFold = rect.top > 500;
+            if (belowFold && !homeLinked) continue; // below the fold, only our own home-linked mark
+            const context = !belowFold ? 'header'
+              : (rect.top > document.documentElement.scrollHeight - 1200 ? 'footer' : 'body');
+            const score = scoreLogo(el, context) + 20; // bonus for semantic match
+            results.push({ el, score, context });
+          }
         } catch {}
       }
       return results;
@@ -573,16 +695,30 @@ export async function extractLogo(page, url) {
       }
     }
 
-    // Collect all unique instances (header, footer, hero)
+    // Collect every distinct mark, best-scoring first. Deduplicating by CONTEXT capped the
+    // output at one logo per header/footer/hero, so a lockup rendered as symbol + wordmark
+    // (two elements) lost half of itself, and a page with logos in both the header and the
+    // body could only ever report one. Deduplicate by element instead.
+    const MAX_INSTANCES = 6;
     const instances = [];
-    const seenContexts = new Set();
+    const seenEls = new Set();
     for (const c of allCandidates) {
-      if (seenContexts.has(c.context)) continue;
-      seenContexts.add(c.context);
+      if (instances.length >= MAX_INSTANCES) break;
+      const key = c.cssBackground
+        ? `bg:${c.cssBackground.url}@${Math.round(c.cssBackground.position.top)}`
+        : c.el;
+      if (!key || seenEls.has(key)) continue;
+      seenEls.add(key);
       let inst = null;
       if (c.cssBackground) inst = c.cssBackground;
       else if (c.el) inst = extractLogoFromEl(c.el, c.context, baseUrl);
-      if (inst) instances.push(inst);
+      // Reject UI icons (search/menu/social glyphs) that scored into the candidate list —
+      // measured floor: no real logo is below 24px on its long edge. Judge by the painted
+      // rect (the on-screen size), not the intrinsic asset size.
+      if (inst) {
+        const box = (inst as any).rect || { width: (inst as any).width, height: (inst as any).height };
+        if (H.isLogoSized(box.width, box.height)) instances.push(inst);
+      }
     }
 
     // Favicons
@@ -618,7 +754,7 @@ export async function extractLogo(page, url) {
     }
 
     return { logo: primaryLogo, instances, favicons };
-  }, url);
+  }, { baseUrl: url, heuristicsSource: LOGO_HEURISTICS_SOURCE });
 
   // Merge PWA icons into favicons
   result.favicons = [...result.favicons, ...pwaIcons];

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -1,5 +1,4 @@
 import { DOM_COLOR_SNAPSHOT_SCRIPT, extractPlatformColors, resolvePlatformColors } from './platform-colors.js';
-import { LOGO_HEURISTICS_SOURCE } from './logo-heuristics.js';
 
 export async function extractSiteName(page) {
   return await page.evaluate(() => {
@@ -88,20 +87,8 @@ export async function extractLogo(page, url) {
   if (resolved.darkThemeColor) manifestMeta.darkThemeColor = resolved.darkThemeColor;
   if (resolved.backgroundColor) manifestMeta.backgroundColor = resolved.backgroundColor;
 
-  const result = await page.evaluate(({ baseUrl, heuristicsSource }) => {
+  const result = await page.evaluate((baseUrl) => {
     const siteDomain = new URL(baseUrl).hostname.replace('www.', '').split('.')[0].toLowerCase();
-    // The pure, unit-tested heuristics from logo-heuristics.ts, run here as the exact same
-    // code. guardExtractor wraps this whole evaluate, so even a rehydration failure only
-    // yields an empty logo result for this one site — never a crash.
-    const H = new Function(heuristicsSource +
-      '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')() as {
-        isHomeHref: (href: any, origin: any) => boolean;
-        classifyContextByPosition: (top: any, docHeight: any, foldY?: number) => 'header'|'footer'|'hero'|'body';
-        thirdPartyBrandFromAlt: (alt: any, site: any) => string | null;
-        positionFraction: (token: any) => number;
-        fitPaintedBox: (content: any, intrinsic: any, fit: any, px?: number, py?: number) => { x: number; y: number; width: number; height: number };
-        isLogoSized: (w: any, h: any, minLongEdge?: number) => boolean;
-      };
 
     // Canvas for background color detection
     const canvas = document.createElement('canvas');
@@ -176,11 +163,7 @@ export async function extractLogo(page, url) {
       if (context === 'footer') score += 20;
       if (context === 'hero') score += 15;
 
-      // Compare against the asset's file name, never the whole URL: every image on
-      // adept.com is served from adept.com, so `Sanofi-Logo.png` scored as adept's own
-      // brand and customer-wall logos outranked the real mark.
-      const imgFile = imgSrc.toLowerCase().split(/[?#]/)[0].split('/').pop() || '';
-      if (imgFile.includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
+      if (imgSrc.toLowerCase().includes(siteDomain) || altText.includes(siteDomain) || className.includes(siteDomain)) score += 40;
       if (className.includes('logo') || el.id?.toLowerCase().includes('logo')) score += 30;
 
       // SVG with aria-label="Homepage" directly in a home anchor — strong signal
@@ -221,58 +204,6 @@ export async function extractLogo(page, url) {
       if (width > height && width < 400 && width > 40 && height > 10 && height < 120) score += 15;
 
       return score;
-    }
-
-    // The box a logo actually occupies on screen. `width`/`height` below report the
-    // asset's intrinsic size (naturalWidth, or the svg's width attribute) — useful, but
-    // not where the mark is painted. Every layer can resize a logo independently:
-    //
-    //   intrinsic   naturalWidth/Height, or the svg viewBox
-    //   attributes  <img width height>
-    //   CSS         width/height/max-*/aspect-ratio, padding, border, box-sizing
-    //   CSS         object-fit + object-position (an img can letterbox inside its box)
-    //   CSS         transform: scale/rotate (getBoundingClientRect already includes it)
-    //   SVG         preserveAspectRatio (letterboxes the same way object-fit: contain does)
-    //   responsive  srcset/sizes and DPR pick a different asset than the one in `src`
-    //   JS          anything that mutates the above at runtime
-    //
-    // getBoundingClientRect() settles most of it: it is the post-layout, post-transform
-    // border box. What it cannot tell us is that a contained image paints only part of
-    // that box. So: strip border+padding to get the content box, then fit the intrinsic
-    // aspect ratio inside it the way object-fit / preserveAspectRatio would.
-    function paintedRect(el) {
-      const r = el.getBoundingClientRect();
-      const cs = getComputedStyle(el);
-      const n = (v) => parseFloat(v) || 0;
-      const x = r.left + n(cs.borderLeftWidth) + n(cs.paddingLeft);
-      const y = r.top + n(cs.borderTopWidth) + n(cs.paddingTop);
-      const w = Math.max(0, r.width - n(cs.borderLeftWidth) - n(cs.borderRightWidth) - n(cs.paddingLeft) - n(cs.paddingRight));
-      const h = Math.max(0, r.height - n(cs.borderTopWidth) - n(cs.borderBottomWidth) - n(cs.paddingTop) - n(cs.paddingBottom));
-
-      let iw = 0, ih = 0, fit = 'fill';
-      if (el.tagName === 'IMG') {
-        iw = el.naturalWidth; ih = el.naturalHeight;
-        fit = cs.objectFit || 'fill';
-      } else if (el.tagName.toLowerCase() === 'svg') {
-        const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number).filter((v) => !isNaN(v));
-        if (vb.length === 4 && vb[2] > 0 && vb[3] > 0) { iw = vb[2]; ih = vb[3]; }
-        const par = el.getAttribute('preserveAspectRatio') || 'xMidYMid meet';
-        fit = /\bnone\b/.test(par) ? 'fill' : (/\bslice\b/.test(par) ? 'cover' : 'contain');
-      }
-
-      // object-position (svg letterboxing centres by default, as xMidYMid does)
-      const pos = (el.tagName === 'IMG' ? cs.objectPosition : '50% 50%').split(/\s+/);
-      const fitted = H.fitPaintedBox(
-        { x, y, width: w, height: h },
-        iw > 0 && ih > 0 ? { width: iw, height: ih } : null,
-        fit,
-        H.positionFraction(pos[0]),
-        H.positionFraction(pos[1] || pos[0]),
-      );
-      return {
-        x: Math.round(fitted.x + window.scrollX), y: Math.round(fitted.y + window.scrollY),
-        width: Math.round(fitted.width), height: Math.round(fitted.height),
-      };
     }
 
     function extractLogoFromEl(el, context, baseUrl) {
@@ -333,10 +264,8 @@ export async function extractLogo(page, url) {
           source: 'img',
           context,
           url: new URL(src, baseUrl).href,
-          width: el.naturalWidth || rect.width,     // intrinsic (asset) size
+          width: el.naturalWidth || rect.width,
           height: el.naturalHeight || rect.height,
-          rect: paintedRect(el),                     // where the mark is actually painted
-          natural: { width: el.naturalWidth || null, height: el.naturalHeight || null },
           alt: altText,
           type: logoType,
           reversed,
@@ -391,10 +320,8 @@ export async function extractLogo(page, url) {
           markup,
           dataUri,
           svgColors: uniqueSvgColors,
-          width: el.width?.baseVal?.value || rect.width,   // the svg's width attribute
+          width: el.width?.baseVal?.value || rect.width,
           height: el.height?.baseVal?.value || rect.height,
-          rect: paintedRect(el),                            // where the mark is actually painted
-          natural: (() => { const vb = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number); return vb.length === 4 ? { width: vb[2], height: vb[3] } : { width: null, height: null }; })(),
           type: logoType,
           reversed,
           background: bg,
@@ -421,16 +348,13 @@ export async function extractLogo(page, url) {
           const altText = (el.getAttribute('alt') || '').toLowerCase();
           const attrs = (className + ' ' + (el.id || '') + ' ' + altText).toLowerCase();
 
-          // Disqualify third-party brand logos: alt naming a brand that isn't our site
+          // Disqualify third-party brand logos: alt like "Notion logo" / "Perplexity logo" / "Figma" where the brand isn't our site
           // These appear in customer/integration/testimonial sections on marketing pages.
-          // A mark that links home is ours whatever its alt says; otherwise, if its alt
-          // names a different brand, it is a customer/integration logo — skip it.
-          const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
-          if (!homeLinked) {
-            const srcFile = (el.currentSrc || el.getAttribute('src') || '').split(/[?#]/)[0].split('/').pop() || '';
-            // alt OR the asset file name may name a different brand (customer/partner wall)
-            if (H.thirdPartyBrandFromAlt(altText, siteDomain) || H.thirdPartyBrandFromAlt(srcFile, siteDomain)) {
-              return; // a third party's brand, in its alt text or its file name
+          const altBrandMatch = altText.match(/^([a-z][a-z0-9.-]{1,30}?)(?:\s+(?:logo|icon|brand|wordmark))?$/i);
+          if (altBrandMatch) {
+            const altBrand = altBrandMatch[1].replace(/[\s.-]/g, '').toLowerCase();
+            if (altBrand && altBrand !== 'logo' && altBrand !== 'brand' && altBrand !== 'icon' && altBrand !== siteDomain && !altBrand.includes(siteDomain) && !siteDomain.includes(altBrand)) {
+              return; // third-party brand, skip entirely
             }
           }
 
@@ -502,33 +426,9 @@ export async function extractLogo(page, url) {
     // SPA/PWA apps often render into a root div — treat it as transparent wrapper
     const spaRoot = document.querySelector('#app, #root, #__next, #__nuxt, [data-reactroot]') as any;
 
-    // A comma-separated querySelector returns the first match in DOCUMENT order, not the
-    // first matching selector. Cookie dialogs and modals ship markup like
-    // `div.osano-cm-info__info-dialog-header` and `div.modal-col-header` near the top of
-    // the body, so `[class*="header"]` won the race and the real <header> was never
-    // scanned (seen on sites whose cookie/modal markup sits before the real header). Try
-    // the selectors in order of authority, and only accept a rendered element.
-    const visible = (el: any) => {
-      if (!el) return false;
-      const s = getComputedStyle(el);
-      if (s.display === 'none' || s.visibility === 'hidden') return false;
-      const r = el.getBoundingClientRect();
-      return r.width > 0 && r.height > 0;
-    };
-    const pickZone = (selectors: string[], accept: (el: any) => boolean = () => true) => {
-      for (const sel of selectors) {
-        for (const el of Array.from(document.querySelectorAll(sel))) {
-          if (visible(el) && accept(el)) return el as any;
-        }
-      }
-      return null;
-    };
-
-    const headerEl = pickZone(
-      ['header', '[role="banner"]', '[class*="header"]', '[id*="header"]'],
-      // a header sits at the top and spans the page; a modal's header does neither
-      (el) => { const r = el.getBoundingClientRect(); return r.top < 300 && r.width > window.innerWidth * 0.3; },
-    ) || pickZone(['header', '[role="banner"]']) || (() => {
+    const headerEl = document.querySelector(
+      'header, [role="banner"], [class*="header"], [id*="header"]'
+    ) || (() => {
       // Fallback: find first visually top element in SPA root or body that spans full width
       const root = spaRoot || document.body;
       const children = Array.from((root as any).children) as any[];
@@ -541,8 +441,8 @@ export async function extractLogo(page, url) {
       }
       return null;
     })();
-    const navEl = pickZone(['nav', '[role="navigation"]']) as any;
-    const footerEl = pickZone(['footer', '[role="contentinfo"]', '[class*="footer"]', '[id*="footer"]']) as any;
+    const navEl = document.querySelector('nav, [role="navigation"]') as any;
+    const footerEl = document.querySelector('footer, [role="contentinfo"], [class*="footer"], [id*="footer"]') as any;
 
     // Hero: first large section that's not header/footer
     const heroEl = (() => {
@@ -613,52 +513,30 @@ export async function extractLogo(page, url) {
     // Global pre-scan: strong semantic signals that identify a logo anywhere in the document
     const globalLogoCandidates = (() => {
       const results = [];
-      // Tag-AGNOSTIC: an inline <svg> logo wrapped in a home link is as much the site's
-      // mark as an <img> is, but the old img-only selectors could not see it — that alone
-      // accounted for a large share of the missed home-linked inline-SVG logos.
-      // Gather both img and svg from three unambiguous sources: a logo-named container, a
-      // logo-named ancestor, and a link to the home page.
-      const isHomeHref = (h) => { h = (h || '').toLowerCase(); return h === '/' || h === './'
-        || h === location.origin || h === location.origin + '/'; };
-      const marks = new Set();
-      document.querySelectorAll('[class*="logo" i] img, [class*="logo" i] svg, [id*="logo" i] img, [id*="logo" i] svg')
-        .forEach(el => marks.add(el));
-      document.querySelectorAll('a[href], [role="link"]').forEach(a => {
-        if (!isHomeHref(a.getAttribute('href'))) return;
-        a.querySelectorAll('img, svg').forEach(el => marks.add(el));
-      });
+      const selectors = [
+        'img[class*="logo"]',
+        'img[id*="logo"]',
+        'a[class*="logo"] img',
+        'a[id*="logo"] img',
+        '[class*="logo-link"] img',
+        '[class*="logo-wrap"] img',
+        '[class*="logo-container"] img',
+        'a[href="/"] img',
+        'a[href="./"] img',
+      ];
       const seen = new Set();
-      for (const el of marks as Set<any>) {
+      for (const sel of selectors) {
         try {
-          if (seen.has(el)) continue;
-          seen.add(el);
-          {
+          document.querySelectorAll(sel).forEach(el => {
+            if (seen.has(el)) return;
+            seen.add(el);
             const rect = el.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) continue;
-            // Below-fold logos are real — 15 of the 22 marks humans found and this extractor
-            // missed sit under the fold. But letting every semantically-named mark through
-            // tripled the proposal count with customer-wall logos, so only the ones that
-            // link to the home page qualify down there: that link is the site claiming the
-            // mark as its own.
-            if (rect.width > 1500 || rect.height > 500) continue; // an illustration, not a mark
-            if (!H.isLogoSized(rect.width, rect.height)) continue; // a UI icon, not a logo
-            const homeLinked = H.isHomeHref(el.closest('a')?.getAttribute('href'), location.origin);
-            // A customer/partner wall matches [class*=logo] too. If a non-home-linked mark
-            // names a different brand in its alt or file name, it is not ours — skip it.
-            // (A partner strip of "logo-<Brand>.svg" images slipped in here: the pre-scan
-            // never ran the third-party guard that findLogosInZone applies.)
-            if (!homeLinked) {
-              const altText = (el.getAttribute('alt') || '');
-              const srcFile = (el.currentSrc || el.getAttribute('src') || '').split(/[?#]/)[0].split('/').pop() || '';
-              if (H.thirdPartyBrandFromAlt(altText, siteDomain) || H.thirdPartyBrandFromAlt(srcFile, siteDomain)) continue;
-            }
-            const belowFold = rect.top > 500;
-            if (belowFold && !homeLinked) continue; // below the fold, only our own home-linked mark
-            const context = !belowFold ? 'header'
-              : (rect.top > document.documentElement.scrollHeight - 1200 ? 'footer' : 'body');
-            const score = scoreLogo(el, context) + 20; // bonus for semantic match
-            results.push({ el, score, context });
-          }
+            if (rect.width === 0 || rect.height === 0) return;
+            if (rect.top > 500) return; // must be near top
+            if (rect.width > 600 || rect.height > 200) return; // too large
+            const score = scoreLogo(el, 'header') + 20; // bonus for semantic match
+            results.push({ el, score, context: 'header' });
+          });
         } catch {}
       }
       return results;
@@ -695,30 +573,16 @@ export async function extractLogo(page, url) {
       }
     }
 
-    // Collect every distinct mark, best-scoring first. Deduplicating by CONTEXT capped the
-    // output at one logo per header/footer/hero, so a lockup rendered as symbol + wordmark
-    // (two elements) lost half of itself, and a page with logos in both the header and the
-    // body could only ever report one. Deduplicate by element instead.
-    const MAX_INSTANCES = 6;
+    // Collect all unique instances (header, footer, hero)
     const instances = [];
-    const seenEls = new Set();
+    const seenContexts = new Set();
     for (const c of allCandidates) {
-      if (instances.length >= MAX_INSTANCES) break;
-      const key = c.cssBackground
-        ? `bg:${c.cssBackground.url}@${Math.round(c.cssBackground.position.top)}`
-        : c.el;
-      if (!key || seenEls.has(key)) continue;
-      seenEls.add(key);
+      if (seenContexts.has(c.context)) continue;
+      seenContexts.add(c.context);
       let inst = null;
       if (c.cssBackground) inst = c.cssBackground;
       else if (c.el) inst = extractLogoFromEl(c.el, c.context, baseUrl);
-      // Reject UI icons (search/menu/social glyphs) that scored into the candidate list —
-      // measured floor: no real logo is below 24px on its long edge. Judge by the painted
-      // rect (the on-screen size), not the intrinsic asset size.
-      if (inst) {
-        const box = (inst as any).rect || { width: (inst as any).width, height: (inst as any).height };
-        if (H.isLogoSized(box.width, box.height)) instances.push(inst);
-      }
+      if (inst) instances.push(inst);
     }
 
     // Favicons
@@ -754,7 +618,7 @@ export async function extractLogo(page, url) {
     }
 
     return { logo: primaryLogo, instances, favicons };
-  }, { baseUrl: url, heuristicsSource: LOGO_HEURISTICS_SOURCE });
+  }, url);
 
   // Merge PWA icons into favicons
   result.favicons = [...result.favicons, ...pwaIcons];


### PR DESCRIPTION
Closes DEM-151 (Action half; Vercel preview integration is covered as the `deployment_status` recipe in the README rather than code). Supersedes #115 (branch renamed).

## What

- **`action.yml`** — composite action at repo root:
  - CLI version pinned (`dembrandt@0.22.0`) so a `@v1` gate never changes behavior between npm releases; bump together with `package.json` on release (noted inline)
  - Chromium install matching `playwright-core` 1.60.0, cached via `actions/cache`
  - Inputs flow through `env`, never inline-interpolated into the script (script-injection hardening)
  - `key` input rides the CLI's own `DEMBRANDT_KEY` env fallback — never appears on the command line
  - Outputs: `report` (JSON path), `score` (from `.drift.score`)
  - Exit code carries the verdict (0 stable / 1 drift / 2 extraction / 67 timeout); drift annotations render automatically because the CLI emits workflow commands under `GITHUB_ACTIONS` (DEM-83). In `--json-only` mode they land on stderr (console.log redirect, index.ts:101), which the runner also parses — stdout JSON stays clean
- **`.github/workflows/action-smoke.yml`** — dogfood: runs `uses: ./` against www.dembrandt.com **without a baseline**, asserting only that the report is valid JSON. Deliberately not a drift assertion, so extraction churn (open issue) cannot flake CI
- **README** — GitHub Action section under Continuous integration: minimal usage, Vercel `deployment_status` recipe, inputs/outputs table; hand-rolled `examples/drift-gate.yml` kept as the advanced reference

## Out of scope (v1.1 candidates)

- PR comment with the drift table rendered from `report` (annotations cover v1)
- Marketplace publish: after merge, cut a `v1` release tag and tick "Publish this Action to the GitHub Marketplace" — mechanical, no code

## Test plan

- `action-smoke` workflow triggers on this PR (path filter matches `action.yml`) and exercises the full composite: Node setup → Chromium cache+install → npx run → report assert