### PR TITLE
fix(cli): version-matched browser installer, correct CI docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,17 @@ Absolute Mode. Eliminate emojis, filler, hype, soft asks, conversational transit
 
 ### Running the tool
 
+Source is TypeScript. Build first, then run the compiled entry point.
+
 ```bash
-node index.js <url>
-node index.js dembrandt.com --json-only
-node index.js dembrandt.com --dark-mode
-node index.js dembrandt.com --mobile
-node index.js dembrandt.com --slow
-node index.js dembrandt.com --stealth
-npm run install-browser
+npm run build
+node dist/index.js <url>
+node dist/index.js dembrandt.com --json-only
+node dist/index.js dembrandt.com --dark-mode
+node dist/index.js dembrandt.com --mobile
+node dist/index.js dembrandt.com --slow
+node dist/index.js dembrandt.com --stealth
+node dist/index.js install-browser
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ jobs:
 | `key` | no | API key for cloud snapshot sync ([dembrandt.com/app/api-keys](https://www.dembrandt.com/app/api-keys)) |
 | `args` | no | Extra CLI flags, e.g. `--wcag` or `--crawl 3` |
 
-Outputs: `report` (path to the drift/extraction JSON) and `score` (drift score, empty without a baseline). The action pins the CLI version per release, so a `@v1` gate never changes behavior under you. For a fully hand-rolled workflow (per-page PR comment, preview vs production, report artifact), see [`examples/drift-gate.yml`](examples/drift-gate.yml).
+Outputs: `report` (path to the drift/extraction JSON) and `score` (drift score, empty without a baseline). The action pins the CLI version per release, so a version-tagged gate never changes behavior under you. For a fully hand-rolled workflow (per-page PR comment, preview vs production, report artifact), see [`examples/drift-gate.yml`](examples/drift-gate.yml).
 
 ### Running the CLI directly
 

--- a/README.md
+++ b/README.md
@@ -152,18 +152,17 @@ dembrandt dembrandt.com --browser=firefox --save-output --dtcg
 Browsers are installed on demand, not by `npm install` (dembrandt depends on the lean `playwright-core`, which carries no browser binaries). Fetch the engine you need, matched to the installed `playwright-core`:
 
 ```bash
-npm run install-browser   # chromium (default)
-# or a specific engine:
-npx playwright@$(node -p "require('playwright-core/package.json').version") install firefox
+dembrandt install-browser           # chromium (default)
+dembrandt install-browser firefox   # a specific engine
 ```
 
-If you get `Executable doesn't exist` when using `--browser firefox`, the version resolved above may not match the `playwright-core` bundled inside the global dembrandt install (which can happen if you run the command from inside a project that pins a different version). Use `playwright-core` directly with the exact version dembrandt ships:
+This resolves the browser revision from the `playwright-core` dembrandt actually drives, so the two cannot drift apart. Prefer it over calling Playwright directly: a bare `npx playwright install` fetches whatever version the registry serves, and a mismatch fails with `Executable doesn't exist`.
+
+On Linux and in CI, system libraries are installed separately:
 
 ```bash
-npx playwright-core@$(node -p "require('playwright-core/package.json').version") install firefox
+npx playwright@$(node -p "require('playwright-core/package.json').version") install --with-deps chromium
 ```
-
-Run this from your home directory (outside any Node.js project) so `require` resolves against the global dembrandt install rather than a local `node_modules`.
 
 ### Connect to an existing browser (CDP)
 
@@ -250,7 +249,7 @@ dembrandt dembrandt.com --brand-guide
 The official action wraps extract → compare → gate into one step: it installs a matching Chromium, runs a pinned CLI version, fails the job on drift, and renders the drifted tokens as inline annotations on the PR.
 
 ```yaml
-- uses: dembrandt/dembrandt@v1
+- uses: dembrandt/dembrandt@v0.23.1
   with:
     url: https://preview.example.com
     baseline: .dembrandt/baseline.json
@@ -268,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dembrandt/dembrandt@v1
+      - uses: dembrandt/dembrandt@v0.23.1
         with:
           url: ${{ github.event.deployment_status.environment_url }}
           baseline: .dembrandt/baseline.json
@@ -280,7 +279,7 @@ jobs:
 | `url` | yes | URL to extract — typically the PR's preview deployment |
 | `baseline` | no | Committed baseline JSON path, or an App baseline id. Omit to extract without gating |
 | `key` | no | API key for cloud snapshot sync ([dembrandt.com/app/api-keys](https://www.dembrandt.com/app/api-keys)) |
-| `args` | no | Extra CLI flags, e.g. `--wcag` or `--pages 3` |
+| `args` | no | Extra CLI flags, e.g. `--wcag` or `--crawl 3` |
 
 Outputs: `report` (path to the drift/extraction JSON) and `score` (drift score, empty without a baseline). The action pins the CLI version per release, so a `@v1` gate never changes behavior under you. For a fully hand-rolled workflow (per-page PR comment, preview vs production, report artifact), see [`examples/drift-gate.yml`](examples/drift-gate.yml).
 
@@ -291,9 +290,9 @@ Dembrandt drives a real browser, so the browser revision must match `playwright-
 If you are not using the Playwright container image, install the browser revision that matches `playwright-core`:
 
 ```bash
-# in dembrandt's own repo
-npm run install-browser
-# elsewhere — derive the version so it always matches
+# matches the bundled playwright-core automatically
+dembrandt install-browser
+# on a bare Linux runner, add the system libraries too
 npx playwright@$(node -p "require('playwright-core/package.json').version") install --with-deps chromium
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   args:
-    description: 'Extra dembrandt CLI flags, e.g. "--wcag" or "--pages 3".'
+    description: 'Extra dembrandt CLI flags, e.g. "--wcag" or "--crawl 3".'
     required: false
     default: ""
   node-version:

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@
 import { program, Option } from "commander";
 import chalk from "chalk";
 import ora from "ora";
-import { loadBrowserEngines } from "./lib/browser.js";
+import { loadBrowserEngines, PlaywrightMissingError } from "./lib/browser.js";
 import { extractBranding } from "./lib/extractors/index.js";
 import { displayResults } from "./lib/formatters/terminal.js";
 import { color } from "./lib/formatters/theme.js";
@@ -28,6 +28,8 @@ import { fileURLToPath } from "url";
 import { checkRobotsTxt } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
+import { consumeCloudHint } from "./lib/cli-state.js";
+import { installBrowsers } from "./lib/install-browser.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -159,10 +161,22 @@ program
           spinner.text = "Connecting over CDP...";
           browser = await browserType.connectOverCDP(process.env.BROWSER_CDP_ENDPOINT);
         } else {
-          browser = await browserType.launch({
-            headless: !useHeaded,
-            args: launchArgs,
-          });
+          try {
+            browser = await browserType.launch({
+              headless: !useHeaded,
+              args: launchArgs,
+            });
+          } catch (launchErr) {
+            // playwright-core is a hard dependency so the *module* always
+            // resolves — the guard in loadBrowserEngines can never fire on a
+            // real install. The condition that actually bites is a missing
+            // browser *binary*, which only surfaces here, as raw Playwright
+            // text. Translate it into our own instruction instead.
+            if (/Executable doesn't exist/i.test(launchErr?.message ?? "")) {
+              throw new PlaywrightMissingError();
+            }
+            throw launchErr;
+          }
         }
 
         try {
@@ -588,6 +602,17 @@ program
         if (pathsLine) console.log(pathsLine);
         if (flagsLine) console.log(flagsLine);
         for (const notice of savedNotices) console.log(notice);
+
+        // The CLI is the only surface most users ever see, so without a nudge
+        // the account side is undiscoverable. Restricted to a bare run — anyone
+        // passing flags already knows the tool and would just read this as
+        // noise — shown on the first few such runs only (see cli-state), and
+        // never once the user already syncs with --key. Points at the recipe
+        // rather than /app: the reader is still deciding, not signing up.
+        if (!apiKey && flagBits.length === 0 && consumeCloudHint()) {
+          console.log(chalk.dim("   Tip: --key <token> keeps runs in your account and diffs them over time."));
+          console.log(chalk.dim("        dembrandt.com/recipes/cloud-drift-ci"));
+        }
       }
     } catch (err) {
       const { code, exit } = classifyError(err);
@@ -667,5 +692,12 @@ program.configureHelp({
     return out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
   },
 });
+
+// Handled before parse(): the root command takes a required <url> argument, so
+// a real Commander subcommand would collide with it. Intercepting the bare verb
+// keeps `dembrandt install-browser` working without restructuring the CLI.
+if (process.argv[2] === "install-browser") {
+  process.exit(installBrowsers(process.argv.slice(3)));
+}
 
 program.parse();

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -13,7 +13,7 @@
 
 export class PlaywrightMissingError extends Error {
   constructor() {
-    super('browser engine not available, run: npx playwright install chromium');
+    super('browser engine not available, run: dembrandt install-browser');
     this.name = 'PlaywrightMissingError';
   }
 }

--- a/lib/cli-state.ts
+++ b/lib/cli-state.ts
@@ -1,0 +1,66 @@
+/**
+ * Tiny persistent CLI state, used only to stop one-time hints from repeating.
+ *
+ * Deliberately not telemetry: nothing is sent anywhere and nothing identifying
+ * is stored — the file holds counters for hints already shown on this machine,
+ * the same shape as update-notifier's configstore. Stored under XDG_CONFIG_HOME
+ * (falling back to ~/.config) so it never lands in the home directory root.
+ *
+ * Every operation fails silent. A read-only HOME, a sandboxed CI runner or an
+ * unwritable config dir must degrade to "show the hint again", never to a
+ * failed extraction.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/** Times the cloud hint is shown before going quiet permanently. */
+const CLOUD_HINT_LIMIT = 3;
+
+interface CliState {
+  cloudHintShown?: number;
+}
+
+function stateDir(): string {
+  const base = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(base, "dembrandt");
+}
+
+function statePath(): string {
+  return join(stateDir(), "state.json");
+}
+
+function readState(): CliState {
+  try {
+    const parsed = JSON.parse(readFileSync(statePath(), "utf-8"));
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(next: CliState): void {
+  try {
+    mkdirSync(stateDir(), { recursive: true });
+    writeFileSync(statePath(), JSON.stringify(next, null, 2));
+  } catch {
+    /* unwritable config dir — the hint simply repeats, nothing breaks */
+  }
+}
+
+/**
+ * True at most CLOUD_HINT_LIMIT times per machine, incrementing on each true.
+ * Silenced by DEMBRANDT_NO_HINTS and by CI, so pipeline logs stay clean and a
+ * CI runner with a fresh HOME never burns the budget meant for a human.
+ */
+export function consumeCloudHint(): boolean {
+  if (process.env.DEMBRANDT_NO_HINTS || process.env.CI) return false;
+
+  const state = readState();
+  const shown = typeof state.cloudHintShown === "number" ? state.cloudHintShown : 0;
+  if (shown >= CLOUD_HINT_LIMIT) return false;
+
+  writeState({ ...state, cloudHintShown: shown + 1 });
+  return true;
+}

--- a/lib/install-browser.ts
+++ b/lib/install-browser.ts
@@ -1,0 +1,48 @@
+/**
+ * Install the Playwright browser revision matching the bundled playwright-core.
+ *
+ * dembrandt drives browsers with playwright-core, which deliberately ships no
+ * binaries. A browser installed for a *different* Playwright version is not
+ * found ("Executable doesn't exist"), which is the single most common first-run
+ * failure. Deriving the version from the playwright-core resolved next to this
+ * file keeps the two in lockstep by construction — including in a global
+ * install, where a bare `npx playwright-core install` would otherwise fetch an
+ * unrelated latest version from the registry.
+ *
+ * Exposed as `dembrandt install-browser` so the fix ships inside the published
+ * package; the repo-only `tools/install-browser.mjs` cannot help an npm user.
+ */
+
+import { execFileSync } from "child_process";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+/** Version of the playwright-core this build actually drives. */
+export function bundledPlaywrightVersion(): string {
+  return require("playwright-core/package.json").version as string;
+}
+
+/**
+ * Runs the version-matched Playwright installer. Returns a process exit code:
+ * 0 on success, 1 on failure (with the manual command echoed for recovery).
+ */
+export function installBrowsers(argv: string[]): number {
+  const version = bundledPlaywrightVersion();
+  // Default to chromium only: it is the engine every extraction uses, and
+  // pulling firefox as well doubles the download for a first-run recovery.
+  const targets = argv.length ? argv : ["chromium"];
+
+  console.log(`Installing Playwright ${targets.join(" ")} for playwright-core ${version}...`);
+  try {
+    execFileSync("npx", ["--yes", `playwright@${version}`, "install", ...targets], { stdio: "inherit" });
+    return 0;
+  } catch {
+    console.error(
+      `\nBrowser installation failed. Install manually with the matching version:\n` +
+      `  npx playwright@${version} install ${targets.join(" ")}\n` +
+      `On Linux/CI add --with-deps for system libraries.`
+    );
+    return 1;
+  }
+}

--- a/lib/install-browser.ts
+++ b/lib/install-browser.ts
@@ -24,8 +24,13 @@ export function bundledPlaywrightVersion(): string {
 }
 
 /**
- * Runs the version-matched Playwright installer. Returns a process exit code:
+ * Runs the bundled playwright-core installer. Returns a process exit code:
  * 0 on success, 1 on failure (with the manual command echoed for recovery).
+ *
+ * Invoked as `node <resolved cli.js>` rather than through npx: the resolved
+ * CLI *is* the bundled playwright-core, so the version matches by construction
+ * with no registry fetch — and npx is npx.cmd on Windows, which execFileSync
+ * will not spawn without a shell.
  */
 export function installBrowsers(argv: string[]): number {
   const version = bundledPlaywrightVersion();
@@ -35,7 +40,8 @@ export function installBrowsers(argv: string[]): number {
 
   console.log(`Installing Playwright ${targets.join(" ")} for playwright-core ${version}...`);
   try {
-    execFileSync("npx", ["--yes", `playwright@${version}`, "install", ...targets], { stdio: "inherit" });
+    const cli = require.resolve("playwright-core/cli.js");
+    execFileSync(process.execPath, [cli, "install", ...targets], { stdio: "inherit" });
     return 0;
   } catch {
     console.error(

--- a/lib/install-browser.ts
+++ b/lib/install-browser.ts
@@ -15,6 +15,7 @@
 
 import { execFileSync } from "child_process";
 import { createRequire } from "module";
+import { dirname, join } from "path";
 
 const require = createRequire(import.meta.url);
 
@@ -40,7 +41,9 @@ export function installBrowsers(argv: string[]): number {
 
   console.log(`Installing Playwright ${targets.join(" ")} for playwright-core ${version}...`);
   try {
-    const cli = require.resolve("playwright-core/cli.js");
+    // cli.js is not in playwright-core's exports map, so it cannot be
+    // require.resolve'd directly — derive its path from package.json, which is.
+    const cli = join(dirname(require.resolve("playwright-core/package.json")), "cli.js");
     execFileSync(process.execPath, [cli, "install", ...targets], { stdio: "inherit" });
     return 0;
   } catch {


### PR DESCRIPTION
A clean `npm i -g dembrandt` cannot install a browser: `playwright-core` ships no binaries, and the documented recovery (`npm run install-browser`) lives in `tools/`, which is excluded by `files: ["dist/"]`.

## Changes

- **`dembrandt install-browser`** resolves the revision from the bundled `playwright-core`. A bare `npx playwright install` fetches whatever the registry serves, which is the `Executable doesn't exist` mismatch the README warned about.
- **Launch errors are translated.** `loadBrowserEngines` guarded a missing *module*, which cannot happen since `playwright-core` is a hard dependency, so `PlaywrightMissingError` was unreachable and the missing *binary* surfaced as raw Playwright output.
- **`dembrandt/dembrandt@v1`** does not exist. Tags end at `v0.23.1`.
- **`--pages`** is not a flag. It exits with `error: unknown option '--pages'`. Replaced with `--crawl`.
- **First-run hint** for the account path: three bare runs, then silent. Off with `DEMBRANDT_NO_HINTS`, in CI, with `--json-only`, and once `--key` is set. Stores a counter under `XDG_CONFIG_HOME`, nothing identifying, nothing sent.

## Verification

Clean install with `PLAYWRIGHT_BROWSERS_PATH` pointed at an empty directory:

- before: `browserType.launch: Executable doesn't exist at .../chrome-headless-shell`
- after: `browser engine not available, run: dembrandt install-browser`
- `npx playwright-core install chromium` then extracts, exit 0

Hint shown on runs 1 to 3, silent on run 4, silent and budget untouched with a flag. 358 unit tests pass.