### PR TITLE
fix(colors): normalise modern CSS colour functions, emit lch() at D50

### DIFF
--- a/lib/color-parse.ts
+++ b/lib/color-parse.ts
@@ -1,0 +1,535 @@
+/**
+ * Spec-complete CSS color parser (CSS Color Level 4).
+ *
+ * One entry point, parseCssColor(), accepts every color notation a stylesheet
+ * or computed style can contain — named colors, hex (3/4/6/8), legacy
+ * comma-separated rgb()/rgba()/hsl()/hsla(), modern space-separated syntax
+ * with slash alpha, hwb(), lab()/lch() (D50), oklab()/oklch(), and color()
+ * with the common predefined spaces — and resolves it to sRGB 8-bit channels
+ * plus float alpha. Out-of-gamut values are mapped by the CSS Color 4
+ * chroma-reduction algorithm, not channel clipping.
+ *
+ * Kept dependency-free and strict-clean; the browser-context mirror in
+ * lib/extractors/colors.ts must stay in sync with this module.
+ */
+
+export interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+type Matrix3 = readonly [readonly [number, number, number], readonly [number, number, number], readonly [number, number, number]];
+
+// ---------------------------------------------------------------------------
+// Matrices and transfer functions
+// ---------------------------------------------------------------------------
+
+const XYZ_D65_TO_LINEAR_SRGB: Matrix3 = [
+  [3.2404542, -1.5371385, -0.4985314],
+  [-0.9692660, 1.8760108, 0.0415560],
+  [0.0556434, -0.2040259, 1.0572252],
+];
+
+const LINEAR_P3_TO_XYZ_D65: Matrix3 = [
+  [0.4865709486482162, 0.26566769316909306, 0.19821728523436247],
+  [0.2289745640697488, 0.6917385218365064, 0.079286914093745],
+  [0.0, 0.04511338185890264, 1.043944368900976],
+];
+
+// Bradford chromatic adaptation. CSS lab()/lch() are specified at D50 while
+// sRGB lives at D65, so parsing adapts D50 → D65.
+const XYZ_D50_TO_D65: Matrix3 = [
+  [0.9554734527042182, -0.023098536874261423, 0.0632593086610217],
+  [-0.028369706963208136, 1.0099954580058226, 0.021041398966943008],
+  [0.012314001688319899, -0.020507696433477912, 1.3303659366080753],
+];
+
+const D50_WHITE: Vec3 = { x: 0.96422, y: 1.0, z: 0.82521 };
+
+function applyMatrix(m: Matrix3, v: Vec3): Vec3 {
+  return {
+    x: m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
+    y: m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
+    z: m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z,
+  };
+}
+
+function srgbToLinear(c: number): number {
+  const abs = Math.abs(c);
+  const sign = c < 0 ? -1 : 1;
+  return abs <= 0.04045 ? c / 12.92 : sign * Math.pow((abs + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgb(c: number): number {
+  const abs = Math.abs(c);
+  const sign = c < 0 ? -1 : 1;
+  return abs <= 0.0031308 ? c * 12.92 : sign * (1.055 * Math.pow(abs, 1 / 2.4) - 0.055);
+}
+
+// ---------------------------------------------------------------------------
+// OKLab
+// ---------------------------------------------------------------------------
+
+interface Oklab {
+  l: number;
+  a: number;
+  b: number;
+}
+
+function linearSrgbToOklab(r: number, g: number, b: number): Oklab {
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return {
+    l: 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s,
+    a: 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s,
+    b: 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s,
+  };
+}
+
+function oklabToLinearSrgb(L: number, a: number, b: number): { r: number; g: number; b: number } {
+  const l = Math.pow(L + 0.3963377774 * a + 0.2158037573 * b, 3);
+  const m = Math.pow(L - 0.1055613458 * a - 0.0638541728 * b, 3);
+  const s = Math.pow(L - 0.0894841775 * a - 1.2914855480 * b, 3);
+  return {
+    r: 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    g: -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    b: -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gamut mapping (CSS Color 4 §13.2: chroma reduction in OKLCH with local
+// clipping when the clipped candidate is within a just-noticeable difference)
+// ---------------------------------------------------------------------------
+
+const GAMUT_EPS = 0.000075;
+const JND = 0.02;
+
+function inGamut(rgb: { r: number; g: number; b: number }): boolean {
+  return (
+    rgb.r >= -GAMUT_EPS && rgb.r <= 1 + GAMUT_EPS &&
+    rgb.g >= -GAMUT_EPS && rgb.g <= 1 + GAMUT_EPS &&
+    rgb.b >= -GAMUT_EPS && rgb.b <= 1 + GAMUT_EPS
+  );
+}
+
+function clamp01(v: number): number {
+  return Math.min(1, Math.max(0, v));
+}
+
+function deltaEok(c1: Oklab, c2: Oklab): number {
+  return Math.sqrt((c1.l - c2.l) ** 2 + (c1.a - c2.a) ** 2 + (c1.b - c2.b) ** 2);
+}
+
+/** Map a (possibly out-of-gamut) linear sRGB triple into gamut, return 8-bit channels. */
+function gamutMapLinear(lin: { r: number; g: number; b: number }): { r: number; g: number; b: number } {
+  const encode = (rgb: { r: number; g: number; b: number }) => ({
+    r: Math.round(clamp01(linearToSrgb(rgb.r)) * 255),
+    g: Math.round(clamp01(linearToSrgb(rgb.g)) * 255),
+    b: Math.round(clamp01(linearToSrgb(rgb.b)) * 255),
+  });
+
+  if (inGamut(lin)) return encode(lin);
+
+  const ok = linearSrgbToOklab(lin.r, lin.g, lin.b);
+  if (ok.l >= 1) return { r: 255, g: 255, b: 255 };
+  if (ok.l <= 0) return { r: 0, g: 0, b: 0 };
+
+  const chroma = Math.sqrt(ok.a * ok.a + ok.b * ok.b);
+  const hueA = chroma === 0 ? 0 : ok.a / chroma;
+  const hueB = chroma === 0 ? 0 : ok.b / chroma;
+
+  const EPSILON = 0.0001;
+  let min = 0;
+  let max = chroma;
+  let minInGamut = true;
+  let current = lin;
+  while (max - min > EPSILON) {
+    const mid = (min + max) / 2;
+    current = oklabToLinearSrgb(ok.l, hueA * mid, hueB * mid);
+    if (minInGamut && inGamut(current)) {
+      min = mid;
+    } else {
+      const clipped = { r: clamp01(current.r), g: clamp01(current.g), b: clamp01(current.b) };
+      const clippedOk = linearSrgbToOklab(clipped.r, clipped.g, clipped.b);
+      const dE = deltaEok(clippedOk, { l: ok.l, a: hueA * mid, b: hueB * mid });
+      if (dE < JND) {
+        if (JND - dE < EPSILON) return encode(clipped);
+        minInGamut = false;
+        min = mid;
+      } else {
+        max = mid;
+      }
+    }
+  }
+  return encode({ r: clamp01(current.r), g: clamp01(current.g), b: clamp01(current.b) });
+}
+
+// ---------------------------------------------------------------------------
+// Component tokenization
+// ---------------------------------------------------------------------------
+
+const NUMBER_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+
+/** Parse a number or percentage token; percentRef is what 100% maps to. 'none' is 0. */
+function parseNumeric(token: string, percentRef: number): number | null {
+  if (token === 'none') return 0;
+  if (token.endsWith('%')) {
+    const v = token.slice(0, -1);
+    if (!NUMBER_RE.test(v)) return null;
+    return (parseFloat(v) / 100) * percentRef;
+  }
+  if (!NUMBER_RE.test(token)) return null;
+  return parseFloat(token);
+}
+
+/** Parse a hue token with optional angle unit, returned in degrees. 'none' is 0. */
+function parseHue(token: string): number | null {
+  if (token === 'none') return 0;
+  const m = token.match(/^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(deg|rad|grad|turn)?$/i);
+  if (!m) return null;
+  const v = parseFloat(m[1]);
+  switch ((m[2] || 'deg').toLowerCase()) {
+    case 'rad': return (v * 180) / Math.PI;
+    case 'grad': return v * 0.9;
+    case 'turn': return v * 360;
+    default: return v;
+  }
+}
+
+function parseAlpha(token: string | undefined): number | null {
+  if (token === undefined) return 1;
+  const v = parseNumeric(token, 1);
+  if (v === null) return null;
+  return clamp01(v);
+}
+
+interface FunctionArgs {
+  channels: string[];
+  alpha: string | undefined;
+}
+
+/**
+ * Split a color function body into channel tokens + optional alpha, accepting
+ * both the legacy comma grammar (alpha as 4th comma argument) and the modern
+ * space grammar (alpha after a slash).
+ */
+function splitArgs(body: string): FunctionArgs | null {
+  const trimmed = body.trim();
+  if (trimmed.includes(',')) {
+    const parts = trimmed.split(',').map((p) => p.trim());
+    if (parts.some((p) => p === '')) return null;
+    if (parts.length === 4) return { channels: parts.slice(0, 3), alpha: parts[3] };
+    if (parts.length === 3) return { channels: parts, alpha: undefined };
+    return null;
+  }
+  const slash = trimmed.split('/');
+  if (slash.length > 2) return null;
+  const channels = slash[0].trim().split(/\s+/);
+  const alpha = slash.length === 2 ? slash[1].trim() : undefined;
+  if (alpha === '') return null;
+  return { channels, alpha };
+}
+
+// ---------------------------------------------------------------------------
+// Per-notation parsers
+// ---------------------------------------------------------------------------
+
+function fromHex(input: string): RgbaColor | null {
+  const m = input.match(/^#([0-9a-f]{3,8})$/i);
+  if (!m) return null;
+  const h = m[1];
+  const dup = (c: string) => parseInt(c + c, 16);
+  if (h.length === 3) return { r: dup(h[0]), g: dup(h[1]), b: dup(h[2]), a: 1 };
+  if (h.length === 4) return { r: dup(h[0]), g: dup(h[1]), b: dup(h[2]), a: dup(h[3]) / 255 };
+  const pair = (i: number) => parseInt(h.slice(i, i + 2), 16);
+  if (h.length === 6) return { r: pair(0), g: pair(2), b: pair(4), a: 1 };
+  if (h.length === 8) return { r: pair(0), g: pair(2), b: pair(4), a: pair(6) / 255 };
+  return null;
+}
+
+function fromRgb(args: FunctionArgs): RgbaColor | null {
+  const channel = (t: string) => parseNumeric(t, 255);
+  const r = channel(args.channels[0]);
+  const g = channel(args.channels[1]);
+  const b = channel(args.channels[2]);
+  const a = parseAlpha(args.alpha);
+  if (r === null || g === null || b === null || a === null) return null;
+  const clamp255 = (v: number) => Math.min(255, Math.max(0, Math.round(v)));
+  return { r: clamp255(r), g: clamp255(g), b: clamp255(b), a };
+}
+
+function hslChannels(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const sat = clamp01(s);
+  const light = clamp01(l);
+  const hue = ((h % 360) + 360) % 360;
+  const c = (1 - Math.abs(2 * light - 1)) * sat;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = light - c / 2;
+  let rgb: [number, number, number];
+  if (hue < 60) rgb = [c, x, 0];
+  else if (hue < 120) rgb = [x, c, 0];
+  else if (hue < 180) rgb = [0, c, x];
+  else if (hue < 240) rgb = [0, x, c];
+  else if (hue < 300) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  return {
+    r: Math.round((rgb[0] + m) * 255),
+    g: Math.round((rgb[1] + m) * 255),
+    b: Math.round((rgb[2] + m) * 255),
+  };
+}
+
+function fromHsl(args: FunctionArgs): RgbaColor | null {
+  const h = parseHue(args.channels[0]);
+  const s = parseNumeric(args.channels[1], 1);
+  const l = parseNumeric(args.channels[2], 1);
+  const a = parseAlpha(args.alpha);
+  if (h === null || s === null || l === null || a === null) return null;
+  // Bare numbers for s/l are percentages in disguise (hsl(120 100 50) is valid
+  // modern syntax): a token without '%' still means 0-100.
+  const norm = (raw: string, v: number) => (raw.endsWith('%') || raw === 'none' ? v : v / 100);
+  return { ...hslChannels(h, norm(args.channels[1], s), norm(args.channels[2], l)), a };
+}
+
+function fromHwb(args: FunctionArgs): RgbaColor | null {
+  const h = parseHue(args.channels[0]);
+  const wRaw = parseNumeric(args.channels[1], 1);
+  const bRaw = parseNumeric(args.channels[2], 1);
+  const a = parseAlpha(args.alpha);
+  if (h === null || wRaw === null || bRaw === null || a === null) return null;
+  const norm = (raw: string, v: number) => (raw.endsWith('%') || raw === 'none' ? v : v / 100);
+  const w = clamp01(norm(args.channels[1], wRaw));
+  const blk = clamp01(norm(args.channels[2], bRaw));
+  if (w + blk >= 1) {
+    const gray = Math.round((w / (w + blk)) * 255);
+    return { r: gray, g: gray, b: gray, a };
+  }
+  const base = hslChannels(h, 1, 0.5);
+  const mix = (c: number) => Math.round(((c / 255) * (1 - w - blk) + w) * 255);
+  return { r: mix(base.r), g: mix(base.g), b: mix(base.b), a };
+}
+
+function fromOklab(args: FunctionArgs): RgbaColor | null {
+  const L = parseNumeric(args.channels[0], 1);
+  const aCh = parseNumeric(args.channels[1], 0.4);
+  const bCh = parseNumeric(args.channels[2], 0.4);
+  const alpha = parseAlpha(args.alpha);
+  if (L === null || aCh === null || bCh === null || alpha === null) return null;
+  const lin = oklabToLinearSrgb(clamp01(L), aCh, bCh);
+  return { ...gamutMapLinear(lin), a: alpha };
+}
+
+function fromOklch(args: FunctionArgs): RgbaColor | null {
+  const L = parseNumeric(args.channels[0], 1);
+  const C = parseNumeric(args.channels[1], 0.4);
+  const H = parseHue(args.channels[2]);
+  const alpha = parseAlpha(args.alpha);
+  if (L === null || C === null || H === null || alpha === null) return null;
+  const hRad = (H * Math.PI) / 180;
+  const lin = oklabToLinearSrgb(clamp01(L), Math.max(0, C) * Math.cos(hRad), Math.max(0, C) * Math.sin(hRad));
+  return { ...gamutMapLinear(lin), a: alpha };
+}
+
+function labD50ToLinearSrgb(l: number, a: number, b: number): { r: number; g: number; b: number } {
+  const fy = (l + 16) / 116;
+  const fx = fy + a / 500;
+  const fz = fy - b / 200;
+  const finv = (t: number) => {
+    const t3 = t * t * t;
+    return t3 > 0.008856 ? t3 : (116 * t - 16) / 903.3;
+  };
+  const xyzD50: Vec3 = {
+    x: finv(fx) * D50_WHITE.x,
+    y: finv(fy) * D50_WHITE.y,
+    z: finv(fz) * D50_WHITE.z,
+  };
+  const xyzD65 = applyMatrix(XYZ_D50_TO_D65, xyzD50);
+  const lin = applyMatrix(XYZ_D65_TO_LINEAR_SRGB, xyzD65);
+  return { r: lin.x, g: lin.y, b: lin.z };
+}
+
+function fromLab(args: FunctionArgs): RgbaColor | null {
+  const L = parseNumeric(args.channels[0], 100);
+  const aCh = parseNumeric(args.channels[1], 125);
+  const bCh = parseNumeric(args.channels[2], 125);
+  const alpha = parseAlpha(args.alpha);
+  if (L === null || aCh === null || bCh === null || alpha === null) return null;
+  const lin = labD50ToLinearSrgb(Math.min(100, Math.max(0, L)), aCh, bCh);
+  return { ...gamutMapLinear(lin), a: alpha };
+}
+
+function fromLch(args: FunctionArgs): RgbaColor | null {
+  const L = parseNumeric(args.channels[0], 100);
+  const C = parseNumeric(args.channels[1], 150);
+  const H = parseHue(args.channels[2]);
+  const alpha = parseAlpha(args.alpha);
+  if (L === null || C === null || H === null || alpha === null) return null;
+  const hRad = (H * Math.PI) / 180;
+  const lin = labD50ToLinearSrgb(
+    Math.min(100, Math.max(0, L)),
+    Math.max(0, C) * Math.cos(hRad),
+    Math.max(0, C) * Math.sin(hRad)
+  );
+  return { ...gamutMapLinear(lin), a: alpha };
+}
+
+function fromColorFunction(args: FunctionArgs): RgbaColor | null {
+  const [space, ...rest] = args.channels;
+  if (!space || rest.length !== 3) return null;
+  const c1 = parseNumeric(rest[0], 1);
+  const c2 = parseNumeric(rest[1], 1);
+  const c3 = parseNumeric(rest[2], 1);
+  const alpha = parseAlpha(args.alpha);
+  if (c1 === null || c2 === null || c3 === null || alpha === null) return null;
+
+  let lin: { r: number; g: number; b: number };
+  switch (space) {
+    case 'srgb':
+      lin = { r: srgbToLinear(c1), g: srgbToLinear(c2), b: srgbToLinear(c3) };
+      break;
+    case 'srgb-linear':
+      lin = { r: c1, g: c2, b: c3 };
+      break;
+    case 'display-p3': {
+      const p3: Vec3 = { x: srgbToLinear(c1), y: srgbToLinear(c2), z: srgbToLinear(c3) };
+      const xyz = applyMatrix(LINEAR_P3_TO_XYZ_D65, p3);
+      const s = applyMatrix(XYZ_D65_TO_LINEAR_SRGB, xyz);
+      lin = { r: s.x, g: s.y, b: s.z };
+      break;
+    }
+    case 'xyz':
+    case 'xyz-d65': {
+      const s = applyMatrix(XYZ_D65_TO_LINEAR_SRGB, { x: c1, y: c2, z: c3 });
+      lin = { r: s.x, g: s.y, b: s.z };
+      break;
+    }
+    case 'xyz-d50': {
+      const d65 = applyMatrix(XYZ_D50_TO_D65, { x: c1, y: c2, z: c3 });
+      const s = applyMatrix(XYZ_D65_TO_LINEAR_SRGB, d65);
+      lin = { r: s.x, g: s.y, b: s.z };
+      break;
+    }
+    default:
+      return null;
+  }
+  return { ...gamutMapLinear(lin), a: alpha };
+}
+
+// ---------------------------------------------------------------------------
+// Named colors (CSS Color 4 §6.1, full table + transparent)
+// ---------------------------------------------------------------------------
+
+const NAMED_COLORS: Record<string, string> = {
+  aliceblue: 'f0f8ff', antiquewhite: 'faebd7', aqua: '00ffff', aquamarine: '7fffd4',
+  azure: 'f0ffff', beige: 'f5f5dc', bisque: 'ffe4c4', black: '000000',
+  blanchedalmond: 'ffebcd', blue: '0000ff', blueviolet: '8a2be2', brown: 'a52a2a',
+  burlywood: 'deb887', cadetblue: '5f9ea0', chartreuse: '7fff00', chocolate: 'd2691e',
+  coral: 'ff7f50', cornflowerblue: '6495ed', cornsilk: 'fff8dc', crimson: 'dc143c',
+  cyan: '00ffff', darkblue: '00008b', darkcyan: '008b8b', darkgoldenrod: 'b8860b',
+  darkgray: 'a9a9a9', darkgreen: '006400', darkgrey: 'a9a9a9', darkkhaki: 'bdb76b',
+  darkmagenta: '8b008b', darkolivegreen: '556b2f', darkorange: 'ff8c00', darkorchid: '9932cc',
+  darkred: '8b0000', darksalmon: 'e9967a', darkseagreen: '8fbc8f', darkslateblue: '483d8b',
+  darkslategray: '2f4f4f', darkslategrey: '2f4f4f', darkturquoise: '00ced1', darkviolet: '9400d3',
+  deeppink: 'ff1493', deepskyblue: '00bfff', dimgray: '696969', dimgrey: '696969',
+  dodgerblue: '1e90ff', firebrick: 'b22222', floralwhite: 'fffaf0', forestgreen: '228b22',
+  fuchsia: 'ff00ff', gainsboro: 'dcdcdc', ghostwhite: 'f8f8ff', gold: 'ffd700',
+  goldenrod: 'daa520', gray: '808080', green: '008000', greenyellow: 'adff2f',
+  grey: '808080', honeydew: 'f0fff0', hotpink: 'ff69b4', indianred: 'cd5c5c',
+  indigo: '4b0082', ivory: 'fffff0', khaki: 'f0e68c', lavender: 'e6e6fa',
+  lavenderblush: 'fff0f5', lawngreen: '7cfc00', lemonchiffon: 'fffacd', lightblue: 'add8e6',
+  lightcoral: 'f08080', lightcyan: 'e0ffff', lightgoldenrodyellow: 'fafad2', lightgray: 'd3d3d3',
+  lightgreen: '90ee90', lightgrey: 'd3d3d3', lightpink: 'ffb6c1', lightsalmon: 'ffa07a',
+  lightseagreen: '20b2aa', lightskyblue: '87cefa', lightslategray: '778899', lightslategrey: '778899',
+  lightsteelblue: 'b0c4de', lightyellow: 'ffffe0', lime: '00ff00', limegreen: '32cd32',
+  linen: 'faf0e6', magenta: 'ff00ff', maroon: '800000', mediumaquamarine: '66cdaa',
+  mediumblue: '0000cd', mediumorchid: 'ba55d3', mediumpurple: '9370db', mediumseagreen: '3cb371',
+  mediumslateblue: '7b68ee', mediumspringgreen: '00fa9a', mediumturquoise: '48d1cc', mediumvioletred: 'c71585',
+  midnightblue: '191970', mintcream: 'f5fffa', mistyrose: 'ffe4e1', moccasin: 'ffe4b5',
+  navajowhite: 'ffdead', navy: '000080', oldlace: 'fdf5e6', olive: '808000',
+  olivedrab: '6b8e23', orange: 'ffa500', orangered: 'ff4500', orchid: 'da70d6',
+  palegoldenrod: 'eee8aa', palegreen: '98fb98', paleturquoise: 'afeeee', palevioletred: 'db7093',
+  papayawhip: 'ffefd5', peachpuff: 'ffdab9', peru: 'cd853f', pink: 'ffc0cb',
+  plum: 'dda0dd', powderblue: 'b0e0e6', purple: '800080', rebeccapurple: '663399',
+  red: 'ff0000', rosybrown: 'bc8f8f', royalblue: '4169e1', saddlebrown: '8b4513',
+  salmon: 'fa8072', sandybrown: 'f4a460', seagreen: '2e8b57', seashell: 'fff5ee',
+  sienna: 'a0522d', silver: 'c0c0c0', skyblue: '87ceeb', slateblue: '6a5acd',
+  slategray: '708090', slategrey: '708090', snow: 'fffafa', springgreen: '00ff7f',
+  steelblue: '4682b4', tan: 'd2b48c', teal: '008080', thistle: 'd8bfd8',
+  tomato: 'ff6347', turquoise: '40e0d0', violet: 'ee82ee', wheat: 'f5deb3',
+  white: 'ffffff', whitesmoke: 'f5f5f5', yellow: 'ffff00', yellowgreen: '9acd32',
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse any CSS color string to sRGB 8-bit channels + float alpha.
+ * Returns null for anything that is not an absolute color (currentcolor,
+ * inherit, var() references, malformed input).
+ */
+export function parseCssColor(input: string): RgbaColor | null {
+  if (typeof input !== 'string') return null;
+  const str = input.trim();
+  if (str === '') return null;
+
+  if (str.startsWith('#')) return fromHex(str);
+
+  const lower = str.toLowerCase();
+  if (lower === 'transparent') return { r: 0, g: 0, b: 0, a: 0 };
+  const named = NAMED_COLORS[lower];
+  if (named) return fromHex(`#${named}`);
+
+  const fn = lower.match(/^([a-z-]+)\(\s*([^)]*)\s*\)$/);
+  if (!fn) return null;
+  const args = splitArgs(fn[2]);
+  if (!args || args.channels.length < 3) return null;
+
+  switch (fn[1]) {
+    case 'rgb':
+    case 'rgba':
+      return args.channels.length === 3 ? fromRgb(args) : null;
+    case 'hsl':
+    case 'hsla':
+      return args.channels.length === 3 ? fromHsl(args) : null;
+    case 'hwb':
+      return args.channels.length === 3 ? fromHwb(args) : null;
+    case 'oklab':
+      return args.channels.length === 3 ? fromOklab(args) : null;
+    case 'oklch':
+      return args.channels.length === 3 ? fromOklch(args) : null;
+    case 'lab':
+      return args.channels.length === 3 ? fromLab(args) : null;
+    case 'lch':
+      return args.channels.length === 3 ? fromLch(args) : null;
+    case 'color':
+      return fromColorFunction(args);
+    default:
+      return null;
+  }
+}
+
+/** #rrggbb for opaque colors, #rrggbbaa when alpha < 1. */
+export function serializeHex(c: RgbaColor): string {
+  const pair = (v: number) => Math.round(v).toString(16).padStart(2, '0');
+  const base = `#${pair(c.r)}${pair(c.g)}${pair(c.b)}`;
+  if (c.a >= 1) return base;
+  return `${base}${pair(clamp01(c.a) * 255)}`;
+}
+
+/** Legacy rgb()/rgba() serialisation, the canonical interchange form in the extractor. */
+export function serializeRgb(c: RgbaColor): string {
+  if (c.a >= 1) return `rgb(${c.r}, ${c.g}, ${c.b})`;
+  const alpha = Math.round(clamp01(c.a) * 10000) / 10000;
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${alpha})`;
+}

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -2,7 +2,10 @@
  * Color Conversion Utilities
  *
  * Converts colors between RGB, LCH, and OKLCH color spaces.
+ * Parsing of arbitrary CSS color strings lives in color-parse.ts.
  */
+
+import { parseCssColor } from './color-parse.js';
 
 /**
  * Convert sRGB to linear RGB
@@ -24,19 +27,15 @@ function linearRgbToXyz(r, g, b) {
 }
 
 /**
- * Convert XYZ to Lab (D65 reference white)
+ * Convert XYZ to Lab against a reference white. Defaults to D65, which is what
+ * the perceptual-distance helpers below use; CSS lch() emission passes D50.
  */
-function xyzToLab(x, y, z) {
-  // D65 reference white
-  const xn = 0.95047;
-  const yn = 1.00000;
-  const zn = 1.08883;
-
+function xyzToLab(x, y, z, white = { x: 0.95047, y: 1.00000, z: 1.08883 }) {
   const f = (t) => t > 0.008856 ? Math.cbrt(t) : (903.3 * t + 16) / 116;
 
-  const fx = f(x / xn);
-  const fy = f(y / yn);
-  const fz = f(z / zn);
+  const fx = f(x / white.x);
+  const fy = f(y / white.y);
+  const fz = f(z / white.z);
 
   return {
     l: 116 * fy - 16,
@@ -44,6 +43,16 @@ function xyzToLab(x, y, z) {
     b: 200 * (fy - fz)
   };
 }
+
+// Bradford adaptation D65 → D50. CSS lab()/lch() are specified at D50 while
+// sRGB lives at D65, so emitted lch() strings must adapt or they are ~ΔE 1 off
+// (GitHub #149).
+const D50_WHITE = { x: 0.96422, y: 1.00000, z: 0.82521 };
+const XYZ_D65_TO_D50 = [
+  [1.0479298208405488, 0.022946793341019088, -0.05019222954313557],
+  [0.029627815688159344, 0.990434484573249, -0.01707382502938514],
+  [-0.009243058152591178, 0.015055144896577895, 0.7518742899580008],
+];
 
 /**
  * Convert Lab to LCH
@@ -72,8 +81,14 @@ export function rgbToLch(r, g, b) {
   const lg = srgbToLinear(g);
   const lb = srgbToLinear(b);
 
-  const xyz = linearRgbToXyz(lr, lg, lb);
-  const lab = xyzToLab(xyz.x, xyz.y, xyz.z);
+  const d65 = linearRgbToXyz(lr, lg, lb);
+  const m = XYZ_D65_TO_D50;
+  const xyz = {
+    x: m[0][0] * d65.x + m[0][1] * d65.y + m[0][2] * d65.z,
+    y: m[1][0] * d65.x + m[1][1] * d65.y + m[1][2] * d65.z,
+    z: m[2][0] * d65.x + m[2][1] * d65.y + m[2][2] * d65.z,
+  };
+  const lab = xyzToLab(xyz.x, xyz.y, xyz.z, D50_WHITE);
   return labToLch(lab.l, lab.a, lab.b);
 }
 
@@ -370,45 +385,12 @@ export function computeWcag(palette) {
  * @returns {{ hex: string, rgb: string, lch: string, oklch: string, hasAlpha: boolean } | null}
  */
 export function convertColor(colorString) {
-  let r, g, b, a;
-
-  // Parse rgba/rgb
-  const rgbaMatch = colorString.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
-  if (rgbaMatch) {
-    r = parseInt(rgbaMatch[1]);
-    g = parseInt(rgbaMatch[2]);
-    b = parseInt(rgbaMatch[3]);
-    a = rgbaMatch[4] ? parseFloat(rgbaMatch[4]) : undefined;
-  } else if (/^hsla?\(/.test(colorString)) {
-    // Parse hsl/hsla
-    const hslMatch = colorString.match(/hsla?\(([\d.]+),\s*([\d.]+)%?,\s*([\d.]+)%?(?:,\s*([\d.]+))?\)/);
-    if (!hslMatch) return null;
-    const h = parseFloat(hslMatch[1]) / 360;
-    const s = parseFloat(hslMatch[2]) / 100;
-    const l = parseFloat(hslMatch[3]) / 100;
-    a = hslMatch[4] ? parseFloat(hslMatch[4]) : undefined;
-    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-    const p = 2 * l - q;
-    const hue2rgb = (p, q, t) => {
-      if (t < 0) t += 1;
-      if (t > 1) t -= 1;
-      if (t < 1/6) return p + (q - p) * 6 * t;
-      if (t < 1/2) return q;
-      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
-      return p;
-    };
-    r = Math.round(hue2rgb(p, q, h + 1/3) * 255);
-    g = Math.round(hue2rgb(p, q, h) * 255);
-    b = Math.round(hue2rgb(p, q, h - 1/3) * 255);
-  } else {
-    // Try hex
-    const rgb = hexToRgb(colorString);
-    if (!rgb) return null;
-    r = rgb.r;
-    g = rgb.g;
-    b = rgb.b;
-    a = rgb.a;
-  }
+  // Spec-complete parsing (hex, named, rgb/hsl legacy+modern, hwb, lab/lch,
+  // oklab/oklch, color()) with CSS Color 4 gamut mapping.
+  const parsed = parseCssColor(String(colorString));
+  if (!parsed) return null;
+  const { r, g, b } = parsed;
+  const a = parsed.a < 1 ? parsed.a : undefined;
 
   const hex = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
   const rgbStr = a !== undefined ? `rgba(${r}, ${g}, ${b}, ${a})` : `rgb(${r}, ${g}, ${b})`;

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -6,7 +6,54 @@ export async function extractColors(page) {
     _canvas.width = _canvas.height = 1;
     const _ctx = _canvas.getContext('2d');
     const _colorMemo = new Map();
+
+    // Chromium serialises computed styles that pass through modern colour
+    // functions (Tailwind v4 opacity modifiers compile to color-mix in oklab)
+    // as oklab()/oklch()/color() strings. Rewrite them to legacy rgb()/rgba()
+    // once, at the read boundary, so every downstream consumer sees one
+    // grammar and alpha survives (GitHub #149). The alpha is parsed textually
+    // and the opaque remainder resolved through canvas, because getImageData
+    // on a semi-transparent fill round-trips through premultiplication and
+    // corrupts the channels.
+    const _modernColorRe = /^(?:oklab|oklch|lab|lch|hwb|color)\(/i;
+    const _legacyMemo = new Map();
+    function toLegacy(color) {
+      if (!color || typeof color !== 'string') return color;
+      const str = color.trim();
+      if (!_modernColorRe.test(str)) return color;
+      if (_legacyMemo.has(str)) return _legacyMemo.get(str);
+      let result = color;
+      if (_ctx) {
+        let alpha = 1;
+        let opaque = str;
+        const am = str.match(/\/\s*([\d.]+%?)\s*\)$/);
+        if (am) {
+          alpha = am[1].endsWith('%') ? parseFloat(am[1]) / 100 : parseFloat(am[1]);
+          opaque = str.slice(0, str.lastIndexOf('/')).trimEnd() + ')';
+        }
+        try {
+          // Sentinel detects parse failure: an invalid assignment leaves
+          // fillStyle untouched.
+          _ctx.fillStyle = '#010203';
+          _ctx.fillStyle = opaque;
+          if (_ctx.fillStyle !== '#010203') {
+            _ctx.clearRect(0, 0, 1, 1);
+            _ctx.fillRect(0, 0, 1, 1);
+            const [r, g, b] = _ctx.getImageData(0, 0, 1, 1).data;
+            result = alpha >= 1
+              ? `rgb(${r}, ${g}, ${b})`
+              : `rgba(${r}, ${g}, ${b}, ${Math.round(alpha * 1000) / 1000})`;
+          }
+        } catch (e) {
+          result = color;
+        }
+      }
+      _legacyMemo.set(str, result);
+      return result;
+    }
+
     function normalizeColor(color) {
+      color = toLegacy(color);
       if (_colorMemo.has(color)) return _colorMemo.get(color);
       let result;
       const rgbaMatch = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
@@ -101,7 +148,9 @@ export async function extractColors(page) {
       if (value.includes("calc(") || value.includes("clamp(") || value.includes("var(")) {
         return /#[0-9a-f]{3,6}|rgba?\(|hsla?\(/i.test(value);
       }
-      if (/^(oklab|oklch|lch|lab|color)\s*\(/i.test(value)) return false;
+      // Modern colour functions are valid iff they resolve; toLegacy returns
+      // the input unchanged when parsing fails.
+      if (_modernColorRe.test(value.trim())) return toLegacy(value) !== value;
       return /^(#[0-9a-f]{3,8}|rgba?\(|hsla?\(|[a-z]+)/i.test(value);
     }
 
@@ -154,7 +203,7 @@ export async function extractColors(page) {
       if (/^--(?:tw-)?colors?-(?:transparent|current|black|white|inherit)$/.test(prop)) continue;
 
       const value = styles.getPropertyValue(prop).trim();
-      if (!value.match(/^(#|rgb|hsl|var\(--.*color|color\()/i)) continue;
+      if (!value.match(/^(#|rgb|hsl|hwb|var\(--.*color|color\(|oklab\(|oklch\(|lab\(|lch\()/i)) continue;
       if (
         value.includes("color.adjust(") || value.includes("rgba(0, 0, 0, 0)") ||
         value.includes("rgba(0,0,0,0)") || value.includes("lighten(") ||
@@ -211,9 +260,9 @@ export async function extractColors(page) {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0) return;
 
-      const bgColor = computed.backgroundColor;
-      const textColor = computed.color;
-      const borderColor = computed.borderColor;
+      const bgColor = toLegacy(computed.backgroundColor);
+      const textColor = toLegacy(computed.color);
+      const borderColor = toLegacy(computed.borderColor);
 
       const context = (
         el.className + " " + el.id + " " +
@@ -275,12 +324,15 @@ export async function extractColors(page) {
 
       function extractColorsFromValue(colorValue) {
         if (!colorValue) return [];
-        const colorRegex = /(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+)/gi;
-        const matches = colorValue.match(colorRegex) || [];
-        const cssColorFunctions = new Set(['oklab','oklch','lch','lab','color','display','hsl','rgb','rgba','hsla','inherit','initial','unset','none','auto','normal']);
+        // Functional notations are matched whole (so color(srgb ...) cannot
+        // leak a bare `srgb` token) and rewritten to legacy form; anything
+        // that fails to resolve is dropped by the modern-form filter below.
+        const colorRegex = /((?:oklab|oklch|lab|lch|hwb|color)\([^)]+\)|#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+)/gi;
+        const matches = (colorValue.match(colorRegex) || []).map(toLegacy);
+        const cssColorFunctions = new Set(['oklab','oklch','lch','lab','color','display','hsl','rgb','rgba','hsla','hwb','srgb','inherit','initial','unset','none','auto','normal']);
         return matches.filter(c =>
           c !== 'transparent' && c !== 'rgba(0, 0, 0, 0)' && c !== 'rgba(0,0,0,0)' &&
-          c.length > 2 && !cssColorFunctions.has(c.toLowerCase())
+          c.length > 2 && !cssColorFunctions.has(c.toLowerCase()) && !_modernColorRe.test(c)
         );
       }
 
@@ -294,6 +346,9 @@ export async function extractColors(page) {
         if (color && color !== "rgba(0, 0, 0, 0)" && color !== "transparent" && colorAlpha(color) >= 0.3) {
           const normalized = normalizeColor(color);
           const existing = colorMap.get(normalized) || { original: color, count: 0, bgCount: 0, score: 0, sources: new Set(), statusCount: 0, nonStatusCount: 0, isToken: tokenHexes.has(normalized) };
+          // The opaque form represents the token; alpha variants of the same
+          // normalized colour are usage, not identity.
+          if (colorAlpha(color) > colorAlpha(existing.original)) existing.original = color;
           existing.count++;
           if (isStatus) existing.statusCount++; else existing.nonStatusCount++;
           if (extractColorsFromValue(bgColor).includes(color)) existing.bgCount++;
@@ -325,7 +380,7 @@ export async function extractColors(page) {
     if (surfaceEl) {
       let bgNode: Element | null = surfaceEl;
       for (let hop = 0; hop < 5 && bgNode; hop++) {
-        const bg = getComputedStyle(bgNode).backgroundColor;
+        const bg = toLegacy(getComputedStyle(bgNode).backgroundColor);
         if (bg && colorAlpha(bg) >= 0.9) { semanticColors.background = bg; break; }
         bgNode = bgNode.parentElement;
       }
@@ -333,7 +388,7 @@ export async function extractColors(page) {
       // user actually sees. Dark sites always set an explicit dark background, so
       // an unset chain means the rendered backdrop is white.
       if (!semanticColors.background) semanticColors.background = 'rgb(255, 255, 255)';
-      const txt = getComputedStyle(surfaceEl).color;
+      const txt = toLegacy(getComputedStyle(surfaceEl).color);
       if (txt && colorAlpha(txt) >= 0.5) semanticColors.text = txt;
     }
 

--- a/test/color-parse.test.ts
+++ b/test/color-parse.test.ts
@@ -258,3 +258,31 @@ test('hex is case-insensitive and exact-length only', () => {
   assert.equal(parseCssColor('#aabbccddee'), null);
   assert.equal(parseCssColor('aabbcc'), null);
 });
+
+// --- Hex notation, W3C CSS Color 4 §5.2 verbatim examples ---
+
+test('hex spec §5.2: worked examples from the spec text', () => {
+  // "#00ff00 represents the same color as rgb(0 255 0)"
+  assert.deepEqual(parseCssColor('#00ff00'), parseCssColor('rgb(0 255 0)'));
+  // "#00ff00 is identical to #00FF00"
+  assert.deepEqual(parseCssColor('#00ff00'), parseCssColor('#00FF00'));
+  // "#0000ffcc represents the same color as rgb(0 0 100% / 80%)"
+  const cc = parseCssColor('#0000ffcc');
+  assert.equal(cc?.b, 255);
+  assert.ok(Math.abs((cc?.a ?? 0) - 0.8) < 0.002);
+  // "#123 specifies the same color as #112233"
+  assert.deepEqual(parseCssColor('#123'), parseCssColor('#112233'));
+  // 4-digit expands like 3-digit, fourth digit is alpha
+  assert.deepEqual(parseCssColor('#123f'), parseCssColor('#112233'));
+  const half = parseCssColor('#1238');
+  assert.ok(Math.abs((half?.a ?? 0) - 136 / 255) < 1e-9);
+});
+
+test('hex spec §5.2: only 3, 4, 6, 8 digit lengths are valid', () => {
+  for (const bad of ['#', '#f', '#ff', '#fffff', '#fffffff', '#fffffffff', '# fff', '#ff f']) {
+    assert.equal(parseCssColor(bad), null, bad);
+  }
+  for (const good of ['#fff', '#ffff', '#ffffff', '#ffffffff']) {
+    assert.ok(parseCssColor(good), good);
+  }
+});

--- a/test/color-parse.test.ts
+++ b/test/color-parse.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { parseCssColor, serializeHex, serializeRgb } from '../lib/color-parse.js';
+
+function hex(input: string): string | null {
+  const c = parseCssColor(input);
+  return c ? serializeHex({ ...c, a: 1 }) : null;
+}
+
+function alphaOf(input: string): number | null {
+  const c = parseCssColor(input);
+  return c ? c.a : null;
+}
+
+// Channel tolerance for float → 8-bit rounding across conversion paths.
+function assertHexClose(actual: string | null, expected: string, tolerance = 1) {
+  assert.ok(actual, `expected ${expected}, got null`);
+  const pairs = [1, 3, 5].map(i => [
+    parseInt((actual as string).slice(i, i + 2), 16),
+    parseInt(expected.slice(i, i + 2), 16),
+  ]);
+  for (const [a, e] of pairs) {
+    assert.ok(Math.abs(a - e) <= tolerance, `expected ${expected}, got ${actual}`);
+  }
+}
+
+// --- Named colors and keywords (CSS Color 4 §6) ---
+
+test('named colors resolve to their spec hex', () => {
+  assert.equal(hex('rebeccapurple'), '#663399');
+  assert.equal(hex('aliceblue'), '#f0f8ff');
+  assert.equal(hex('RED'), '#ff0000');
+  assert.equal(hex('white'), '#ffffff');
+});
+
+test('transparent is black with zero alpha', () => {
+  const c = parseCssColor('transparent');
+  assert.deepEqual(c, { r: 0, g: 0, b: 0, a: 0 });
+});
+
+test('non-color keywords and garbage return null', () => {
+  assert.equal(parseCssColor('currentcolor'), null);
+  assert.equal(parseCssColor('inherit'), null);
+  assert.equal(parseCssColor('none'), null);
+  assert.equal(parseCssColor('auto'), null);
+  assert.equal(parseCssColor(''), null);
+  assert.equal(parseCssColor('notacolor'), null);
+  assert.equal(parseCssColor('srgb'), null);
+});
+
+// --- Hex notation (3, 4, 6, 8 digit) ---
+
+test('hex notations across all four lengths', () => {
+  assert.deepEqual(parseCssColor('#abc'), { r: 170, g: 187, b: 204, a: 1 });
+  assert.deepEqual(parseCssColor('#aabbcc'), { r: 170, g: 187, b: 204, a: 1 });
+  const four = parseCssColor('#abcd');
+  assert.equal(four?.r, 170);
+  assert.ok(Math.abs((four?.a ?? 0) - 221 / 255) < 1e-9);
+  const eight = parseCssColor('#aabbccdd');
+  assert.ok(Math.abs((eight?.a ?? 0) - 221 / 255) < 1e-9);
+});
+
+test('malformed hex returns null', () => {
+  assert.equal(parseCssColor('#ab'), null);
+  assert.equal(parseCssColor('#abcde'), null);
+  assert.equal(parseCssColor('#gggggg'), null);
+});
+
+// --- rgb()/rgba(): legacy comma and modern space syntax ---
+
+test('legacy rgb()/rgba() with commas', () => {
+  assert.deepEqual(parseCssColor('rgb(255, 0, 0)'), { r: 255, g: 0, b: 0, a: 1 });
+  assert.equal(alphaOf('rgba(255, 0, 0, 0.5)'), 0.5);
+  assert.equal(hex('rgb(100%, 0%, 0%)'), '#ff0000');
+});
+
+test('modern rgb() space syntax with slash alpha', () => {
+  assert.deepEqual(parseCssColor('rgb(255 0 0)'), { r: 255, g: 0, b: 0, a: 1 });
+  assert.equal(alphaOf('rgb(255 0 0 / 0.5)'), 0.5);
+  assert.equal(alphaOf('rgb(255 0 0 / 50%)'), 0.5);
+  assert.equal(hex('rgb(50% 50% 50%)'), '#808080');
+});
+
+test('rgb() clamps out-of-range channels and maps none to 0', () => {
+  assert.equal(hex('rgb(300 -20 0)'), '#ff0000');
+  assert.equal(hex('rgb(none 128 none)'), '#008000');
+  assert.equal(alphaOf('rgb(0 0 0 / 1.5)'), 1);
+});
+
+// --- hsl()/hsla() ---
+
+test('hsl() legacy and modern forms', () => {
+  assert.equal(hex('hsl(0, 100%, 50%)'), '#ff0000');
+  assert.equal(hex('hsl(120 100% 25%)'), '#008000');
+  assert.equal(alphaOf('hsla(0, 100%, 50%, 0.3)'), 0.3);
+  assert.equal(alphaOf('hsl(0 100% 50% / 30%)'), 0.3);
+});
+
+test('hsl() hue angle units and wrapping', () => {
+  assert.equal(hex('hsl(120deg 100% 25%)'), '#008000');
+  assert.equal(hex('hsl(0.3333333turn 100% 25%)'), '#008000');
+  assert.equal(hex('hsl(133.3333grad 100% 25%)'), '#008000');
+  assertHexClose(hex('hsl(2.0944rad 100% 25%)'), '#008000');
+  assert.equal(hex('hsl(480 100% 25%)'), '#008000');
+  assert.equal(hex('hsl(-240 100% 25%)'), '#008000');
+});
+
+// --- hwb() ---
+
+test('hwb() basics', () => {
+  assert.equal(hex('hwb(0 0% 0%)'), '#ff0000');
+  assert.equal(hex('hwb(120 0% 0%)'), '#00ff00');
+  assert.equal(hex('hwb(0 100% 0%)'), '#ffffff');
+  assert.equal(hex('hwb(0 0% 100%)'), '#000000');
+  assert.equal(alphaOf('hwb(0 0% 0% / 0.4)'), 0.4);
+});
+
+test('hwb() normalises whiteness + blackness over 100% to gray', () => {
+  // w=b scaled: gray at w/(w+b) lightness
+  assert.equal(hex('hwb(90 100% 100%)'), '#808080');
+});
+
+// --- oklab()/oklch() ---
+
+test('oklab() from GitHub issue #149 resolves to verified hex', () => {
+  assertHexClose(hex('oklab(0.363344 -0.0549272 0.0203635 / 0.3)'), '#1f4733');
+  assert.equal(alphaOf('oklab(0.363344 -0.0549272 0.0203635 / 0.3)'), 0.3);
+  assertHexClose(hex('oklab(0.999994 0.0000455678 0.0000200868 / 0.8)'), '#ffffff');
+});
+
+test('oklab()/oklch() extremes and percentage lightness', () => {
+  assert.equal(hex('oklab(1 0 0)'), '#ffffff');
+  assert.equal(hex('oklab(0 0 0)'), '#000000');
+  assert.equal(hex('oklab(100% 0 0)'), '#ffffff');
+  assert.equal(hex('oklch(1 0 0)'), '#ffffff');
+  assert.equal(hex('oklch(0 0 none)'), '#000000');
+});
+
+test('oklch() of pure sRGB red round-trips', () => {
+  assertHexClose(hex('oklch(0.627955 0.257683 29.2339)'), '#ff0000');
+});
+
+test('oklch() marginally out-of-gamut returns the local-MINDE clip', () => {
+  // CSS Color 4 §14.2.1: clip(origin) is returned when deltaEOK < JND (0.02).
+  // Here R=1.003 linear, deltaEOK ~0.002, so the spec answer is the clip
+  // #ffd230. Issue #149 expected #ffd237 (chroma reduction without local
+  // MINDE); the two are within a just-noticeable difference by construction.
+  assert.equal(hex('oklch(0.879 0.169 91.605)'), '#ffd230');
+});
+
+test('grossly out-of-gamut engages chroma reduction, not naive clip', () => {
+  // P3 green in linear sRGB is (-0.51, 1.04, -0.31); naive clip gives #00ff00.
+  // The clip is perceptually far from the origin (deltaEOK >> JND), so the
+  // binary search must produce a different, in-gamut green.
+  const mapped = hex('color(display-p3 0 1 0)');
+  assert.ok(mapped);
+  assert.notEqual(mapped, '#00ff00');
+  const c = parseCssColor('color(display-p3 0 1 0)');
+  assert.ok((c?.g ?? 0) > 200);
+  assert.ok((c?.r ?? 255) < 130);
+  assert.ok((c?.b ?? 255) < 130);
+});
+
+// --- lab()/lch() at D50 ---
+
+test('lch() parses at D50 (issue #149 reference pair)', () => {
+  // #1f242e at D50 is lch(14.03% 7.44 268.93); the D65 value 14.12%/7.37/275.12
+  // must NOT round-trip to the same hex.
+  assertHexClose(hex('lch(14.03% 7.44 268.93)'), '#1f242e');
+});
+
+test('lab() extremes', () => {
+  assert.equal(hex('lab(100 0 0)'), '#ffffff');
+  assert.equal(hex('lab(0 0 0)'), '#000000');
+  assert.equal(alphaOf('lab(50 20 -30 / 25%)'), 0.25);
+});
+
+// --- color() function ---
+
+test('color(srgb) from issue #149', () => {
+  assert.equal(hex('color(srgb 0.072 0.168 0.12)'), '#122b1f');
+});
+
+test('color() across supported spaces', () => {
+  assert.equal(hex('color(srgb 1 0 0)'), '#ff0000');
+  assert.equal(hex('color(srgb-linear 1 0 0)'), '#ff0000');
+  assert.equal(hex('color(srgb-linear 0.2158605 0.2158605 0.2158605)'), '#808080');
+  assert.equal(hex('color(display-p3 0 0 0)'), '#000000');
+  assert.equal(hex('color(display-p3 1 1 1)'), '#ffffff');
+  assertHexClose(hex('color(display-p3 0.5 0.5 0.5)'), '#808080');
+  assertHexClose(hex('color(xyz 0.4124564 0.2126729 0.0193339)'), '#ff0000');
+  assertHexClose(hex('color(xyz-d65 0.4124564 0.2126729 0.0193339)'), '#ff0000');
+  assert.equal(alphaOf('color(srgb 0 0 0 / 0.6)'), 0.6);
+});
+
+test('color() with out-of-gamut p3 red stays a saturated red after mapping', () => {
+  const c = parseCssColor('color(display-p3 1 0 0)');
+  assert.ok(c);
+  assert.equal(c?.r, 255);
+  assert.ok((c?.g ?? 99) < 60);
+  assert.ok((c?.b ?? 99) < 60);
+});
+
+test('color() with unknown space returns null', () => {
+  assert.equal(parseCssColor('color(magic 1 0 0)'), null);
+});
+
+// --- Round-trip properties ---
+
+test('sRGB corners survive oklab round trip', () => {
+  const corners = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#00ffff', '#ff00ff', '#ffffff', '#000000'];
+  for (const h of corners) {
+    const c = parseCssColor(h);
+    assert.ok(c, h);
+  }
+});
+
+// --- Serialisation ---
+
+test('serializeHex emits 6-digit for opaque, 8-digit with alpha', () => {
+  assert.equal(serializeHex({ r: 31, g: 71, b: 51, a: 1 }), '#1f4733');
+  assert.equal(serializeHex({ r: 31, g: 71, b: 51, a: 0.3 }), '#1f47334d');
+});
+
+test('serializeRgb emits legacy rgb()/rgba() strings', () => {
+  assert.equal(serializeRgb({ r: 31, g: 71, b: 51, a: 1 }), 'rgb(31, 71, 51)');
+  assert.equal(serializeRgb({ r: 31, g: 71, b: 51, a: 0.3 }), 'rgba(31, 71, 51, 0.3)');
+});
+
+// --- Whitespace and case robustness ---
+
+test('parser tolerates case and irregular whitespace', () => {
+  assert.equal(hex('RGB( 255 , 0 , 0 )'), '#ff0000');
+  assert.equal(hex('OKLCH(0.627955 0.257683 29.2339)') !== null, true);
+  assert.equal(hex('  #ff0000  '), '#ff0000');
+});
+
+// --- HEX/RGB hardening (the dominant real-world notation) ---
+
+test('rgb() fractional channels round, scientific notation accepted', () => {
+  assert.equal(hex('rgb(127.5 0 0)'), '#800000');
+  assert.equal(hex('rgb(2.55e2 0 0)'), '#ff0000');
+  assert.equal(hex('rgb(45% 45% 45%)'), '#737373');
+});
+
+test('rgb() malformed forms return null', () => {
+  assert.equal(parseCssColor('rgb(255 0)'), null);
+  assert.equal(parseCssColor('rgb(255, 0)'), null);
+  assert.equal(parseCssColor('rgb(255, 0, 0, 0.5, 9)'), null);
+  assert.equal(parseCssColor('rgb(a b c)'), null);
+  assert.equal(parseCssColor('rgb()'), null);
+});
+
+test('hex is case-insensitive and exact-length only', () => {
+  assert.equal(hex('#ABC'), '#aabbcc');
+  assert.equal(hex('#AABBCC'), '#aabbcc');
+  assert.equal(parseCssColor('#abcde'), null);
+  assert.equal(parseCssColor('#aabbccddee'), null);
+  assert.equal(parseCssColor('aabbcc'), null);
+});

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -72,3 +72,24 @@ test('convertColor flags alpha and returns null for junk', () => {
   assert.equal(convertColor('rgba(0, 0, 0, 0.5)').hasAlpha, true);
   assert.equal(convertColor('not-a-color'), null);
 });
+
+test('convertColor parses modern colour functions (GitHub #149)', () => {
+  const scrim = convertColor('oklab(0.363344 -0.0549272 0.0203635 / 0.3)');
+  assert.equal(scrim.hex, '#1f4733');
+  assert.equal(scrim.hasAlpha, true);
+  const wide = convertColor('color(srgb 0.072 0.168 0.12)');
+  assert.equal(wide.hex, '#122b1f');
+  const amber = convertColor('oklch(0.879 0.169 91.605)');
+  assert.equal(amber.hex, '#ffd230');
+});
+
+test('emitted lch() is D50 as the CSS spec requires (GitHub #149)', () => {
+  // Issue reference: #1f242e is lch(14.03% 7.44 268.93) at D50;
+  // the old D65 output was lch(14.12% 7.37 275.12).
+  const c = convertColor('#1f242e');
+  const m = c.lch.match(/^lch\(([\d.]+)% ([\d.]+) ([\d.]+)\)$/);
+  assert.ok(m, c.lch);
+  assert.ok(Math.abs(parseFloat(m[1]) - 14.03) < 0.05, c.lch);
+  assert.ok(Math.abs(parseFloat(m[2]) - 7.44) < 0.05, c.lch);
+  assert.ok(Math.abs(parseFloat(m[3]) - 268.93) < 0.1, c.lch);
+});


### PR DESCRIPTION
Fixes #149.

- New `lib/color-parse.ts`: CSS Color 4 parser (named, hex, rgb/hsl legacy+modern, hwb, lab/lch at D50, oklab/oklch, color()) with spec gamut mapping (binary search + local MINDE).
- Extractor rewrites modern computed values to legacy rgb()/rgba() at the read boundary; alpha preserved, no raw strings or bare `srgb` tokens in output.
- `convertColor` now parses all notations; emitted `lch()` adapted to D50.
- 423 unit tests green, liveness 6/6.