### PR TITLE
chore(release): 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.25.0] - 2026-07-26
+
+### Added
+- Consent dismissal now sweeps child iframes and pierces open shadow roots, reaching iframe-hosted CMPs (Sourcepoint, TrustArc, Quantcast, Cookiebot) and shadow-DOM CMPs (Usercentrics, Osano, CookieYes) that the main-document pass could not (#129)
+
+### Changed
+- Framework detection anchors class-prefix selectors (`fa-`, `uk-`, `p-`, `ms-`, `q-`, `el-`) instead of substring matching, and requires real `data-radix-*` markers; removes false positives from Tailwind and unrelated utility classes (#125)
+- Cloud hint is a single line with a clickable recipe link (#126)
+
+### Removed
+- Golden-baseline `qa.mjs` and `gold:*` harness layers; replaced by a minimal liveness smoke and `release:churn`. Accuracy ground truth lives in dembrandt-ml (#127)
+
+## [0.24.0] - 2026-07-18
+
+### Changed
+- Drift comparison: validity warnings, scoring calibration, meta provenance (schema 1.3.0) (#123)
+
+### Fixed
+- `install-browser` installs the Playwright version matched to the resolved CLI; corrected CI docs (#124)
+
+### Refactored
+- Brand-guide: split the HTML builder from the PDF generator (#122)
+
 ## [0.23.1] - 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ dembrandt dembrandt.com --brand-guide
 The official action wraps extract → compare → gate into one step: it installs a matching Chromium, runs a pinned CLI version, fails the job on drift, and renders the drifted tokens as inline annotations on the PR.
 
 ```yaml
-- uses: dembrandt/dembrandt@v0.24.0
+- uses: dembrandt/dembrandt@v0.25.0
   with:
     url: https://preview.example.com
     baseline: .dembrandt/baseline.json
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dembrandt/dembrandt@v0.24.0
+      - uses: dembrandt/dembrandt@v0.25.0
         with:
           url: ${{ github.event.deployment_status.environment_url }}
           baseline: .dembrandt/baseline.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported versions
+
+Pre-1.0. Only the latest published `0.x` release receives fixes. Upgrade before reporting.
+
+## Reporting a vulnerability
+
+Report privately. Do not open a public issue for a security bug.
+
+- Preferred: GitHub private vulnerability reporting (repository **Security** tab -> **Report a vulnerability**).
+- Alternative: email dembrandt@tutamail.com.
+
+Include the version, the command or MCP call, the target URL if relevant, and a reproduction. Expect an acknowledgement within a few days.
+
+## Scope
+
+dembrandt drives a headless browser against arbitrary third-party URLs and parses their DOM, CSS, and assets. Treat all extracted output as untrusted input. In-scope reports include: sandbox or navigation escapes, code execution from crafted page content, credential or token leakage (`--key`, cookies), and path traversal in output writing. Denial of service from a hostile page (hangs, memory) is lower priority and usually handled by the existing timeouts.

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         path: ~/.cache/ms-playwright
         # The CLI version pinned in the install step below fixes playwright-core
         # transitively; bump this key together with that pin on release.
-        key: dembrandt-chromium-${{ runner.os }}-0.23.1
+        key: dembrandt-chromium-${{ runner.os }}-0.25.0
 
     - name: Install dembrandt CLI and Chromium
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
       # installed tree instead of hardcoding — same rule as README "Continuous
       # integration".
       run: |
-        npm install -g dembrandt@0.24.0
+        npm install -g dembrandt@0.25.0
         PW_VERSION=$(node -p "require('$(npm root -g)/dembrandt/node_modules/playwright-core/package.json').version")
         echo "playwright-core resolved to $PW_VERSION"
         npx --yes "playwright@$PW_VERSION" install chromium --with-deps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Extract design tokens and publicly visible CSS information from any website",
   "mcpName": "io.github.dembrandt/dembrandt",
   "main": "dist/index.js",


### PR DESCRIPTION
Release prep for 0.25.0. Does not publish.

- version 0.24.0 -> 0.25.0 (package.json, action.yml pin, README uses: examples)
- CHANGELOG: 0.25.0 section + backfilled 0.24.0
- SECURITY.md: reporting policy + scope

Churn measured 0 on dembrandt.com and stripe.com (threshold 10), so no drift-gate remedy needed. Publish, tag, and v0 move remain manual per release process.