### PR TITLE
fix(drift): comparison-validity warnings, scoring calibration, meta provenance (schema 1.3.0)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -470,6 +470,13 @@ program
             // CI gate: drift fails the run, but the report still writes first.
             process.exitCode = EXIT.DRIFT;
           }
+          // A compare where every category was degraded proved nothing. Same
+          // rule as an unreadable baseline: "check broke, investigate" (exit
+          // RUNTIME), never a silent pass. An explicit --approve of a local
+          // baseline still wins: the user chose to accept this extraction.
+          if (report.inconclusive && !(opts.approve && mode === "local") && process.exitCode === undefined) {
+            process.exitCode = EXIT.RUNTIME;
+          }
           // Under GitHub Actions, surface a failing drift gate inline on the PR
           // via workflow-command annotations (DEM-83). No-op locally. Gated on
           // the gate actually failing, so an --approve'd local baseline (which

--- a/index.ts
+++ b/index.ts
@@ -448,6 +448,9 @@ program
               `${report.summary.changed} changed, ${report.summary.added} added, ${report.summary.removed} removed`
             )
           );
+          for (const w of report.warnings ?? []) {
+            savedNotices.push(color.warning(`! ${w}`));
+          }
           // --approve: accept the current extraction as the new baseline.
           // Only local files can be overwritten; App baseline ids are read-only.
           if (opts.approve) {

--- a/lib/ci-annotations.ts
+++ b/lib/ci-annotations.ts
@@ -69,6 +69,12 @@ export function driftAnnotations(report: DriftReport): string[] {
   const title = `Design drift ${report.score} exceeds threshold ${report.threshold}`;
   const summary = `${report.summary.changed} changed, ${report.summary.added} added, ${report.summary.removed} removed`;
   lines.push(`::error title=${escapeProperty(title)}::${escapeData(summary)}`);
+  // Comparison-validity caveats (viewport/flag/font mismatch, degraded
+  // categories) must render next to the failures they qualify, or reviewers
+  // act on drift that the engine itself has flagged as suspect.
+  for (const w of report.warnings ?? []) {
+    lines.push(`::warning title=${escapeProperty("Drift comparison caveat")}::${escapeData(w)}`);
+  }
   for (const c of report.changes) {
     lines.push(`::${severityForKind(c.kind)}::${escapeData(changeMessage(c))}`);
   }

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -537,6 +537,7 @@ const STAGE_CATEGORY: Record<string, DriftCategory> = {
   "hover-focus": "color",
   "gradient-colors": "color",
   "svg-logo-colors": "color",
+  manifest: "color",
 };
 
 function degradedDriftCategories(r: ExtractionResult): Set<DriftCategory> {

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -614,6 +614,15 @@ export function computeDrift(
     }
   }
 
+  // Degradation can exclude every comparable category. The score is then 0 by
+  // construction, not by evidence — a gate must not treat that as a clean pass.
+  if (totalW === 0 && (baseDegraded.size > 0 || candDegraded.size > 0)) {
+    warnings.push(
+      "no category could be scored: every comparable category was degraded — " +
+      "this compare is inconclusive, not stable. Re-extract and retry."
+    );
+  }
+
   const score = totalW > 0 ? Math.round((weighted / totalW) * 100) : 0;
   const summary = changes.reduce(
     (acc, c) => {

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -68,6 +68,10 @@ export interface DriftReport {
    *  different viewport widths). The score stands, but changes may be
    *  environment-induced rather than design drift. */
   warnings?: string[];
+  /** True when degradation excluded every comparable category: the score is 0
+   *  by construction, not evidence. A gate must treat this as "could not
+   *  evaluate", not as a pass. */
+  inconclusive?: boolean;
 }
 
 /* ----------------------------- color math ----------------------------- */
@@ -211,16 +215,22 @@ function fieldDiffs(b: TypographyStyle, c: TypographyStyle, cfg: DriftConfig): n
   return d;
 }
 
-// Typography severities, tuned so no single style change can max the category
-// on its own. Removals are the noisiest signal live-DOM extraction produces (a
-// style missing from one crawl is usually crawl variance, not a design change),
-// so a removal scores below a confirmed in-place family change.
-const TYPO_FAMILY_PENALTY = 0.8;
-const TYPO_REMOVED_PENALTY = 0.6;
+// Typography severities. Two invariants pull against each other and both must
+// hold with the default weights (sum 4.0) and threshold (10):
+//  - a single CONFIRMED in-place family change must flag drift (damped peak
+//    must exceed 0.4), and mass deletion must flag drift (removal must carry
+//    full weight in the accumulating penalty so 6/10 styles removed → 0.6);
+//  - a single removed style must NOT flag drift (removals are the noisiest
+//    signal live-DOM extraction produces — usually crawl variance), and no
+//    single change may read as the whole type system being replaced (peak
+//    never maxes the category).
+const TYPO_FAMILY_PENALTY = 1.0;
+const TYPO_REMOVED_PENALTY = 1.0; // accumulating penalty: deletions scale linearly
+const TYPO_REMOVED_PEAK = 0.6; // peak: one removal (0.3 damped, overall 7.5) stays stable
 const TYPO_ADDED_PENALTY = 0.5;
 // The peak floor keeps one large regression visible among many unchanged
-// styles, but damped: severity 1.0 floors the category at 50%, not 100%, so a
-// single style change never reads as the whole type system being replaced.
+// styles, damped so severity 1.0 floors the category at 50% (overall 12.5,
+// drifts) instead of 100%.
 const TYPO_PEAK_DAMP = 0.5;
 
 // Severity of one style's change, scaled by magnitude (0..1). A doubled font
@@ -259,7 +269,7 @@ function compareTypography(base: TypographyStyle[], cand: TypographyStyle[], cfg
     if (!bucket || bucket.length === 0) {
       changes.push({ category: "typography", kind: "removed", label: b.context, before: fmt(b) });
       penalty += TYPO_REMOVED_PENALTY;
-      peak = Math.max(peak, TYPO_REMOVED_PENALTY);
+      peak = Math.max(peak, TYPO_REMOVED_PEAK);
       removed++;
       continue;
     }
@@ -437,12 +447,17 @@ function viewportWarning(baseline: ExtractionResult, candidate: ExtractionResult
   const b = baseline.meta?.viewport;
   const c = candidate.meta?.viewport;
   if (!b || !c) return null;
-  // Persisted blobs are untrusted: widths may be strings or absent. Coerce, and
-  // stay silent on anything non-numeric rather than warn on garbage.
-  const bw = Number(b.width);
-  const cw = Number(c.width);
-  if (!Number.isFinite(bw) || !Number.isFinite(cw) || bw === cw) return null;
-  const dim = (v: { width: unknown; height: unknown }) => `${Number(v.width)}x${Number(v.height)}`;
+  // Persisted blobs are untrusted: widths may be strings, null, or absent.
+  // Coerce, and stay silent unless both widths are real positive numbers —
+  // Number(null) and Number('') are 0, which is finite but not a viewport.
+  const px = (v: unknown) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
+  const bw = px(b.width);
+  const cw = px(c.width);
+  if (bw === null || cw === null || bw === cw) return null;
+  const dim = (v: { width: unknown; height: unknown }) => `${px(v.width)}x${px(v.height) ?? "?"}`;
   return (
     `baseline extracted at ${dim(b)}, candidate at ${dim(c)} — ` +
     `layout-dependent changes below may be viewport-induced, not design drift. ` +
@@ -470,16 +485,21 @@ function pageMismatchWarning(baseline: ExtractionResult, candidate: ExtractionRe
   );
 }
 
-/** --dark-mode merges a dark-scheme pass into the palette, so extracts with and
- * without it are not comparable: the whole palette "changes". */
-function darkModeWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
-  const b = Boolean(baseline.meta?.flags?.darkMode);
-  const c = Boolean(candidate.meta?.flags?.darkMode);
-  if (b === c) return null;
-  return (
-    `--dark-mode was on for the ${b ? "baseline" : "candidate"} only — ` +
-    `palette drift may be theme-induced, not design drift. Re-extract with matching flags.`
-  );
+/** --dark-mode and --mobile merge extra passes into the palette, so extracts
+ * with and without them are not comparable: the whole palette "changes". */
+function flagMismatchWarnings(baseline: ExtractionResult, candidate: ExtractionResult): string[] {
+  const out: string[] = [];
+  for (const flag of ["darkMode", "mobile"] as const) {
+    const b = Boolean(baseline.meta?.flags?.[flag]);
+    const c = Boolean(candidate.meta?.flags?.[flag]);
+    if (b === c) continue;
+    const name = flag === "darkMode" ? "--dark-mode" : "--mobile";
+    out.push(
+      `${name} was on for the ${b ? "baseline" : "candidate"} only — ` +
+      `palette drift may be flag-induced, not design drift. Re-extract with matching flags.`
+    );
+  }
+  return out;
 }
 
 /** A snapshot taken before web fonts finished loading carries fallback
@@ -501,8 +521,10 @@ function fontsWarning(baseline: ExtractionResult, candidate: ExtractionResult): 
 }
 
 /** Stage names the extractor records in meta.errors / meta.degraded, mapped to
- * the drift category they invalidate. The dark-mode and mobile passes merge
- * extra colors into the palette, so their failure degrades color. */
+ * the drift category they invalidate. Every pass that merges colors into the
+ * palette (dark-mode, mobile, reveal, hover-focus, gradient-colors,
+ * svg-logo-colors) degrades color when it fails: its colors go missing and
+ * would read as removed brand colors. */
 const STAGE_CATEGORY: Record<string, DriftCategory> = {
   colors: "color",
   typography: "typography",
@@ -511,6 +533,10 @@ const STAGE_CATEGORY: Record<string, DriftCategory> = {
   shadows: "shadow",
   "dark-mode": "color",
   mobile: "color",
+  reveal: "color",
+  "hover-focus": "color",
+  "gradient-colors": "color",
+  "svg-logo-colors": "color",
 };
 
 function degradedDriftCategories(r: ExtractionResult): Set<DriftCategory> {
@@ -537,8 +563,11 @@ export function computeDrift(
   const candPalette = paletteEntries(candidate);
   const baseTypo = baseline.typography?.styles ?? [];
   const candTypo = candidate.typography?.styles ?? [];
-  const baseSpacing = (baseline.spacing?.commonValues ?? []).map((s) => String(s.px));
-  const candSpacing = (candidate.spacing?.commonValues ?? []).map((s) => String(s.px));
+  // Filter before the comparable check, like radius/shadows below: a list of
+  // only unparseable entries must count as "nothing to compare", not enter the
+  // average as a guaranteed-zero category.
+  const baseSpacing = (baseline.spacing?.commonValues ?? []).map((s) => String(s.px)).filter(isRealisticDimension);
+  const candSpacing = (candidate.spacing?.commonValues ?? []).map((s) => String(s.px)).filter(isRealisticDimension);
   const baseRadius = (baseline.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension);
   const candRadius = (candidate.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension);
   const baseShadows = (baseline.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow);
@@ -576,7 +605,7 @@ export function computeDrift(
   for (const w of [
     viewportWarning(baseline, candidate),
     pageMismatchWarning(baseline, candidate),
-    darkModeWarning(baseline, candidate),
+    ...flagMismatchWarnings(baseline, candidate),
     fontsWarning(baseline, candidate),
   ]) {
     if (w) warnings.push(w);
@@ -591,8 +620,6 @@ export function computeDrift(
   const categories: CategoryResult[] = [];
   const changes: DriftChange[] = [];
   for (const p of parts) {
-    categories.push(p.result);
-    changes.push(...p.changes);
     const cat = p.result.category;
     const degradedSides = [
       baseDegraded.has(cat) ? "baseline" : null,
@@ -600,14 +627,17 @@ export function computeDrift(
     ].filter(Boolean);
     if (degradedSides.length > 0) {
       // Engine rule (see ExtractionMeta.degraded): a degraded category failed
-      // extraction, the brand did not change — its missing tokens would read
-      // as removals, so it must not enter the score.
+      // extraction, the brand did not change — its phantom tokens must not
+      // enter the score, the change list, the summary, or CI annotations.
+      categories.push({ category: cat, score: 0, changed: 0, added: 0, removed: 0 });
       warnings.push(
         `${cat} extraction was degraded in the ${degradedSides.join(" and ")} — ` +
         `category excluded from the drift score.`
       );
       continue;
     }
+    categories.push(p.result);
+    changes.push(...p.changes);
     if (p.comparable) {
       weighted += p.result.score * p.w;
       totalW += p.w;
@@ -616,7 +646,8 @@ export function computeDrift(
 
   // Degradation can exclude every comparable category. The score is then 0 by
   // construction, not by evidence — a gate must not treat that as a clean pass.
-  if (totalW === 0 && (baseDegraded.size > 0 || candDegraded.size > 0)) {
+  const inconclusive = totalW === 0 && (baseDegraded.size > 0 || candDegraded.size > 0);
+  if (inconclusive) {
     warnings.push(
       "no category could be scored: every comparable category was degraded — " +
       "this compare is inconclusive, not stable. Re-extract and retry."
@@ -640,5 +671,6 @@ export function computeDrift(
     categories,
     changes,
     ...(warnings.length ? { warnings } : {}),
+    ...(inconclusive ? { inconclusive: true } : {}),
   };
 }

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -211,12 +211,24 @@ function fieldDiffs(b: TypographyStyle, c: TypographyStyle, cfg: DriftConfig): n
   return d;
 }
 
+// Typography severities, tuned so no single style change can max the category
+// on its own. Removals are the noisiest signal live-DOM extraction produces (a
+// style missing from one crawl is usually crawl variance, not a design change),
+// so a removal scores below a confirmed in-place family change.
+const TYPO_FAMILY_PENALTY = 0.8;
+const TYPO_REMOVED_PENALTY = 0.6;
+const TYPO_ADDED_PENALTY = 0.5;
+// The peak floor keeps one large regression visible among many unchanged
+// styles, but damped: severity 1.0 floors the category at 50%, not 100%, so a
+// single style change never reads as the whole type system being replaced.
+const TYPO_PEAK_DAMP = 0.5;
+
 // Severity of one style's change, scaled by magnitude (0..1). A doubled font
 // size weighs far more than a 5% nudge — binary field counting hid that, making
 // a hero-size regression look as mild as a rounding tweak.
 function fieldPenalty(b: TypographyStyle, c: TypographyStyle, cfg: DriftConfig): number {
   let p = 0;
-  if (normFamily(b.family) !== normFamily(c.family)) p += 1;
+  if (normFamily(b.family) !== normFamily(c.family)) p += TYPO_FAMILY_PENALTY;
   if (String(b.weight) !== String(c.weight)) p += 0.5;
   const sizePct = pctChange(parseFloat(b.size), parseFloat(c.size));
   if (sizePct > cfg.dimPct) p += clamp01(sizePct / cfg.dimShiftPct);
@@ -246,8 +258,8 @@ function compareTypography(base: TypographyStyle[], cand: TypographyStyle[], cfg
     const bucket = buckets.get(key(b));
     if (!bucket || bucket.length === 0) {
       changes.push({ category: "typography", kind: "removed", label: b.context, before: fmt(b) });
-      penalty += 1;
-      peak = Math.max(peak, 1);
+      penalty += TYPO_REMOVED_PENALTY;
+      peak = Math.max(peak, TYPO_REMOVED_PENALTY);
       removed++;
       continue;
     }
@@ -276,16 +288,23 @@ function compareTypography(base: TypographyStyle[], cand: TypographyStyle[], cfg
   for (const arr of buckets.values()) {
     for (const c of arr) {
       changes.push({ category: "typography", kind: "added", label: c.context, after: fmt(c) });
-      penalty += 0.5;
-      peak = Math.max(peak, 0.5);
+      penalty += TYPO_ADDED_PENALTY;
+      peak = Math.max(peak, TYPO_ADDED_PENALTY);
       added++;
     }
   }
 
   return {
     changes,
-    // Peak keeps a single large regression from being diluted by many unchanged styles.
-    result: { category: "typography", score: Math.max(categoryScore(penalty, base.length, cand.length), peak), changed, added, removed },
+    // Damped peak keeps a single large regression from being diluted by many
+    // unchanged styles without letting it max the category (see TYPO_PEAK_DAMP).
+    result: {
+      category: "typography",
+      score: Math.max(categoryScore(penalty, base.length, cand.length), peak * TYPO_PEAK_DAMP),
+      changed,
+      added,
+      removed,
+    },
   };
 }
 

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -451,36 +451,42 @@ export function computeDrift(
 ): DriftReport {
   const cfg: DriftConfig = { ...DEFAULT_DRIFT_CONFIG, ...config, weights: { ...DEFAULT_DRIFT_CONFIG.weights, ...config.weights } };
 
+  const basePalette = paletteEntries(baseline);
+  const candPalette = paletteEntries(candidate);
+  const baseTypo = baseline.typography?.styles ?? [];
+  const candTypo = candidate.typography?.styles ?? [];
+  const baseSpacing = (baseline.spacing?.commonValues ?? []).map((s) => String(s.px));
+  const candSpacing = (candidate.spacing?.commonValues ?? []).map((s) => String(s.px));
+  const baseRadius = (baseline.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension);
+  const candRadius = (candidate.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension);
+  const baseShadows = (baseline.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow);
+  const candShadows = (candidate.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow);
+
+  // A category empty on BOTH sides carries no information; letting it enter the
+  // average at score 0 dilutes real drift in the categories that were measured.
+  const comparable = (b: unknown[], c: unknown[]) => b.length + c.length > 0;
+
   const parts = [
-    { ...compareColors(paletteEntries(baseline), paletteEntries(candidate), cfg), w: cfg.weights.color },
+    { ...compareColors(basePalette, candPalette, cfg), w: cfg.weights.color, comparable: comparable(basePalette, candPalette) },
     {
-      ...compareTypography(baseline.typography?.styles ?? [], candidate.typography?.styles ?? [], cfg),
+      ...compareTypography(baseTypo, candTypo, cfg),
       w: cfg.weights.typography,
+      comparable: comparable(baseTypo, candTypo),
     },
     {
-      ...compareDimensions(
-        "spacing",
-        (baseline.spacing?.commonValues ?? []).map((s) => String(s.px)),
-        (candidate.spacing?.commonValues ?? []).map((s) => String(s.px)),
-        cfg
-      ),
+      ...compareDimensions("spacing", baseSpacing, candSpacing, cfg),
       w: cfg.weights.spacing,
+      comparable: comparable(baseSpacing, candSpacing),
     },
     {
-      ...compareDimensions(
-        "radius",
-        (baseline.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension),
-        (candidate.borderRadius?.values ?? []).filter(notLowConfidence).map((r) => r.value).filter(isRealisticDimension),
-        cfg
-      ),
+      ...compareDimensions("radius", baseRadius, candRadius, cfg),
       w: cfg.weights.radius,
+      comparable: comparable(baseRadius, candRadius),
     },
     {
-      ...compareShadows(
-        (baseline.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow),
-        (candidate.shadows ?? []).filter(notLowConfidence).map((s) => s.shadow).filter(isSupportedShadow)
-      ),
+      ...compareShadows(baseShadows, candShadows),
       w: cfg.weights.shadow,
+      comparable: comparable(baseShadows, candShadows),
     },
   ];
 
@@ -492,8 +498,7 @@ export function computeDrift(
   for (const p of parts) {
     categories.push(p.result);
     changes.push(...p.changes);
-    const active = p.result.changed + p.result.added + p.result.removed > 0 || p.result.score > 0;
-    if (active || p.w > 0) {
+    if (p.comparable) {
       weighted += p.result.score * p.w;
       totalW += p.w;
     }

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -450,6 +450,82 @@ function viewportWarning(baseline: ExtractionResult, candidate: ExtractionResult
   );
 }
 
+/** Both extracts must come from the same page: result.url is the final URL
+ * after redirects, so a baseline that landed on /fi/ diffed against a candidate
+ * on / compares two different surfaces. */
+function pageMismatchWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
+  let b: URL;
+  let c: URL;
+  try {
+    b = new URL(baseline.url);
+    c = new URL(candidate.url);
+  } catch {
+    return null;
+  }
+  const norm = (u: URL) => u.host.replace(/^www\./, "") + u.pathname.replace(/\/+$/, "");
+  if (norm(b) === norm(c)) return null;
+  return (
+    `baseline was extracted from ${b.href}, candidate from ${c.href} — ` +
+    `different pages after redirects, the diff compares two different surfaces.`
+  );
+}
+
+/** --dark-mode merges a dark-scheme pass into the palette, so extracts with and
+ * without it are not comparable: the whole palette "changes". */
+function darkModeWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
+  const b = Boolean(baseline.meta?.flags?.darkMode);
+  const c = Boolean(candidate.meta?.flags?.darkMode);
+  if (b === c) return null;
+  return (
+    `--dark-mode was on for the ${b ? "baseline" : "candidate"} only — ` +
+    `palette drift may be theme-induced, not design drift. Re-extract with matching flags.`
+  );
+}
+
+/** A snapshot taken before web fonts finished loading carries fallback
+ * families; family drift against it is suspect. */
+function fontsWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
+  const sides: string[] = [];
+  if (baseline.meta?.fontsReady === false) sides.push("baseline");
+  if (candidate.meta?.fontsReady === false) sides.push("candidate");
+  if (sides.length === 0) return null;
+  const pending = [
+    ...(baseline.meta?.pendingFonts ?? []),
+    ...(candidate.meta?.pendingFonts ?? []),
+  ];
+  const detail = pending.length ? ` (pending: ${[...new Set(pending)].join(", ")})` : "";
+  return (
+    `web fonts had not finished loading in the ${sides.join(" and ")} extraction${detail} — ` +
+    `typography family changes may be fallback fonts, not design drift.`
+  );
+}
+
+/** Stage names the extractor records in meta.errors / meta.degraded, mapped to
+ * the drift category they invalidate. The dark-mode and mobile passes merge
+ * extra colors into the palette, so their failure degrades color. */
+const STAGE_CATEGORY: Record<string, DriftCategory> = {
+  colors: "color",
+  typography: "typography",
+  spacing: "spacing",
+  borderRadius: "radius",
+  shadows: "shadow",
+  "dark-mode": "color",
+  mobile: "color",
+};
+
+function degradedDriftCategories(r: ExtractionResult): Set<DriftCategory> {
+  const out = new Set<DriftCategory>();
+  for (const e of r.meta?.errors ?? []) {
+    const cat = STAGE_CATEGORY[e.stage];
+    if (cat) out.add(cat);
+  }
+  for (const stage of r.meta?.degraded ?? []) {
+    const cat = STAGE_CATEGORY[stage];
+    if (cat) out.add(cat);
+  }
+  return out;
+}
+
 export function computeDrift(
   baseline: ExtractionResult,
   candidate: ExtractionResult,
@@ -496,6 +572,19 @@ export function computeDrift(
     },
   ];
 
+  const warnings: string[] = [];
+  for (const w of [
+    viewportWarning(baseline, candidate),
+    pageMismatchWarning(baseline, candidate),
+    darkModeWarning(baseline, candidate),
+    fontsWarning(baseline, candidate),
+  ]) {
+    if (w) warnings.push(w);
+  }
+
+  const baseDegraded = degradedDriftCategories(baseline);
+  const candDegraded = degradedDriftCategories(candidate);
+
   // Weighted average over categories that actually have something to compare.
   let weighted = 0;
   let totalW = 0;
@@ -504,6 +593,21 @@ export function computeDrift(
   for (const p of parts) {
     categories.push(p.result);
     changes.push(...p.changes);
+    const cat = p.result.category;
+    const degradedSides = [
+      baseDegraded.has(cat) ? "baseline" : null,
+      candDegraded.has(cat) ? "candidate" : null,
+    ].filter(Boolean);
+    if (degradedSides.length > 0) {
+      // Engine rule (see ExtractionMeta.degraded): a degraded category failed
+      // extraction, the brand did not change — its missing tokens would read
+      // as removals, so it must not enter the score.
+      warnings.push(
+        `${cat} extraction was degraded in the ${degradedSides.join(" and ")} — ` +
+        `category excluded from the drift score.`
+      );
+      continue;
+    }
     if (p.comparable) {
       weighted += p.result.score * p.w;
       totalW += p.w;
@@ -519,8 +623,6 @@ export function computeDrift(
     { changed: 0, added: 0, removed: 0 } as Record<DriftKind, number>
   );
 
-  const vw = viewportWarning(baseline, candidate);
-
   return {
     score,
     status: score > cfg.failThreshold ? "drift" : "stable",
@@ -528,6 +630,6 @@ export function computeDrift(
     summary,
     categories,
     changes,
-    ...(vw ? { warnings: [vw] } : {}),
+    ...(warnings.length ? { warnings } : {}),
   };
 }

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -436,9 +436,15 @@ function notLowConfidence(t: { confidence?: Confidence }): boolean {
 function viewportWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
   const b = baseline.meta?.viewport;
   const c = candidate.meta?.viewport;
-  if (!b || !c || b.width === c.width) return null;
+  if (!b || !c) return null;
+  // Persisted blobs are untrusted: widths may be strings or absent. Coerce, and
+  // stay silent on anything non-numeric rather than warn on garbage.
+  const bw = Number(b.width);
+  const cw = Number(c.width);
+  if (!Number.isFinite(bw) || !Number.isFinite(cw) || bw === cw) return null;
+  const dim = (v: { width: unknown; height: unknown }) => `${Number(v.width)}x${Number(v.height)}`;
   return (
-    `baseline extracted at ${b.width}x${b.height}, candidate at ${c.width}x${c.height} — ` +
+    `baseline extracted at ${dim(b)}, candidate at ${dim(c)} — ` +
     `layout-dependent changes below may be viewport-induced, not design drift. ` +
     `Re-extract both at the same width (--screen-size).`
   );

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -64,6 +64,10 @@ export interface DriftReport {
   summary: { changed: number; added: number; removed: number };
   categories: CategoryResult[];
   changes: DriftChange[];
+  /** Comparison-validity caveats (e.g. baseline and candidate extracted at
+   *  different viewport widths). The score stands, but changes may be
+   *  environment-induced rather than design drift. */
+  warnings?: string[];
 }
 
 /* ----------------------------- color math ----------------------------- */
@@ -407,6 +411,20 @@ function notLowConfidence(t: { confidence?: Confidence }): boolean {
   return t.confidence !== "low";
 }
 
+/** Layout-dependent tokens vary by viewport width, so a baseline and candidate
+ * extracted at different widths diff the responsive layout, not the design.
+ * Old snapshots lack meta.viewport; only warn when both sides carry it. */
+function viewportWarning(baseline: ExtractionResult, candidate: ExtractionResult): string | null {
+  const b = baseline.meta?.viewport;
+  const c = candidate.meta?.viewport;
+  if (!b || !c || b.width === c.width) return null;
+  return (
+    `baseline extracted at ${b.width}x${b.height}, candidate at ${c.width}x${c.height} — ` +
+    `layout-dependent changes below may be viewport-induced, not design drift. ` +
+    `Re-extract both at the same width (--screen-size).`
+  );
+}
+
 export function computeDrift(
   baseline: ExtractionResult,
   candidate: ExtractionResult,
@@ -471,6 +489,8 @@ export function computeDrift(
     { changed: 0, added: 0, removed: 0 } as Record<DriftKind, number>
   );
 
+  const vw = viewportWarning(baseline, candidate);
+
   return {
     score,
     status: score > cfg.failThreshold ? "drift" : "stable",
@@ -478,5 +498,6 @@ export function computeDrift(
     summary,
     categories,
     changes,
+    ...(vw ? { warnings: [vw] } : {}),
   };
 }

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1491,5 +1491,10 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
     console.error(`  ↳ URL: ${url}`);
     console.error(`  ↳ Stage: ${spinner.text || "unknown"}`);
     throw error;
+  } finally {
+    // We opened the context, we close it. Otherwise crawls accumulate one
+    // context per page, and on CDP-connected shared browsers (browser.close()
+    // only disconnects) every extraction leaks a context permanently.
+    await context.close().catch(() => {});
   }
 }

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -298,14 +298,26 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
 
   const context = await browser.newContext(contextOptions);
 
+  // Setup between context creation and the main try/finally below runs outside
+  // the finally that closes the context; a throw here (malformed cookie, dead
+  // CDP browser at newPage) must still release it or shared browsers leak.
+  const closingOnError = async <T>(p: Promise<T>): Promise<T> => {
+    try {
+      return await p;
+    } catch (err) {
+      await context.close().catch(() => {});
+      throw err;
+    }
+  };
+
   const parsedCookies = parseCookies(options.cookie, url);
   if (parsedCookies.length > 0) {
-    await context.addCookies(parsedCookies);
+    await closingOnError(context.addCookies(parsedCookies));
   }
 
   if (options.stealth) {
     const stealthLocale = locale;
-    await context.addInitScript(({ loc, sw, sh }) => {
+    await closingOnError(context.addInitScript(({ loc, sw, sh }) => {
       Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
       Object.defineProperty(navigator, 'deviceMemory', { get: () => 8 });
       Object.defineProperty(navigator, 'platform', { get: () => 'Win32' });
@@ -404,10 +416,10 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
           });
         };
       }
-    }, { loc: stealthLocale, sw: screenW, sh: screenH });
+    }, { loc: stealthLocale, sw: screenW, sh: screenH }));
   }
 
-  const page = await context.newPage();
+  const page = await closingOnError(context.newPage());
 
   // Track font requests to identify self-hosted custom fonts
   const fontRequests = new Set<string>();
@@ -1254,6 +1266,9 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       spinner.stop();
       log(color.success(`  ✓ Mobile: +${mobileColors.palette.length} colors`));
       } catch (e) { spinner.stop(); degraded.push('mobile'); log(color.warning('  ! Mobile: failed (continuing)')); }
+      // Restore the configured viewport: every later pass (reveal, screenshot)
+      // and meta.viewport describe the desktop run, not the mobile detour.
+      try { await page.setViewportSize({ width: screenW, height: screenH }); } catch {}
     }
 
     // Reveal pass (standard, on by default): open click-toggle menus (megamenus,

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { randomUUID } from 'node:crypto';
 import { color } from '../formatters/theme.js';
 import { discoverLinks } from '../discovery.js';
 import { extractLogo, extractSiteName } from './logo.js';
@@ -742,6 +743,29 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
 
     log(color.info("\n  Extracting design tokens...\n"));
 
+    // Font readiness is read here, at the moment styles are about to be read:
+    // a family still loading (or failed) renders as an OS fallback, and
+    // typography from this run must carry that fact (meta.fontsReady) instead
+    // of consumers inferring it from generic family names. 'unloaded' faces are
+    // declared but never requested — no rendered text uses them — so they are
+    // not fallback risks and must not be listed.
+    let fontsReady = true;
+    let pendingFonts: string[] = [];
+    try {
+      const fontState = await page.evaluate(() => ({
+        status: document.fonts ? document.fonts.status : 'loaded',
+        unsettled: document.fonts
+          ? Array.from(document.fonts)
+              .filter((f) => f.status === 'loading' || f.status === 'error')
+              .map((f) => f.family)
+          : [],
+      }));
+      fontsReady = fontState.status === 'loaded' && fontState.unsettled.length === 0;
+      pendingFonts = [...new Set(
+        fontState.unsettled.map((f) => String(f).replace(/^["']|["']$/g, ''))
+      )].sort();
+    } catch { /* best-effort; absence of the stamp must never abort extraction */ }
+
     spinner.start("Analyzing design system (17 parallel tasks)...");
     const [
       logoResult,
@@ -1392,9 +1416,12 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       url: page.url(),
       extractedAt: new Date().toISOString(),
       meta: {
+        snapshotId: randomUUID(),
         dembrandtVersion: options._version || null,
         schemaVersion: SCHEMA_VERSION,
         viewport: { width: screenW, height: screenH },
+        fontsReady,
+        ...(pendingFonts.length ? { pendingFonts } : {}),
         flags: {
           ...(options.stealth && { stealth: true }),
           ...(options.darkMode && { darkMode: true }),

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1394,6 +1394,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       meta: {
         dembrandtVersion: options._version || null,
         schemaVersion: SCHEMA_VERSION,
+        viewport: { width: screenW, height: screenH },
         flags: {
           ...(options.stealth && { stealth: true }),
           ...(options.darkMode && { darkMode: true }),

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -60,7 +60,14 @@ const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 async function waitForSettled(page: Page, capMs: number, quietMs = 500) {
   const start = Date.now();
   try { await page.waitForLoadState("networkidle", { timeout: capMs }); } catch {}
-  try { await page.evaluate(() => document.fonts?.ready ?? null); } catch {}
+  // fonts.ready resolves only when no face is loading; a hung font request
+  // would stall it past every cap, so race it against the remaining budget.
+  try {
+    await Promise.race([
+      page.evaluate(() => document.fonts?.ready ?? null),
+      new Promise((r) => setTimeout(r, Math.max(250, capMs - (Date.now() - start)))),
+    ]);
+  } catch {}
   const remaining = Math.max(250, capMs - (Date.now() - start));
   try {
     await page.evaluate(({ quietMs, remaining }) => new Promise<void>((resolve) => {

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -632,12 +632,17 @@ function driftSection(drift: DriftReport, result: BrandingResult, baselineLabel?
   const more = drift.changes.length > 120 ? `<p class="sub">… ${drift.changes.length - 120} more changes</p>` : "";
   const legend = capped.length ? `<p class="dlegend"><span class="g-add">+</span> added · <span class="g-rem">−</span> removed · <span class="g-chg">~</span> changed</p>` : "";
   const empty = capped.length ? "" : `<p class="dempty">✓ No changes detected — tokens match the baseline.</p>`;
+  // Comparison-validity warnings (viewport/flags/fonts mismatch) render above
+  // the change groups: they qualify everything below.
+  const warnings = (drift.warnings ?? [])
+    .map((w) => `<p class="sub" style="color:var(--bad)">! ${esc(w)}</p>`)
+    .join("");
   // Plaintext diff for the clipboard (App's "Copy report").
   const copyText = capped
     .map((ch) => `${ch.kind === "added" ? "+" : ch.kind === "removed" ? "-" : "~"} [${ch.category}] ${ch.label}${ch.before && ch.after ? `: ${ch.before} -> ${ch.after}` : ch.before || ch.after ? `: ${ch.before ?? ch.after}` : ""}`)
     .join("\n");
   const copyBtn = capped.length ? `<button class="copyall" data-copy="${esc(`Drift ${drift.score} (threshold ${drift.threshold}) — ${drift.status}\n${copyText}`)}" style="margin-left:auto">Copy report</button>` : "";
-  return `<div class="drift ${cls}" id="drift"><div class="row"><div class="score">${esc(drift.score)}</div><div><div>${verdict} <span class="sub">threshold ${esc(drift.threshold)}</span></div><div class="sub">${esc(drift.summary.changed)} changed · ${esc(drift.summary.added)} added · ${esc(drift.summary.removed)} removed${baselineLabel ? ` · vs ${esc(baselineLabel)}` : ""}</div></div>${copyBtn}</div>${groups}${more}${legend}${empty}</div>`;
+  return `<div class="drift ${cls}" id="drift"><div class="row"><div class="score">${esc(drift.score)}</div><div><div>${verdict} <span class="sub">threshold ${esc(drift.threshold)}</span></div><div class="sub">${esc(drift.summary.changed)} changed · ${esc(drift.summary.added)} added · ${esc(drift.summary.removed)} removed${baselineLabel ? ` · vs ${esc(baselineLabel)}` : ""}</div></div>${copyBtn}</div>${warnings}${groups}${more}${legend}${empty}</div>`;
 }
 
 /* -------------------------------- entry --------------------------------- */

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -7,7 +7,33 @@
  * pageCount on palette entries) added.
  */
 
+import { randomUUID } from 'node:crypto';
 import { deltaE } from './colors.js';
+
+/**
+ * Meta for a merged snapshot. The merged artifact is a distinct snapshot, so it
+ * gets its own snapshotId; readiness aggregates across pages (one page that
+ * rendered fallback fonts taints the merged typography).
+ */
+function mergeMeta(results) {
+  const home = results[0];
+  if (!home.meta) return {};
+  const metas = results.map((r) => r.meta).filter(Boolean);
+  const fontsReady = metas.every((m) => m.fontsReady !== false);
+  const pendingFonts = [...new Set(metas.flatMap((m) => m.pendingFonts ?? []))].sort();
+  const degraded = [...new Set(metas.flatMap((m) => m.degraded ?? []))];
+  const errors = metas.flatMap((m) => m.errors ?? []);
+  return {
+    meta: {
+      ...home.meta,
+      snapshotId: randomUUID(),
+      fontsReady,
+      ...(pendingFonts.length ? { pendingFonts } : {}),
+      ...(degraded.length ? { degraded } : {}),
+      ...(errors.length ? { errors } : {}),
+    },
+  };
+}
 
 const DELTA_E_THRESHOLD = 15;
 
@@ -389,7 +415,7 @@ export function mergeResults(results) {
   return {
     url: home.url,
     extractedAt: home.extractedAt,
-    ...(home.meta ? { meta: home.meta } : {}),
+    ...mergeMeta(results),
     siteName: home.siteName,
     logo: home.logo,
     favicons: home.favicons,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -292,6 +292,12 @@ export interface WcagPair {
 
 /** Metadata block on the native extraction output. */
 export interface ExtractionMeta {
+  /**
+   * Unique id of this snapshot, stamped at extraction time. The canonical key
+   * for consumers: extractedAt and storage timestamps drift by seconds, so
+   * anything pinning or deduping snapshots must use this, not a time.
+   */
+  snapshotId?: string;
   /** Provenance: the CLI release that produced this. Doubles as source.cliVersion. */
   dembrandtVersion?: string | null;
   /**
@@ -307,6 +313,15 @@ export interface ExtractionMeta {
    * different widths produces false drift; the drift engine warns on mismatch.
    */
   viewport?: { width: number; height: number };
+  /**
+   * False when web fonts had not finished loading when styles were read:
+   * typography families may be OS fallbacks, and family drift against this
+   * snapshot is suspect. Consumers must not have to infer this from generic
+   * family names.
+   */
+  fontsReady?: boolean;
+  /** Font families still pending when fontsReady is false. */
+  pendingFonts?: string[];
   /**
    * Categories that extracted incompletely. Engine rule: do NOT flag drift from a
    * degraded category (it failed extraction, the brand did not change) — surface

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -302,6 +302,12 @@ export interface ExtractionMeta {
   schemaVersion: string;
   flags?: Record<string, unknown>;
   /**
+   * Viewport the extraction ran at. Layout-dependent tokens (typography,
+   * spacing, visible components) vary by width, so comparing extracts taken at
+   * different widths produces false drift; the drift engine warns on mismatch.
+   */
+  viewport?: { width: number; height: number };
+  /**
    * Categories that extracted incompletely. Engine rule: do NOT flag drift from a
    * degraded category (it failed extraction, the brand did not change) — surface
    * it in the UI instead.

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -41,7 +41,10 @@
  *          width/height; mismatched widths produce false layout drift),
  *          fontsReady and pendingFonts (false = typography families may be OS
  *          fallbacks). DriftReport gains warnings[] (comparison-validity
- *          caveats). Additive: 1.2.x consumers ignore the new keys.
+ *          caveats) and inconclusive. Additive: 1.2.x consumers ignore the new
+ *          keys. BEHAVIOR: drift scores recalibrated — categories empty on
+ *          both sides no longer dilute the average, and typography severities
+ *          changed; an approved baseline may need re-approval after upgrade.
  *  1.2.0 — added colors.semantic.background, colors.semantic.text and
  *          colors.semantic.accent (canonical page surface, body text, and a
  *          hue-distinct brand accent). Typography gains a "text" context value

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -36,6 +36,12 @@
 /**
  * dembrandt output contract version. Bump per the policy documented above.
  *
+ *  1.3.0 — meta gains snapshotId (canonical snapshot key: pin/dedupe on this,
+ *          not on extractedAt or storage timestamps), viewport (extraction
+ *          width/height; mismatched widths produce false layout drift),
+ *          fontsReady and pendingFonts (false = typography families may be OS
+ *          fallbacks). DriftReport gains warnings[] (comparison-validity
+ *          caveats). Additive: 1.2.x consumers ignore the new keys.
  *  1.2.0 — added colors.semantic.background, colors.semantic.text and
  *          colors.semantic.accent (canonical page surface, body text, and a
  *          hue-distinct brand accent). Typography gains a "text" context value
@@ -48,7 +54,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.2.0';
+export const SCHEMA_VERSION = '1.3.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/test/ci-annotations.test.ts
+++ b/test/ci-annotations.test.ts
@@ -35,6 +35,14 @@ test('driftAnnotations leads with an error summary carrying score + threshold', 
   assert.match(lines[0], /1 changed, 1 added, 1 removed/);
 });
 
+test('driftAnnotations surfaces comparison-validity warnings next to the failures', () => {
+  const lines = driftAnnotations(report({ warnings: ['baseline extracted at 1920x1080, candidate at 390x844'] }));
+  const caveat = lines.find((l) => l.includes('Drift comparison caveat'));
+  assert.ok(caveat, lines.join('\n'));
+  assert.ok(caveat!.startsWith('::warning '));
+  assert.ok(caveat!.includes('390x844'));
+});
+
 test('driftAnnotations maps changed/removed to error and added to warning', () => {
   const lines = driftAnnotations(report()).slice(1);
   assert.match(lines[0], /^::error::#2564ea #2564ea -> #1050d0 \(token-drift:color, delta 6.2\)/);

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -67,6 +67,18 @@ test('same viewport width produces no warning', () => {
   assert.equal(report.warnings, undefined);
 });
 
+test('malformed viewport meta produces no warning instead of garbage', () => {
+  const base = fixture({ meta: { schemaVersion: '1', viewport: {} } });
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
+  assert.equal(computeDrift(base, cand).warnings, undefined);
+});
+
+test('same width as string vs number is not a mismatch', () => {
+  const base = fixture({ meta: { schemaVersion: '1', viewport: { width: '1920', height: '1080' } } });
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 1920, height: 1080 } } });
+  assert.equal(computeDrift(base, cand).warnings, undefined);
+});
+
 test('missing viewport meta on either side produces no warning (pre-viewport snapshots)', () => {
   const base = fixture(); // no meta at all
   const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
@@ -75,7 +87,9 @@ test('missing viewport meta on either side produces no warning (pre-viewport sna
   assert.equal(report.warnings, undefined);
 });
 
-function typoStyles(n: number, family = 'Inter'): any[] {
+interface TestStyle { context: string; family: string; size: string; weight: string }
+
+function typoStyles(n: number, family = 'Inter'): TestStyle[] {
   return Array.from({ length: n }, (_, i) => ({
     context: `style-${i}`, family, size: '16px', weight: '400',
   }));
@@ -122,7 +136,8 @@ test('a removed style scores below an in-place family change', () => {
     typography: { styles: styles.map((s, i) => (i === 0 ? { ...s, family: 'Georgia' } : s)), sources: {} },
   }));
 
-  const score = (r: any) => r.categories.find((c: any) => c.category === 'typography').score;
+  const score = (r: ReturnType<typeof computeDrift>) =>
+    r.categories.find((c) => c.category === 'typography')!.score;
   assert.ok(score(removedReport) < score(changedReport),
     `removal (${score(removedReport)}) must score below family change (${score(changedReport)})`);
 });

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -47,6 +47,32 @@ test('a low-confidence radius present in one extraction but not the other is not
   assert.equal(report.changes.filter((c) => c.category === 'radius').length, 0);
 });
 
+test('baseline and candidate extracted at different viewport widths produce a warning', () => {
+  const base = fixture({ meta: { schemaVersion: '1', viewport: { width: 1920, height: 1080 } } });
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.warnings?.length, 1);
+  assert.match(report.warnings![0], /1920x1080/);
+  assert.match(report.warnings![0], /390x844/);
+});
+
+test('same viewport width produces no warning', () => {
+  const base = fixture({ meta: { schemaVersion: '1', viewport: { width: 1920, height: 1080 } } });
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 1920, height: 900 } } });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.warnings, undefined);
+});
+
+test('missing viewport meta on either side produces no warning (pre-viewport snapshots)', () => {
+  const base = fixture(); // no meta at all
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.warnings, undefined);
+});
+
 test('a high-confidence radius change is still real drift', () => {
   const base = fixture({
     borderRadius: { values: [{ value: '4px', count: 20, confidence: 'high' }] },

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -68,9 +68,20 @@ test('same viewport width produces no warning', () => {
 });
 
 test('malformed viewport meta produces no warning instead of garbage', () => {
-  const base = fixture({ meta: { schemaVersion: '1', viewport: {} } });
   const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
-  assert.equal(computeDrift(base, cand).warnings, undefined);
+  for (const viewport of [{}, { width: null, height: null }, { width: '', height: 844 }, { width: [], height: 1080 }]) {
+    const base = fixture({ meta: { schemaVersion: '1', viewport } });
+    assert.equal(computeDrift(base, cand).warnings, undefined, JSON.stringify(viewport));
+  }
+});
+
+test('a real width mismatch with a garbage height renders ? instead of NaN', () => {
+  const base = fixture({ meta: { schemaVersion: '1', viewport: { width: 1920, height: null } } });
+  const cand = fixture({ meta: { schemaVersion: '1', viewport: { width: 390, height: 844 } } });
+
+  const w = computeDrift(base, cand).warnings![0];
+  assert.match(w, /1920x\?/);
+  assert.doesNotMatch(w, /NaN/);
 });
 
 test('same width as string vs number is not a mismatch', () => {
@@ -106,7 +117,7 @@ test('one removed typography style among many does not max the category', () => 
   assert.equal(report.status, 'stable');
 });
 
-test('one font-family change among many does not max the category', () => {
+test('one font-family change flags drift without maxing the category', () => {
   const styles = typoStyles(10);
   const changed = styles.map((s, i) => (i === 0 ? { ...s, family: 'Comic Sans MS' } : s));
   const base = fixture({ typography: { styles, sources: {} } });
@@ -114,7 +125,19 @@ test('one font-family change among many does not max the category', () => {
 
   const report = computeDrift(base, cand);
   const typo = report.categories.find((c) => c.category === 'typography')!;
-  assert.ok(typo.score < 0.5, `one family change must not dominate the category, got ${typo.score}`);
+  assert.ok(typo.score <= 0.5, `one family change must not read as full replacement, got ${typo.score}`);
+  assert.equal(report.status, 'drift', 'a confirmed in-place family change is real drift and must flag');
+});
+
+test('mass deletion of typography styles flags drift even though one removal does not', () => {
+  const styles = typoStyles(10);
+  const base = fixture({ typography: { styles, sources: {} } });
+  const cand = fixture({ typography: { styles: styles.slice(0, 4), sources: {} } });
+
+  const report = computeDrift(base, cand);
+  const typo = report.categories.find((c) => c.category === 'typography')!;
+  assert.ok(typo.score >= 0.6, `deleting 6/10 styles must scale, got ${typo.score}`);
+  assert.equal(report.status, 'drift');
 });
 
 test('replacing the font family across all styles still drifts', () => {
@@ -188,6 +211,10 @@ test('a degraded category is excluded from the score instead of read as removals
   const report = computeDrift(base, cand);
   assert.equal(report.status, 'stable', `16 missing styles from a failed extractor must not read as drift, got ${report.score}`);
   assert.ok(report.warnings?.some((w) => w.includes('typography extraction was degraded')), JSON.stringify(report.warnings));
+  // Phantom tokens must not leak into changes/summary either: CI annotations
+  // render report.changes unfiltered.
+  assert.equal(report.changes.filter((c) => c.category === 'typography').length, 0);
+  assert.equal(report.summary.removed, 0);
 });
 
 test('a compare where every comparable category is degraded warns that it is inconclusive', () => {
@@ -223,8 +250,8 @@ test('categories empty on both sides do not dilute the score', () => {
 
   const report = computeDrift(base, cand);
   // Comparable categories: color (w 1) + typography (w 1). A full family swap
-  // (category 0.8) must average against those alone, not the empty three.
-  assert.equal(report.score, 40);
+  // (category 1.0) must average against those alone, not the empty three.
+  assert.equal(report.score, 50);
 });
 
 test('a high-confidence radius change is still real drift', () => {

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -142,6 +142,54 @@ test('a removed style scores below an in-place family change', () => {
     `removal (${score(removedReport)}) must score below family change (${score(changedReport)})`);
 });
 
+test('extracts from different final URLs produce a page-mismatch warning', () => {
+  const base = fixture({ url: 'https://example.com/' });
+  const cand = fixture({ url: 'https://www.example.com/fi/' });
+
+  const report = computeDrift(base, cand);
+  assert.ok(report.warnings?.some((w) => w.includes('different pages')), JSON.stringify(report.warnings));
+});
+
+test('www and trailing slash are not a page mismatch', () => {
+  const base = fixture({ url: 'https://example.com/pricing' });
+  const cand = fixture({ url: 'https://www.example.com/pricing/' });
+
+  assert.equal(computeDrift(base, cand).warnings, undefined);
+});
+
+test('--dark-mode on one side only produces a warning', () => {
+  const base = fixture({ meta: { schemaVersion: '1', flags: { darkMode: true } } });
+  const cand = fixture({ meta: { schemaVersion: '1', flags: {} } });
+
+  const report = computeDrift(base, cand);
+  assert.ok(report.warnings?.some((w) => w.includes('--dark-mode')), JSON.stringify(report.warnings));
+});
+
+test('unloaded web fonts on either side produce a warning naming the pending families', () => {
+  const base = fixture({ meta: { schemaVersion: '1', fontsReady: true } });
+  const cand = fixture({ meta: { schemaVersion: '1', fontsReady: false, pendingFonts: ['Inter'] } });
+
+  const report = computeDrift(base, cand);
+  const w = report.warnings?.find((x) => x.includes('web fonts'));
+  assert.ok(w, JSON.stringify(report.warnings));
+  assert.match(w!, /candidate/);
+  assert.match(w!, /Inter/);
+});
+
+test('a degraded category is excluded from the score instead of read as removals', () => {
+  const styles = typoStyles(16);
+  const base = fixture({ typography: { styles, sources: {} } });
+  // Candidate's typography extractor failed: empty styles + a scoped error.
+  const cand = fixture({
+    typography: { styles: [], sources: {} },
+    meta: { schemaVersion: '1', errors: [{ stage: 'typography', reason: 'timeout' }] },
+  });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.status, 'stable', `16 missing styles from a failed extractor must not read as drift, got ${report.score}`);
+  assert.ok(report.warnings?.some((w) => w.includes('typography extraction was degraded')), JSON.stringify(report.warnings));
+});
+
 test('categories empty on both sides do not dilute the score', () => {
   const styles = typoStyles(2);
   const sparse = {

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -15,8 +15,10 @@ function fixture(overrides: any = {}): any {
     extractedAt: 't',
     colors: { palette: [{ normalized: '#133174', count: 40, confidence: 'high' }], semantic: { primary: '#133174' }, cssVariables: {} },
     typography: { styles: [], sources: {} },
-    spacing: { scaleType: 'base-8', commonValues: [] },
-    borderRadius: { values: [] },
+    // Representative extract: spacing and radius present, so overall-score
+    // assertions run against a realistic category denominator.
+    spacing: { scaleType: 'base-8', commonValues: [{ px: 8 }, { px: 16 }, { px: 24 }] },
+    borderRadius: { values: [{ value: '4px', count: 20, confidence: 'high' }] },
     borders: {}, shadows: [],
     components: { buttons: [], inputs: [], links: [], badges: [] },
     breakpoints: [], iconSystem: [], frameworks: [],
@@ -123,6 +125,23 @@ test('a removed style scores below an in-place family change', () => {
   const score = (r: any) => r.categories.find((c: any) => c.category === 'typography').score;
   assert.ok(score(removedReport) < score(changedReport),
     `removal (${score(removedReport)}) must score below family change (${score(changedReport)})`);
+});
+
+test('categories empty on both sides do not dilute the score', () => {
+  const styles = typoStyles(2);
+  const sparse = {
+    typography: { styles, sources: {} },
+    spacing: { scaleType: 'base-8', commonValues: [] },
+    borderRadius: { values: [] },
+    shadows: [],
+  };
+  const base = fixture(sparse);
+  const cand = fixture({ ...sparse, typography: { styles: typoStyles(2, 'Georgia'), sources: {} } });
+
+  const report = computeDrift(base, cand);
+  // Comparable categories: color (w 1) + typography (w 1). A full family swap
+  // (category 0.8) must average against those alone, not the empty three.
+  assert.equal(report.score, 40);
 });
 
 test('a high-confidence radius change is still real drift', () => {

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -190,6 +190,26 @@ test('a degraded category is excluded from the score instead of read as removals
   assert.ok(report.warnings?.some((w) => w.includes('typography extraction was degraded')), JSON.stringify(report.warnings));
 });
 
+test('a compare where every comparable category is degraded warns that it is inconclusive', () => {
+  const sparse = {
+    typography: { styles: typoStyles(3), sources: {} },
+    colors: { palette: [], semantic: {}, cssVariables: {} },
+    spacing: { scaleType: 'base-8', commonValues: [] },
+    borderRadius: { values: [] },
+    shadows: [],
+  };
+  const base = fixture(sparse);
+  const cand = fixture({
+    ...sparse,
+    typography: { styles: [], sources: {} },
+    meta: { schemaVersion: '1', errors: [{ stage: 'typography', reason: 'timeout' }] },
+  });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.score, 0);
+  assert.ok(report.warnings?.some((w) => w.includes('inconclusive')), JSON.stringify(report.warnings));
+});
+
 test('categories empty on both sides do not dilute the score', () => {
   const styles = typoStyles(2);
   const sparse = {

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -73,6 +73,58 @@ test('missing viewport meta on either side produces no warning (pre-viewport sna
   assert.equal(report.warnings, undefined);
 });
 
+function typoStyles(n: number, family = 'Inter'): any[] {
+  return Array.from({ length: n }, (_, i) => ({
+    context: `style-${i}`, family, size: '16px', weight: '400',
+  }));
+}
+
+test('one removed typography style among many does not max the category', () => {
+  const styles = typoStyles(10);
+  const base = fixture({ typography: { styles, sources: {} } });
+  const cand = fixture({ typography: { styles: styles.slice(0, 9), sources: {} } });
+
+  const report = computeDrift(base, cand);
+  const typo = report.categories.find((c) => c.category === 'typography')!;
+  assert.ok(typo.score < 0.5, `one removal must not dominate the category, got ${typo.score}`);
+  assert.equal(report.status, 'stable');
+});
+
+test('one font-family change among many does not max the category', () => {
+  const styles = typoStyles(10);
+  const changed = styles.map((s, i) => (i === 0 ? { ...s, family: 'Comic Sans MS' } : s));
+  const base = fixture({ typography: { styles, sources: {} } });
+  const cand = fixture({ typography: { styles: changed, sources: {} } });
+
+  const report = computeDrift(base, cand);
+  const typo = report.categories.find((c) => c.category === 'typography')!;
+  assert.ok(typo.score < 0.5, `one family change must not dominate the category, got ${typo.score}`);
+});
+
+test('replacing the font family across all styles still drifts', () => {
+  const base = fixture({ typography: { styles: typoStyles(10, 'Inter'), sources: {} } });
+  const cand = fixture({ typography: { styles: typoStyles(10, 'Georgia'), sources: {} } });
+
+  const report = computeDrift(base, cand);
+  const typo = report.categories.find((c) => c.category === 'typography')!;
+  assert.ok(typo.score >= 0.7, `full family swap must score high, got ${typo.score}`);
+  assert.equal(report.status, 'drift');
+});
+
+test('a removed style scores below an in-place family change', () => {
+  const styles = typoStyles(10);
+  const base = fixture({ typography: { styles, sources: {} } });
+
+  const removedReport = computeDrift(base, fixture({ typography: { styles: styles.slice(0, 9), sources: {} } }));
+  const changedReport = computeDrift(base, fixture({
+    typography: { styles: styles.map((s, i) => (i === 0 ? { ...s, family: 'Georgia' } : s)), sources: {} },
+  }));
+
+  const score = (r: any) => r.categories.find((c: any) => c.category === 'typography').score;
+  assert.ok(score(removedReport) < score(changedReport),
+    `removal (${score(removedReport)}) must score below family change (${score(changedReport)})`);
+});
+
 test('a high-confidence radius change is still real drift', () => {
   const base = fixture({
     borderRadius: { values: [{ value: '4px', count: 20, confidence: 'high' }] },

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -217,6 +217,25 @@ test('a degraded category is excluded from the score instead of read as removals
   assert.equal(report.summary.removed, 0);
 });
 
+test('a failed manifest injection degrades color: its palette entries must not read as removed brand colors', () => {
+  // Manifest injection pushes theme_color/background_color into the palette
+  // (count 10, high confidence). If the candidate's injection fails, those
+  // colors vanish — without the manifest→color mapping they scored as drift.
+  const palette = [
+    { color: '#ff6600', normalized: '#ff6600', count: 10, confidence: 'high' },
+    { color: '#123456', normalized: '#123456', count: 40, confidence: 'high' },
+  ];
+  const base = fixture({ colors: { palette, semantic: {}, cssVariables: {} } });
+  const cand = fixture({
+    colors: { palette: [palette[1]], semantic: {}, cssVariables: {} },
+    meta: { schemaVersion: '1', degraded: ['manifest'] },
+  });
+
+  const report = computeDrift(base, cand);
+  assert.equal(report.status, 'stable', `a failed manifest stage must not read as color drift, got ${report.score}`);
+  assert.equal(report.changes.filter((c) => c.category === 'color').length, 0);
+});
+
 test('a compare where every comparable category is degraded warns that it is inconclusive', () => {
   const sparse = {
     typography: { styles: typoStyles(3), sources: {} },

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -2,8 +2,11 @@
   "url": "https://synthetic.example.com",
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
-    "schemaVersion": "1.2.0",
-    "dembrandtVersion": "0.17.0"
+    "snapshotId": "00000000-0000-4000-8000-000000000001",
+    "schemaVersion": "1.3.0",
+    "dembrandtVersion": "0.17.0",
+    "viewport": { "width": 1920, "height": 1080 },
+    "fontsReady": true
   },
   "colors": {
     "semantic": {

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -35,6 +35,23 @@ function page(url, overrides: any = {}) {
 
 const color = (hex, count, confidence) => ({ normalized: hex, color: hex, count, confidence });
 
+test('merged meta gets a fresh snapshotId and aggregates readiness across pages', () => {
+  const a = page('https://a.com/', {
+    meta: { schemaVersion: '1.3.0', snapshotId: 'id-a', viewport: { width: 1920, height: 1080 }, fontsReady: true },
+  });
+  const b = page('https://a.com/pricing', {
+    meta: { schemaVersion: '1.3.0', snapshotId: 'id-b', fontsReady: false, pendingFonts: ['Inter'], degraded: ['hover-focus'] },
+  });
+
+  const merged = mergeResults([a, b]);
+  assert.ok(merged.meta.snapshotId, 'merged snapshot must have an id');
+  assert.notEqual(merged.meta.snapshotId, 'id-a', 'merged artifact is a distinct snapshot');
+  assert.equal(merged.meta.fontsReady, false, 'one fallback-rendered page taints the merged snapshot');
+  assert.deepEqual(merged.meta.pendingFonts, ['Inter']);
+  assert.deepEqual(merged.meta.degraded, ['hover-focus']);
+  assert.deepEqual(merged.meta.viewport, { width: 1920, height: 1080 }, 'home meta fields survive');
+});
+
 test('mergeResults throws on empty input', () => {
   assert.throws(() => mergeResults([]), /No results to merge/);
 });


### PR DESCRIPTION
- meta: snapshotId, viewport, fontsReady/pendingFonts; merged crawls aggregate readiness
- drift warnings: viewport width, final URL, --dark-mode/--mobile flags, unloaded fonts; surfaced in CLI, HTML and CI annotations
- degraded categories excluded from score, changes and annotations; all-degraded compare is inconclusive (exit RUNTIME)
- typography calibration: single family change drifts without maxing the category, single removal stays stable, mass deletion scales
- empty categories no longer dilute the score (approved baselines may need re-approval)
- extractBranding closes its context (incl. setup-path failures); --mobile restores viewport; fonts.ready wait capped
- schema 1.3.0, changelog in lib/version.ts

378 tests. 10 findings from high-effort review applied.