### PR TITLE
feat: extract font source URLs in typography extraction

### DIFF
--- a/docs/superpowers/specs/2026-07-29-font-source-urls-design.md
+++ b/docs/superpowers/specs/2026-07-29-font-source-urls-design.md
@@ -1,0 +1,108 @@
+# Font source URLs in typography extraction
+
+## Problem
+
+`typography.sources` currently records font *names* (`googleFonts: string[]`,
+`adobeFonts`) but never the actual URLs the browser loaded fonts from. Callers
+that want to re-fetch, cache, or verify font assets have nothing to go on,
+unlike logos/favicons which already carry resolved URLs.
+
+## Design
+
+### `lib/extractors/typography.ts`
+
+- Export a new pure function:
+
+  ```ts
+  export function filterFontUrls(urls: string[]): string[]
+  ```
+
+  Input: raw, already-absolute candidate URL strings collected in the browser.
+  Behavior:
+  - Drop `data:` URIs.
+  - Keep only URLs that either end in a font file extension
+    (`.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`, allowing a trailing `?`/`#`
+    query/fragment) OR match a known webfont provider host
+    (`fonts.googleapis.com`, `fonts.gstatic.com`, `use.typekit.net`,
+    `fonts.bunny.net`).
+  - Dedupe.
+  - Return sorted array (stable output for tests/diffing).
+  - No browser APIs used — unit-testable directly, same convention as
+    `parseVariableAxes` / `parseOpenTypeFeatures`.
+
+- Inside the existing `page.evaluate()` block, collect **unfiltered** absolute
+  candidate URLs into a new `fontUrlCandidates: string[]` array on the
+  returned data object, from three sources:
+  1. `link[rel*="stylesheet"]` elements whose `href` matches the provider
+     hosts above.
+  2. `link[rel*="preload"][as="font"]` elements' `href`.
+  3. `@font-face` `src` declarations, parsed via `url(...)` regex, from the
+     existing `document.styleSheets` walk already used for `customFonts` /
+     `fontDisplay` detection (extend that loop rather than adding a second
+     traversal).
+  - All resolved via `new URL(href, location.href).href`.
+  - Filtering/dedup happens in Node afterward via `filterFontUrls`, not in the
+    browser.
+
+- After `page.evaluate()` returns, in Node:
+  ```ts
+  sources.urls = filterFontUrls(data.fontUrlCandidates);
+  ```
+  Always an array; `[]` when nothing found (never `undefined`), matching the
+  existing convention for `styles` and other array fields.
+
+### `lib/types.ts`
+
+Add to `Typography['sources']`:
+```ts
+/** Resolved font asset/stylesheet URLs discovered during extraction. */
+urls?: string[];
+```
+
+### `lib/merger.ts`, `lib/normalize.ts`
+
+No changes. `urls` is a plain `string[]` under `sources`; the existing
+generic array-union merge (`sources[k] = [...new Set([...sources[k], ...v])]`)
+already handles it correctly across crawled pages. `normalizeExtraction`
+requires no coercion for a plain string array.
+
+### Formatters
+
+- **`lib/formatters/terminal.ts`** (`displayTypography`): after the existing
+  "Fonts: ..." line, if `typography.sources.urls?.length`, print each URL as
+  a clickable line using the existing `terminalLink()` OSC-8 helper (same
+  pattern used for favicons), truncated with a "+N more" line past the first
+  few entries — consistent with how the existing font-name list truncates.
+- **`lib/formatters/html.ts`** (`typographySection`): append a short "Font
+  files" list of `<a>` links below the existing `srcLine`, using the file's
+  existing `esc()` helper.
+- **`lib/formatters/markdown.ts`** (`buildTypographySection`): add a
+  `- **Font URLs**: ...` bullet (or nested list) next to the existing
+  "Font source" bullet, only rendered when non-empty.
+- **`lib/formatters/brand-guide.ts`, `lib/formatters/dtcg.ts`**: intentionally
+  untouched. Brand-guide is a print/visual artifact with no raw-URL
+  precedent; DTCG typography tokens model design values (family/size/weight),
+  not asset provenance.
+
+### Tests (`test/typography.test.ts`)
+
+Add unit tests for `filterFontUrls` covering:
+- Dedupes repeated URLs.
+- Drops `data:` URIs.
+- Keeps `.woff2` / `.woff` / `.ttf` / `.otf` / `.eot` URLs (with and without
+  query strings).
+- Keeps Google Fonts / Typekit / Bunny Fonts stylesheet URLs even without a
+  font-file extension.
+- Drops unrelated URLs (e.g. a plain image, analytics script).
+- Returns `[]` for empty input.
+
+### Backward compatibility
+
+`sources.urls` is always emitted as `[]` when empty. Existing consumers that
+don't know about the field are unaffected; anything that spreads
+`typography.sources` picks it up automatically.
+
+### Release note
+
+"Typography extraction now includes discovered font source URLs
+(stylesheets, preload hints, and @font-face assets)."

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -72,6 +72,34 @@ export function parseOpenTypeFeatures(settings: string[]): string[] {
   return [...set].sort();
 }
 
+const FONT_FILE_EXTENSIONS = /\.(woff2?|ttf|otf|eot)(?:[?#].*)?$/i;
+const WEBFONT_PROVIDER_HOSTS = ['fonts.googleapis.com', 'fonts.gstatic.com', 'use.typekit.net', 'fonts.bunny.net'];
+
+/**
+ * Filter raw, already-absolute candidate URLs down to real font asset/
+ * stylesheet URLs: font files by extension, or known webfont provider hosts
+ * (whose stylesheet URLs carry no file extension). Pure and unit-testable,
+ * same convention as parseVariableAxes / parseOpenTypeFeatures.
+ */
+export function filterFontUrls(urls: string[]): string[] {
+  const set = new Set<string>();
+  for (const url of urls) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      continue; // not a parseable absolute URL — skip
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+    if (FONT_FILE_EXTENSIONS.test(parsed.pathname)) {
+      set.add(parsed.href);
+      continue;
+    }
+    if (WEBFONT_PROVIDER_HOSTS.includes(parsed.hostname)) set.add(parsed.href);
+  }
+  return [...set].sort();
+}
+
 export async function extractTypography(page) {
   const data = await page.evaluate(() => {
     const seen = new Map();
@@ -87,6 +115,21 @@ export async function extractTypography(page) {
       customFonts: [],
       variableFonts: new Set(),
     };
+    const fontUrlCandidates: string[] = [];
+    const webfontProviderHosts = ['fonts.googleapis.com', 'fonts.gstatic.com', 'use.typekit.net', 'fonts.bunny.net'];
+
+    document
+      .querySelectorAll('link[rel*="stylesheet"]')
+      .forEach((l: any) => {
+        if (webfontProviderHosts.some(h => l.href.includes(h))) {
+          fontUrlCandidates.push(new URL(l.href, location.href).href);
+        }
+      });
+    document
+      .querySelectorAll('link[rel*="preload"][as="font"]')
+      .forEach((l: any) => {
+        if (l.href) fontUrlCandidates.push(new URL(l.href, location.href).href);
+      });
 
     document
       .querySelectorAll(
@@ -122,6 +165,11 @@ export async function extractTypography(page) {
           for (const rule of sheet.cssRules || []) {
             if (rule instanceof CSSFontFaceRule) {
               const src = rule.style.getPropertyValue('src') || '';
+              for (const m of src.matchAll(/url\(\s*['"]?([^'")]+)['"]?\s*\)/g)) {
+                try {
+                  fontUrlCandidates.push(new URL(m[1], location.href).href);
+                } catch {}
+              }
               const family = (rule.style.getPropertyValue('font-family') || '').replace(/['"]/g, '').trim();
               if (!family) continue;
               const isThirdParty = thirdPartyHosts.some(h => src.includes(h));
@@ -276,6 +324,7 @@ export async function extractTypography(page) {
       featureSettings,
       familyBodyWeight,
       bodyComputedFamily,
+      fontUrlCandidates,
     };
   });
 
@@ -283,6 +332,7 @@ export async function extractTypography(page) {
   // unit-testable. Attach to sources only when present — no empty arrays.
   const variableAxes = parseVariableAxes(data.variationSettings);
   const openTypeFeatures = parseOpenTypeFeatures(data.featureSettings);
+  const urls = filterFontUrls(data.fontUrlCandidates);
 
   // Disambiguate the body font. The size/tag heuristic labels every non-special
   // element "body", so a decorative face on one stray element can masquerade as
@@ -303,6 +353,7 @@ export async function extractTypography(page) {
       ...data.sources,
       ...(variableAxes.length ? { variableAxes } : {}),
       ...(openTypeFeatures.length ? { openTypeFeatures } : {}),
+      urls,
     },
   };
 }

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -395,10 +395,22 @@ function typographySection(result: BrandingResult): string {
     ...(srcs.selfHostedFonts ?? []),
   ];
   const srcLine = fams.length ? `<p class="sub">Sources: ${esc(fams.join(", "))}</p>` : "";
+  const isHttpUrl = (u: string): boolean => {
+    try {
+      const p = new URL(u).protocol;
+      return p === "http:" || p === "https:";
+    } catch {
+      return false;
+    }
+  };
+  const fontUrls = (srcs.urls ?? []).filter(isHttpUrl);
+  const urlsLine = fontUrls.length
+    ? `<p class="sub">Font files: ${fontUrls.map((u) => `<a href="${esc(u)}">${esc(u)}</a>`).join(", ")}</p>`
+    : "";
   const all = styles.map((s) => `${s.context}: ${(s.family ?? "").split(",")[0]} ${s.size}/${s.weight}${s.lineHeight ? ` lh ${s.lineHeight}` : ""}`).join("\n");
   return section(
     "Typography",
-    `<table><thead><tr><th>Context</th><th>Family</th><th>Size</th><th>Weight</th><th>Line height</th></tr></thead><tbody>${rows}</tbody></table>${srcLine}`,
+    `<table><thead><tr><th>Context</th><th>Family</th><th>Size</th><th>Weight</th><th>Line height</th></tr></thead><tbody>${rows}</tbody></table>${srcLine}${urlsLine}`,
     undefined,
     all
   );

--- a/lib/formatters/markdown.ts
+++ b/lib/formatters/markdown.ts
@@ -269,6 +269,10 @@ function buildTypographySection(result, typographyTokens) {
     lines.push(`- **Font source**: Google Fonts (${result.typography.sources.googleFonts.join(', ')})`);
   }
 
+  if (result.typography?.sources?.urls?.length) {
+    lines.push(`- **Font URLs**: ${result.typography.sources.urls.join(', ')}`);
+  }
+
   return lines.join('\n');
 }
 

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -297,6 +297,16 @@ function displayTypography(typography) {
     }
   }
 
+  const fontUrls = typography.sources?.urls || [];
+  if (fontUrls.length > 0) {
+    fontUrls.slice(0, 3).forEach((url: string) => {
+      console.log(chalk.dim('│  ├─') + ' ' + chalk.blue(terminalLink(url)));
+    });
+    if (fontUrls.length > 3) {
+      console.log(chalk.dim('│  ├─') + ' ' + chalk.dim(`+${fontUrls.length - 3} more`));
+    }
+  }
+
   // Group styles by font family: collect unique sizes (largest first) and weights
   if (typography.styles?.length > 0) {
     const fontFamilies = new Map();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,6 +64,8 @@ export interface Typography {
     variableAxes?: VariableFontAxis[];
     /** OpenType features actively enabled via font-feature-settings (e.g. ss01, calt). */
     openTypeFeatures?: string[];
+    /** Resolved font asset/stylesheet URLs discovered during extraction. */
+    urls?: string[];
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./extractors": {
+      "types": "./dist/lib/extractors/index.d.ts",
+      "default": "./dist/lib/extractors/index.js"
+    },
     "./dtcg": {
       "types": "./dist/lib/dtcg/validate.d.ts",
       "default": "./dist/lib/dtcg/validate.js"
@@ -59,6 +63,7 @@
   "scripts": {
     "start": "node dist/index.js",
     "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "test": "npm run build && node --test dist/test/*.test.js",
     "install-browser": "node tools/install-browser.mjs",
     "dev": "tsc --watch",

--- a/test/typography.test.ts
+++ b/test/typography.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseVariableAxes, parseOpenTypeFeatures, pickBodyFamily } from '../lib/extractors/typography.js';
+import { parseVariableAxes, parseOpenTypeFeatures, pickBodyFamily, filterFontUrls } from '../lib/extractors/typography.js';
 
 /**
  * The typography extractor reads computed styles in the browser, but the
@@ -69,4 +69,73 @@ test('pickBodyFamily breaks coverage ties on first-seen for determinism', () => 
 test('pickBodyFamily returns null when neither signal yields a family', () => {
   assert.equal(pickBodyFamily(null, {}), null);
   assert.equal(pickBodyFamily('', { Inter: 0 }), null);
+});
+
+test('filterFontUrls dedupes repeated URLs', () => {
+  const urls = filterFontUrls([
+    'https://example.com/fonts/a.woff2',
+    'https://example.com/fonts/a.woff2',
+  ]);
+  assert.deepEqual(urls, ['https://example.com/fonts/a.woff2']);
+});
+
+test('filterFontUrls drops data: URIs', () => {
+  const urls = filterFontUrls([
+    'data:font/woff2;base64,AAAA',
+    'https://example.com/fonts/a.woff2',
+  ]);
+  assert.deepEqual(urls, ['https://example.com/fonts/a.woff2']);
+});
+
+test('filterFontUrls keeps font file extensions with and without query strings', () => {
+  const urls = filterFontUrls([
+    'https://example.com/a.woff2',
+    'https://example.com/b.woff?v=2',
+    'https://example.com/c.ttf#hash',
+    'https://example.com/d.otf',
+    'https://example.com/e.eot',
+  ]);
+  assert.deepEqual(urls, [
+    'https://example.com/a.woff2',
+    'https://example.com/b.woff?v=2',
+    'https://example.com/c.ttf#hash',
+    'https://example.com/d.otf',
+    'https://example.com/e.eot',
+  ].sort());
+});
+
+test('filterFontUrls keeps webfont provider stylesheet URLs without a font extension', () => {
+  const urls = filterFontUrls([
+    'https://fonts.googleapis.com/css2?family=Inter',
+    'https://fonts.gstatic.com/s/inter/v1/foo.woff2',
+    'https://use.typekit.net/abc123.css',
+    'https://fonts.bunny.net/css?family=inter',
+  ]);
+  assert.deepEqual(urls, [
+    'https://fonts.googleapis.com/css2?family=Inter',
+    'https://fonts.gstatic.com/s/inter/v1/foo.woff2',
+    'https://use.typekit.net/abc123.css',
+    'https://fonts.bunny.net/css?family=inter',
+  ].sort());
+});
+
+test('filterFontUrls drops unrelated URLs', () => {
+  const urls = filterFontUrls([
+    'https://example.com/images/logo.png',
+    'https://example.com/analytics.js',
+  ]);
+  assert.deepEqual(urls, []);
+});
+
+test('filterFontUrls returns [] for empty input', () => {
+  assert.deepEqual(filterFontUrls([]), []);
+});
+
+test('filterFontUrls rejects non-http(s) schemes even with a font-like path', () => {
+  const urls = filterFontUrls([
+    'javascript:alert(1)//a.woff2',
+    'data:font/woff2;base64,AAAA',
+    'file:///etc/passwd.woff2',
+  ]);
+  assert.deepEqual(urls, []);
 });


### PR DESCRIPTION
## What

`typography.sources` records font *names* but never the URLs the browser actually loaded fonts from. This adds `typography.sources.urls: string[]` — resolved stylesheet, preload, and `@font-face` asset URLs discovered during extraction — so callers can re-fetch, cache, or verify font assets, matching the existing convention for logos/favicons.

## How

- New pure, unit-tested `filterFontUrls()` in `lib/extractors/typography.ts`: keeps only `http(s)` URLs that either end in a font file extension (`.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`) or match a known webfont provider host (Google Fonts, Typekit, Bunny Fonts). URL is parsed first and non-`http(s)` schemes (`javascript:`, `data:`, `file:`) are rejected before any extension/host matching, since this list is later rendered as clickable links in the HTML/terminal reports.
- Browser-side collection extends the existing `@font-face` / `document.styleSheets` walk (no second traversal) plus `link[rel=stylesheet]` (provider hosts) and `link[rel=preload][as=font]`.
- `sources.urls` is always an array (`[]` when empty), consistent with other array fields.
- `lib/merger.ts` / `lib/normalize.ts` needed no changes — the existing generic array-union merge already handles a plain `string[]` correctly.
- Terminal, HTML, and Markdown formatters render the URLs when present; HTML formatter defensively re-checks scheme before emitting `href` as well.

## Test plan

- `npm run lint` and `npm test` (390 tests, all passing)
- New unit tests in `test/typography.test.ts` covering: dedupe, `data:` URI rejection, font-extension matching (with/without query strings), webfont provider host matching, rejection of unrelated URLs, empty input, and rejection of non-http(s) schemes (`javascript:`, `data:`, `file:`) even with a font-like path.

## Checklist

- [x] `npm run lint` and `npm test` pass locally
- [ ] New/changed flags: N/A — no new CLI flags
- [x] CLI contract intact: no change to exit codes or `--json-only` stdout
- [ ] User-facing behavior change → README — not updated; this is an additive output field, no README changes typically accompany new `sources` fields (matches convention of prior `variableAxes`/`openTypeFeatures` additions)