### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Title: conventional commit style — feat(scope): …, fix(scope): …, chore: … -->
+
+## What
+
+<!-- What changes and why. One paragraph. Link the ticket: Closes DEM-XXX -->
+
+## How
+
+<!-- Decisions a reviewer needs: approach, tradeoffs, rejected alternatives.
+     Delete if the diff speaks for itself. -->
+
+## Test plan
+
+<!-- How this was verified: `npm test`, a real CLI run against a live site,
+     qa:diff, or the CI smoke — name the concrete command, not "tested". -->
+
+## Checklist
+
+- [ ] `npm run lint` and `npm test` pass locally
+- [ ] New/changed flags: orthogonal, propagate to multi-page runs, documented in README and `docs/FLAGS.md`
+- [ ] CLI contract intact: exit-code taxonomy and clean `--json-only` stdout (status output to stderr)
+- [ ] User-facing behavior change → README updated


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md`.

Sections mirror how recent PRs (#110–#116) are already written — What / How / Test plan — so the template codifies existing practice instead of inventing a new format. The checklist encodes the repo's standing contracts that CI does not fully enforce: flag orthogonality + `docs/FLAGS.md`, exit-code taxonomy, and clean `--json-only` stdout.

## Test plan

Markdown-only change; the template renders on the next PR opened after merge.