### PR TITLE
fix(brand-guide): inline logo as data URI for PDF render

### DIFF
--- a/lib/formatters/brand-guide.ts
+++ b/lib/formatters/brand-guide.ts
@@ -967,7 +967,7 @@ ${(() => {
 </html>`;
 }
 
-function getLogoImageUrl(data) {
+export function getLogoImageUrl(data) {
   const isImageUrl = (url) => {
     if (/\.(svg|png|jpg|jpeg|webp|gif|avif)(\?.*)?$/i.test(url)) return true;
     // Image optimizers (Next.js /_next/image, Cloudflare /cdn-cgi/image, etc.)

--- a/lib/formatters/pdf.ts
+++ b/lib/formatters/pdf.ts
@@ -9,9 +9,52 @@
  */
 
 import { loadBrowserEngines } from '../browser.js';
-import { buildHTML } from './brand-guide.js';
+import { buildHTML, getLogoImageUrl } from './brand-guide.js';
 
 export { buildHTML };
+
+const EXT_CONTENT_TYPES: Record<string, string> = {
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+};
+
+function contentTypeFromUrl(url: string): string | null {
+  const m = /\.([a-z0-9]+)(?:[?&#]|$)/i.exec(url);
+  return m ? EXT_CONTENT_TYPES[m[1].toLowerCase()] ?? null : null;
+}
+
+/**
+ * The PDF renders via page.setContent() in an about:blank context with no base
+ * URL, so a remote <img src> never loads and every logo slot shows a
+ * broken-image glyph. Resolve the logo to a self-contained data URI up front;
+ * if the bytes cannot be fetched, drop the logo entirely — a guide without a
+ * logo beats one with broken-image placeholders on every page.
+ */
+export async function inlineLogoForPdf(data, fetchImpl = fetch) {
+  const url = getLogoImageUrl(data);
+  if (!url) return data;
+  if (url.startsWith('data:')) return data;
+  try {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(15000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const headerType = (res.headers.get('content-type') || '').split(';')[0].trim();
+    const contentType = headerType.startsWith('image/')
+      ? headerType
+      : contentTypeFromUrl(url) ?? 'image/png';
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length === 0) throw new Error('empty body');
+    const dataUri = `data:${contentType};base64,${buf.toString('base64')}`;
+    return { ...data, logo: { ...(data.logo || {}), inline: true, dataUri } };
+  } catch {
+    return { ...data, logo: undefined, favicons: [] };
+  }
+}
 
 /**
  * Generate a brand guide PDF from extraction data
@@ -19,7 +62,7 @@ export { buildHTML };
  * @param {string} outputPath - Path to write the PDF
  */
 export async function generatePDF(data, outputPath, existingBrowser) {
-  const html = buildHTML(data);
+  const html = buildHTML(await inlineLogoForPdf(data));
   const ownBrowser = !existingBrowser;
   let browser = existingBrowser;
   if (!browser) {

--- a/test/pdf-logo.test.ts
+++ b/test/pdf-logo.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { inlineLogoForPdf, buildHTML } from '../lib/formatters/pdf.js';
+
+const PNG_BYTES = Buffer.from('89504e470d0a1a0a', 'hex');
+
+function fakeFetch(status = 200, contentType = 'image/png', body: Buffer = PNG_BYTES) {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => (k.toLowerCase() === 'content-type' ? contentType : null) },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  });
+}
+
+const base = { url: 'https://example.com', colors: { palette: [], semantic: {} } };
+
+test('remote logo is inlined as a data URI', async () => {
+  const data = { ...base, logo: { url: 'https://example.com/logo.png' } };
+  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  assert.equal(out.logo.inline, true);
+  assert.ok(out.logo.dataUri.startsWith('data:image/png;base64,'));
+});
+
+test('already-inline data URI logo passes through untouched', async () => {
+  const data = { ...base, logo: { inline: true, dataUri: 'data:image/svg+xml;base64,PHN2Zz4=' } };
+  let called = false;
+  const out = await inlineLogoForPdf(data, (async () => { called = true; }) as any);
+  assert.equal(called, false);
+  assert.equal(out, data);
+});
+
+test('favicon fallback URL is also inlined', async () => {
+  const data = { ...base, favicons: [{ type: 'apple-touch-icon', url: 'https://example.com/apple-touch-icon.png' }] };
+  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  assert.ok(out.logo.dataUri.startsWith('data:image/png;base64,'));
+});
+
+test('fetch failure drops the logo instead of leaving a broken remote URL', async () => {
+  const data = { ...base, logo: { url: 'https://example.com/logo.png' }, favicons: [{ type: 'icon', url: 'https://example.com/favicon.png' }] };
+  const out = await inlineLogoForPdf(data, fakeFetch(404) as any);
+  assert.equal(out.logo, undefined);
+  assert.deepEqual(out.favicons, []);
+  const html = buildHTML(out);
+  assert.ok(!html.includes('https://example.com/logo.png'));
+});
+
+test('non-image content-type falls back to extension-derived type', async () => {
+  const data = { ...base, logo: { url: 'https://example.com/logo.svg' } };
+  const out = await inlineLogoForPdf(data, fakeFetch(200, 'text/plain') as any);
+  assert.ok(out.logo.dataUri.startsWith('data:image/svg+xml;base64,'));
+});
+
+test('rendered HTML embeds only the data URI, never the remote URL', async () => {
+  const data = { ...base, logo: { url: 'https://example.com/logo.png' } };
+  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  const html = buildHTML(out);
+  assert.ok(html.includes('data:image/png;base64,'));
+  assert.ok(!html.includes('src="https://example.com/logo.png"'));
+});


### PR DESCRIPTION
page.setContent renders in an about:blank context with no base URL, so remote logo/favicon URLs never load and every logo slot in the --brand-guide PDF shows a broken-image glyph. Fetch the logo bytes up front and embed as a base64 data URI; on fetch failure drop the logo instead of leaving broken placeholders. Verified visually on dembrandt.com's regenerated PDF (cover, all lockups, all six misuse tiles). 6 new unit tests, 431 total green.