### PR TITLE
test: type fetch stubs without any casts

### DIFF
--- a/test/pdf-logo.test.ts
+++ b/test/pdf-logo.test.ts
@@ -17,7 +17,7 @@ const base = { url: 'https://example.com', colors: { palette: [], semantic: {} }
 
 test('remote logo is inlined as a data URI', async () => {
   const data = { ...base, logo: { url: 'https://example.com/logo.png' } };
-  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  const out = await inlineLogoForPdf(data, fakeFetch() as unknown as typeof fetch);
   assert.equal(out.logo.inline, true);
   assert.ok(out.logo.dataUri.startsWith('data:image/png;base64,'));
 });
@@ -25,20 +25,20 @@ test('remote logo is inlined as a data URI', async () => {
 test('already-inline data URI logo passes through untouched', async () => {
   const data = { ...base, logo: { inline: true, dataUri: 'data:image/svg+xml;base64,PHN2Zz4=' } };
   let called = false;
-  const out = await inlineLogoForPdf(data, (async () => { called = true; }) as any);
+  const out = await inlineLogoForPdf(data, (async () => { called = true; }) as unknown as typeof fetch);
   assert.equal(called, false);
   assert.equal(out, data);
 });
 
 test('favicon fallback URL is also inlined', async () => {
   const data = { ...base, favicons: [{ type: 'apple-touch-icon', url: 'https://example.com/apple-touch-icon.png' }] };
-  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  const out = await inlineLogoForPdf(data, fakeFetch() as unknown as typeof fetch);
   assert.ok(out.logo.dataUri.startsWith('data:image/png;base64,'));
 });
 
 test('fetch failure drops the logo instead of leaving a broken remote URL', async () => {
   const data = { ...base, logo: { url: 'https://example.com/logo.png' }, favicons: [{ type: 'icon', url: 'https://example.com/favicon.png' }] };
-  const out = await inlineLogoForPdf(data, fakeFetch(404) as any);
+  const out = await inlineLogoForPdf(data, fakeFetch(404) as unknown as typeof fetch);
   assert.equal(out.logo, undefined);
   assert.deepEqual(out.favicons, []);
   const html = buildHTML(out);
@@ -47,13 +47,13 @@ test('fetch failure drops the logo instead of leaving a broken remote URL', asyn
 
 test('non-image content-type falls back to extension-derived type', async () => {
   const data = { ...base, logo: { url: 'https://example.com/logo.svg' } };
-  const out = await inlineLogoForPdf(data, fakeFetch(200, 'text/plain') as any);
+  const out = await inlineLogoForPdf(data, fakeFetch(200, 'text/plain') as unknown as typeof fetch);
   assert.ok(out.logo.dataUri.startsWith('data:image/svg+xml;base64,'));
 });
 
 test('rendered HTML embeds only the data URI, never the remote URL', async () => {
   const data = { ...base, logo: { url: 'https://example.com/logo.png' } };
-  const out = await inlineLogoForPdf(data, fakeFetch() as any);
+  const out = await inlineLogoForPdf(data, fakeFetch() as unknown as typeof fetch);
   const html = buildHTML(out);
   assert.ok(html.includes('data:image/png;base64,'));
   assert.ok(!html.includes('src="https://example.com/logo.png"'));


### PR DESCRIPTION
Unblocks the lint gate on main; 0.26.1 release workflow failed at lint before opening sync PRs.