### PR TITLE
feat(consent): dismiss banners in iframes and shadow roots

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   unit:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +31,17 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      # consent.test.ts drives a real page, so the unit suite needs chromium.
+      # Same cache key as the smoke job reuses the ~100MB download.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
 
       - name: Run unit tests
         run: npm test

--- a/lib/extractors/consent.ts
+++ b/lib/extractors/consent.ts
@@ -1,0 +1,173 @@
+import type { Frame, Page } from 'playwright';
+
+/**
+ * Cookie/consent dismissal.
+ *
+ * The banner is not always in the main document. Two common cases were
+ * previously unreachable:
+ *
+ *  - iframe-hosted CMPs (Sourcepoint `sp_message_iframe_*`, TrustArc,
+ *    Quantcast, Cookiebot's dialog) live in a child frame, so a
+ *    `page.evaluate` on the top document never sees the button.
+ *  - shadow-DOM CMPs (Usercentrics, Osano, CookieYes) put the button inside
+ *    an open shadow root, where `document.querySelector` does not reach.
+ *
+ * Both leave the overlay up, and the extractors then read the overlay's
+ * palette and type as if it were the site's. So: sweep every frame, and
+ * pierce open shadow roots in each.
+ */
+
+const ACCEPT_SELECTORS = [
+  // Generic accept patterns
+  'button[id*="accept"]', 'button[class*="accept"]',
+  'button[id*="agree"]', 'button[class*="agree"]',
+  'button[id*="consent"]', 'button[class*="consent"]',
+  '[data-testid*="accept"]', '[data-testid*="agree"]',
+  // Common consent libraries
+  '#onetrust-accept-btn-handler',
+  '.cc-btn.cc-allow', '.cc-accept',
+  '[aria-label*="Accept"]', '[aria-label*="agree"]',
+  // EU/GDPR common patterns
+  'button[data-cookiebanner]',
+  '.cookiebanner button', '#cookiebanner button',
+  '[class*="cookie"] button[class*="primary"]',
+  '[id*="cookie"] button[class*="primary"]',
+  '[class*="gdpr"] button', '[id*="gdpr"] button',
+  // CMP patterns — main document
+  '.sp-message-open .message-button',
+  '#sp-cc-accept', '.optanon-allow-all',
+  // CMP patterns — inside the CMP's own iframe, where the wrapper class above
+  // does not exist and the button stands alone
+  '.message-button', '.sp_choice_type_11',
+  '#truste-consent-button', '.trustarc-agree-btn',
+  '.qc-cmp2-summary-buttons button[mode="primary"]',
+  '#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll',
+  '#CybotCookiebotDialogBodyButtonAccept',
+  // Shadow-DOM CMPs — these ids/classes only resolve once the shadow root is
+  // pierced, which the deep query below does
+  '#uc-btn-accept-banner', '[data-testid="uc-accept-all-button"]',
+  '.osano-cm-accept-all', '.cky-btn-accept',
+];
+
+// Last resort inside a frame that looks like a consent surface: match the
+// button by its label. Scoped to affirmative-only text so we never click
+// "Reject all" or "Manage preferences" (which opens a second overlay).
+const ACCEPT_TEXT = /^(accept|allow|agree|i agree|got it|ok|okay|understood|continue)\b/i;
+const REJECT_TEXT = /\b(reject|decline|deny|manage|settings|preferences|customi[sz]e|options|necessary only|more info)\b/i;
+
+/**
+ * Runs inside the page/frame — Playwright serializes this function, so it must
+ * stay self-contained and reference nothing from module scope. Returns the
+ * selector that was clicked, or null.
+ */
+function dismissInFrame(
+  { selectors, acceptSrc, rejectSrc }: { selectors: string[]; acceptSrc: string; rejectSrc: string }
+): string | null {
+  const MAX_NODES = 4000;   // bound the shadow walk on pathological DOMs
+  const MAX_DEPTH = 6;      // shadow roots nest, but not deeply in practice
+  const TEXT_CAP = 60;
+
+  const isVisible = (el: Element): boolean => {
+    try {
+      const h = el as HTMLElement;
+      return h.offsetParent !== null ||
+        (typeof h.getClientRects === 'function' && h.getClientRects().length > 0);
+    } catch { return false; }
+  };
+  const safeClick = (el: Element): boolean => {
+    try {
+      if (typeof (el as HTMLElement).click === 'function') {
+        (el as HTMLElement).click();
+        return true;
+      }
+    } catch {}
+    return false;
+  };
+
+  // Every root worth searching: the document plus each open shadow root.
+  const roots: (Document | ShadowRoot)[] = [document];
+  let budget = MAX_NODES;
+  const collect = (root: Document | ShadowRoot, depth: number): void => {
+    if (depth > MAX_DEPTH || budget <= 0) return;
+    let all: Element[] = [];
+    try { all = Array.from(root.querySelectorAll('*')); } catch { return; }
+    for (const el of all) {
+      if (budget-- <= 0) return;
+      const sr = (el as HTMLElement).shadowRoot;   // null for closed roots
+      if (sr) { roots.push(sr); collect(sr, depth + 1); }
+    }
+  };
+  try { collect(document, 0); } catch {}
+
+  for (const sel of selectors) {
+    for (const root of roots) {
+      try {
+        const el = root.querySelector(sel);
+        if (el && isVisible(el) && safeClick(el)) return sel;
+      } catch {}
+    }
+  }
+
+  // Text fallback. Only inside a frame/root that actually looks like consent
+  // UI, so an ordinary "Continue" button on the site is never clicked.
+  let looksLikeConsent = false;
+  try {
+    const hay = (document.body?.innerText || '').slice(0, 4000);
+    looksLikeConsent = /cookie|consent|gdpr|privacy|tracking/i.test(hay);
+  } catch {}
+  if (!looksLikeConsent) return null;
+
+  const accept = new RegExp(acceptSrc, 'i');
+  const reject = new RegExp(rejectSrc, 'i');
+  for (const root of roots) {
+    let candidates: Element[] = [];
+    try {
+      candidates = Array.from(
+        root.querySelectorAll('button, a[role="button"], [role="button"], input[type="submit"], input[type="button"]')
+      ).slice(0, 80);
+    } catch { continue; }
+    for (const el of candidates) {
+      try {
+        if (!isVisible(el)) continue;
+        const raw = el.textContent || (el as HTMLInputElement).value ||
+          el.getAttribute('aria-label') || '';
+        const text = String(raw).trim().replace(/\s+/g, ' ').slice(0, TEXT_CAP);
+        if (!text || !accept.test(text) || reject.test(text)) continue;
+        if (safeClick(el)) return `text:${text}`;
+      } catch {}
+    }
+  }
+  return null;
+}
+
+/**
+ * Try the main document first, then every child frame. Returns a label for the
+ * dismissal that succeeded, or null if no banner was found. Never throws: a
+ * click can navigate the page and destroy the execution context, which is a
+ * successful dismissal, not a failure.
+ */
+export async function dismissConsent(page: Page): Promise<string | null> {
+  let frames: Frame[] = [];
+  try { frames = page.frames(); } catch { frames = []; }
+
+  // frames[0] is the main frame, so the main document is tried first and a
+  // top-level banner still wins before any iframe is touched.
+  for (const frame of frames) {
+    let hit: string | null = null;
+    try {
+      hit = await frame.evaluate(dismissInFrame, {
+        selectors: ACCEPT_SELECTORS,
+        acceptSrc: ACCEPT_TEXT.source,
+        rejectSrc: REJECT_TEXT.source,
+      });
+    } catch {
+      // Detached frame, cross-origin eval refusal, or a click that navigated
+      // the page and destroyed the execution context. Only the last is a
+      // dismissal, and it is indistinguishable here — so keep sweeping the
+      // remaining frames rather than claiming either outcome.
+      continue;
+    }
+    if (hit) return frame === frames[0] ? hit : `frame:${hit}`;
+  }
+  return null;
+}

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -14,6 +14,7 @@ import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import { guardExtractor } from './guard.js';
+import { dismissConsent } from './consent.js';
 import type { Browser, Page } from 'playwright';
 import type { ExtractOptions, BrandingResult, Spinner, ExtractorError, WcagPair } from '../types.js';
 
@@ -524,38 +525,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
         log(color.success(`  ✓ Full page scrolled (lazy content triggered)`));
 
         spinner.start("Dismissing cookie consent banners...");
-        const dismissed = await page.evaluate(async () => {
-          const selectors = [
-            // Generic accept patterns
-            'button[id*="accept"]', 'button[class*="accept"]',
-            'button[id*="agree"]', 'button[class*="agree"]',
-            'button[id*="consent"]', 'button[class*="consent"]',
-            '[data-testid*="accept"]', '[data-testid*="agree"]',
-            // Common consent libraries
-            '#onetrust-accept-btn-handler',
-            '.cc-btn.cc-allow', '.cc-accept',
-            '[aria-label*="Accept"]', '[aria-label*="agree"]',
-            // EU/GDPR common patterns
-            'button[data-cookiebanner]',
-            '.cookiebanner button', '#cookiebanner button',
-            '[class*="cookie"] button[class*="primary"]',
-            '[id*="cookie"] button[class*="primary"]',
-            '[class*="gdpr"] button', '[id*="gdpr"] button',
-            // CMP patterns
-            '.sp-message-open .message-button',
-            '#sp-cc-accept', '.optanon-allow-all',
-          ];
-          for (const sel of selectors) {
-            try {
-              const el = document.querySelector(sel) as HTMLElement | null;
-              if (el && el.offsetParent !== null) {
-                el.click();
-                return sel;
-              }
-            } catch {}
-          }
-          return null;
-        });
+        const dismissed = await dismissConsent(page);
         spinner.stop();
         if (dismissed) {
           log(color.success(`  ✓ Cookie banner dismissed (${dismissed})`));

--- a/test/consent.test.ts
+++ b/test/consent.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser } from 'playwright';
+import { dismissConsent } from '../lib/extractors/consent.js';
+
+// The two banner placements the old main-document-only pass could not reach:
+// an open shadow root, and a child iframe. Each fixture marks window.__accepted
+// on click so the assertion is on the click actually landing, not on the
+// returned label.
+
+const SHADOW_FIXTURE = `<!doctype html><html><body>
+<div id="host"></div>
+<script>
+  window.__accepted = false;
+  const root = document.getElementById('host').attachShadow({ mode: 'open' });
+  root.innerHTML =
+    '<div style="position:fixed;inset:auto 0 0 0;height:120px;background:#222">' +
+    '<p>We use cookies</p>' +
+    '<button id="uc-btn-accept-banner">Accept All</button></div>';
+  root.getElementById('uc-btn-accept-banner')
+      .addEventListener('click', () => { window.__accepted = true; });
+</script></body></html>`;
+
+const IFRAME_INNER = `<!doctype html><html><body style="margin:0">
+<div style="height:100px;background:#111;color:#fff">
+  <p>This site uses cookies for consent purposes</p>
+  <button class="message-button">Yes, I accept</button>
+</div>
+<script>
+  document.querySelector('.message-button')
+    .addEventListener('click', () => { document.title = 'accepted'; });
+</script></body></html>`;
+
+const IFRAME_FIXTURE = `<!doctype html><html><body>
+<h1>Site content</h1>
+<iframe id="sp_message_iframe_1" style="position:fixed;inset:0;width:100%;height:200px"
+        srcdoc="${IFRAME_INNER.replace(/"/g, '&quot;')}"></iframe>
+</body></html>`;
+
+// A plain page with a "Continue" button and no consent language: the text
+// fallback must not fire here, or every site with a CTA gets a phantom click.
+const DECOY_FIXTURE = `<!doctype html><html><body>
+<h1>Pricing</h1>
+<button id="cta" onclick="window.__accepted = true">Continue</button>
+<script>window.__accepted = false;</script></body></html>`;
+
+// Consent UI offering reject first — the sweep must never take that path.
+const REJECT_FIRST_FIXTURE = `<!doctype html><html><body>
+<div class="cky-consent-bar">
+  <p>We use cookies to improve your experience</p>
+  <button id="no" onclick="window.__rejected = true">Reject all</button>
+  <button class="cky-btn-accept" onclick="window.__accepted = true">Accept all</button>
+</div>
+<script>window.__accepted = false; window.__rejected = false;</script></body></html>`;
+
+let browser: Browser;
+before(async () => { browser = await chromium.launch({ headless: true }); });
+after(async () => { await browser?.close().catch(() => {}); });
+
+test('dismissConsent pierces an open shadow root', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(SHADOW_FIXTURE, { waitUntil: 'load' });
+    // The button exists only inside the shadow root, so any hit at all proves
+    // the walk pierced it; which selector matched first is not the contract.
+    assert.notEqual(await dismissConsent(page), null);
+    assert.equal(await page.evaluate(() => (window as any).__accepted), true);
+  } finally {
+    await page.close().catch(() => {});
+  }
+});
+
+test('dismissConsent reaches a banner inside a child iframe', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(IFRAME_FIXTURE, { waitUntil: 'load' });
+    const hit = await dismissConsent(page);
+    assert.equal(hit, 'frame:.message-button');
+    const inner = page.frames().find((f) => f !== page.mainFrame());
+    assert.equal(await inner!.title(), 'accepted');
+  } finally {
+    await page.close().catch(() => {});
+  }
+});
+
+test('dismissConsent leaves a non-consent page alone', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(DECOY_FIXTURE, { waitUntil: 'load' });
+    assert.equal(await dismissConsent(page), null);
+    assert.equal(await page.evaluate(() => (window as any).__accepted), false);
+  } finally {
+    await page.close().catch(() => {});
+  }
+});
+
+test('dismissConsent accepts rather than rejects', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(REJECT_FIRST_FIXTURE, { waitUntil: 'load' });
+    assert.notEqual(await dismissConsent(page), null);
+    assert.equal(await page.evaluate(() => (window as any).__accepted), true);
+    assert.equal(await page.evaluate(() => (window as any).__rejected), false);
+  } finally {
+    await page.close().catch(() => {});
+  }
+});


### PR DESCRIPTION
Sweep every frame and pierce open shadow roots when dismissing consent banners. iframe-hosted and shadow-DOM CMPs were previously unreachable, leaving the overlay's palette and type to bleed into extraction.

Supersedes #128 (base branch was deleted on release merge). Rebased onto main; consent commit + chromium for the unit job.