### PR TITLE
fix(cli): cloud hint one-liner with clickable link

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadBrowserEngines, PlaywrightMissingError } from "./lib/browser.js";
 import { extractBranding } from "./lib/extractors/index.js";
-import { displayResults } from "./lib/formatters/terminal.js";
+import { displayResults, terminalLink } from "./lib/formatters/terminal.js";
 import { color } from "./lib/formatters/theme.js";
 import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generatePDF } from "./lib/formatters/pdf.js";
@@ -610,8 +610,7 @@ program
         // never once the user already syncs with --key. Points at the recipe
         // rather than /app: the reader is still deciding, not signing up.
         if (!apiKey && flagBits.length === 0 && consumeCloudHint()) {
-          console.log(chalk.dim("   Tip: --key <token> keeps runs in your account and diffs them over time."));
-          console.log(chalk.dim("        dembrandt.com/recipes/cloud-drift-ci"));
+          console.log(chalk.dim("💡 --key <token> snapshots each run to your account and catches design drift over time: ") + chalk.dim(terminalLink("https://www.dembrandt.com/recipes/cloud-drift-ci", "dembrandt.com/recipes/cloud-drift-ci")));
         }
       }
     } catch (err) {

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -17,7 +17,7 @@ import { convertColor } from '../colors.js';
  * @param {string} text - The text to display (defaults to url)
  * @returns {string} ANSI-formatted clickable link
  */
-function terminalLink(url, text = url) {
+export function terminalLink(url, text = url) {
   // OSC 8 hyperlink format: \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\
   return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }


### PR DESCRIPTION
Bare-run cloud hint: one dim line, value phrasing (snapshots, design drift), OSC 8 link to the recipe.