### PR TITLE
chore(ci): dependabot + token scoping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    labels: [dependencies]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: [dependencies]

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -11,6 +11,9 @@ on:
       - "action.yml"
       - ".github/workflows/action-smoke.yml"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -9,6 +9,11 @@ on:
         required: true
         default: "v0.12.0"
 
+# Cross-repo writes use SKILLS_REPO_PAT / NEXT_REPO_PAT, not GITHUB_TOKEN, so
+# the default token stays read-only.
+permissions:
+  contents: read
+
 jobs:
   sync-skills:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- dependabot for npm (weekly, minor/patch grouped) and github-actions
- contents: read on action-smoke and sync-skills (parity with smoke/nightly; cross-repo writes use PATs)

Separate from the feature release. Does not touch the hono transitive advisories (unreachable in a stdio CLI; the sdk carries them, dependabot will surface the bump).