### PR TITLE
feat: --color-format for displayed colour notation (DEM-190)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Source is TypeScript. Build first, then run the compiled entry point.
 npm run build
 node dist/index.js <url>
 node dist/index.js dembrandt.com --json-only
+node dist/index.js dembrandt.com --color-format=oklch
 node dist/index.js dembrandt.com --dark-mode
 node dist/index.js dembrandt.com --mobile
 node dist/index.js dembrandt.com --slow

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ dembrandt <url>                        # Basic extraction (terminal display only
 dembrandt dembrandt.com --json-only     # Output raw JSON to terminal (no formatted display, no file save)
 dembrandt dembrandt.com --save-output   # Save JSON to output/dembrandt.com/YYYY-MM-DDTHH-MM-SS.json
 dembrandt dembrandt.com --dtcg          # Export in W3C Design Tokens (DTCG) format (auto-saves as .tokens.json)
+dembrandt dembrandt.com --color-format=oklch # Notation for displayed colors: hex|rgb|lch|oklch|source (default: hex)
 dembrandt dembrandt.com --dark-mode     # Extract colors from dark mode variant
 dembrandt dembrandt.com --mobile        # Use mobile viewport (390x844) for responsive analysis
 dembrandt dembrandt.com --slow          # 3x longer timeouts (24s hydration) for JavaScript-heavy sites
@@ -113,6 +114,8 @@ dembrandt dembrandt.com --screen-size 2560x1440                  # Physical scre
 ```
 
 Default: formatted terminal display only. Use `--save-output` to persist results as JSON files. Browser automatically retries in visible mode if headless extraction fails.
+
+`--color-format` is presentational and covers terminal output only: the palette, borders and every component section print the notation you pick. `source` shows a declared token as it was authored. The JSON payload is unaffected — it carries hex, rgb, lch and oklch for every color regardless — so `--json-only`, `--save-output`, `--dtcg`, `--design-md`, `--html` and `--brand-guide` are untouched, and drift comparisons stay stable across notations. The CLI warns when you combine it with one of those.
 
 All flags combine unless noted otherwise: see [docs/FLAGS.md](docs/FLAGS.md) for the flag compatibility tables (interactions, ignored combinations, multi-page propagation).
 

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -24,6 +24,7 @@ The tables below list the only exceptions: combinations that change each other's
 |---|---|
 | `--approve` without `--compare` | No effect. A warning is printed. |
 | Explicit `[paths...]` arguments + `--crawl` or `--sitemap` | Explicit paths win; link and sitemap discovery are skipped entirely. |
+| `--color-format` + `--json-only` / `--save-output` / `--dtcg` / `--design-md` / `--html` / `--brand-guide` | Ignored by those paths. The flag is presentational and covers terminal output only; the payload carries hex, rgb, lch and oklch for every color. A warning names the paths it misses. |
 | `--no-sandbox` + `--browser firefox` | Ignored. Sandbox flags are Chromium-only. |
 | `BROWSER_CDP_ENDPOINT` (env) + `--browser firefox` | Error. CDP connect is Chromium-only. CDP mode also disables the visible-browser retry on navigation failure. |
 

--- a/index.ts
+++ b/index.ts
@@ -7,12 +7,13 @@
  * from any website using Playwright.
  */
 
-import { program, Option } from "commander";
+import { program, Option, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import ora from "ora";
 import { loadBrowserEngines, PlaywrightMissingError } from "./lib/browser.js";
 import { extractBranding } from "./lib/extractors/index.js";
 import { displayResults, terminalLink } from "./lib/formatters/terminal.js";
+import { COLOR_FORMATS, isColorFormat } from "./lib/colors.js";
 import { color } from "./lib/formatters/theme.js";
 import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generatePDF } from "./lib/formatters/pdf.js";
@@ -66,6 +67,18 @@ program
   .option("--approve", "With --compare <file>: accept the current extraction as the new baseline by overwriting that local file, and pass instead of failing. Ignored for App baseline ids.")
   .option("--no-sandbox", "Disable browser sandbox (needed for Docker/CI)")
   .option("--raw-colors", "Include pre-filter raw colors in JSON output")
+  .option(
+    "--color-format <format>",
+    `Notation for displayed colors: ${COLOR_FORMATS.join("|")} ('source' keeps declared tokens as authored). JSON keeps every notation regardless.`,
+    (v: string) => {
+      const value = String(v).toLowerCase();
+      if (!isColorFormat(value)) {
+        throw new InvalidArgumentError(`expected one of ${COLOR_FORMATS.join(", ")}`);
+      }
+      return value;
+    },
+    "hex",
+  )
   .option("--screenshot <path>", "Save a viewport screenshot of the page (not full-page)")
   // Internal, undocumented flag. Hidden from --help; not part of the product surface.
   .addOption(new Option("--teach").hideHelp())
@@ -596,7 +609,7 @@ program
         for (const notice of savedNotices) console.error(notice);
       } else {
         console.log();
-        displayResults(result);
+        displayResults(result, { colorFormat: opts.colorFormat });
         console.log();
         console.log(summaryLine);
         if (pathsLine) console.log(pathsLine);

--- a/index.ts
+++ b/index.ts
@@ -113,6 +113,26 @@ program
       console.error(color.warning("! --approve has no effect without --compare <file>."));
     }
 
+    // --color-format governs the terminal colour column only. Silently ignoring
+    // it on an export path would read as a bug, so name the paths it misses.
+    if (opts.colorFormat && opts.colorFormat !== "hex") {
+      const unaffected = [
+        opts.jsonOnly && "--json-only",
+        opts.saveOutput && "--save-output",
+        opts.dtcg && "--dtcg",
+        opts.designMd && "--design-md",
+        opts.html && "--html",
+        opts.brandGuide && "--brand-guide",
+      ].filter(Boolean);
+      if (unaffected.length) {
+        console.error(
+          color.warning(
+            `! --color-format=${opts.colorFormat} applies to terminal output only; ${unaffected.join(", ")} ${unaffected.length > 1 ? "are" : "is"} unaffected. JSON carries hex, rgb, lch and oklch for every colour.`
+          )
+        );
+      }
+    }
+
     // In --json-only mode, redirect all status output to stderr so stdout is clean JSON
     const originalConsoleLog = console.log;
     if (opts.jsonOnly) {

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -146,9 +146,15 @@ export function rgbToOklch(r, g, b) {
  * @returns {string}
  */
 export function formatLch(lch, alpha?: number) {
-  const l = Math.round(lch.l * 100) / 100;
-  const c = Math.round(lch.c * 100) / 100;
-  const h = Math.round(lch.h * 100) / 100;
+  // Precision is chosen so a serialise/parse round trip is lossless at 8-bit
+  // sRGB: at 2 decimals the cycle shifted a channel by up to 1/255, which is a
+  // silent colour change for anyone pasting the emitted value back into CSS.
+  const l = Math.round(lch.l * 1000) / 1000;
+  const c = Math.round(lch.c * 1000) / 1000;
+  // Hue is meaningless once chroma rounds away (atan2 on denormal a/b yields a
+  // stable but arbitrary angle for neutrals), so pin achromatic colours to 0
+  // rather than emitting lch(53.59% 0 53.35) for mid grey.
+  const h = c === 0 ? 0 : Math.round(lch.h * 1000) / 1000;
 
   if (alpha !== undefined && alpha < 1) {
     return `lch(${l}% ${c} ${h} / ${alpha})`;
@@ -163,10 +169,14 @@ export function formatLch(lch, alpha?: number) {
  * @returns {string}
  */
 export function formatOklch(oklch, alpha?: number) {
-  // OKLCH lightness is 0-1, displayed as percentage
-  const l = Math.round(oklch.l * 10000) / 100;
-  const c = Math.round(oklch.c * 1000) / 1000;
-  const h = Math.round(oklch.h * 100) / 100;
+  // OKLCH lightness is 0-1, displayed as percentage. Precision is chosen so a
+  // serialise/parse round trip is lossless at 8-bit sRGB: at 2 decimals on L and
+  // 3 on C the cycle shifted a channel by up to 6/255, a visible shift for
+  // anyone pasting the emitted value back into their CSS.
+  const l = Math.round(oklch.l * 1000000) / 10000;
+  const c = Math.round(oklch.c * 100000) / 100000;
+  // See formatLch: a neutral's hue is float noise, so pin it to 0.
+  const h = c === 0 ? 0 : Math.round(oklch.h * 1000) / 1000;
 
   if (alpha !== undefined && alpha < 1) {
     return `oklch(${l}% ${c} ${h} / ${alpha})`;

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -145,7 +145,7 @@ export function rgbToOklch(r, g, b) {
  * @param {number} [alpha] - Optional alpha value (0-1)
  * @returns {string}
  */
-export function formatLch(lch, alpha) {
+export function formatLch(lch, alpha?: number) {
   const l = Math.round(lch.l * 100) / 100;
   const c = Math.round(lch.c * 100) / 100;
   const h = Math.round(lch.h * 100) / 100;
@@ -162,7 +162,7 @@ export function formatLch(lch, alpha) {
  * @param {number} [alpha] - Optional alpha value (0-1)
  * @returns {string}
  */
-export function formatOklch(oklch, alpha) {
+export function formatOklch(oklch, alpha?: number) {
   // OKLCH lightness is 0-1, displayed as percentage
   const l = Math.round(oklch.l * 10000) / 100;
   const c = Math.round(oklch.c * 1000) / 1000;
@@ -377,6 +377,39 @@ export function computeWcag(palette) {
   }
 
   return pairs.sort((a, b) => b.ratio - a.ratio);
+}
+
+/**
+ * Notations a user may select for emitted colors. `source` keeps the string as
+ * authored (only meaningful where provenance survived extraction, i.e. declared
+ * custom properties); the rest are computed from the parsed sRGB identity.
+ */
+export const COLOR_FORMATS = ['hex', 'rgb', 'oklch', 'lch', 'source'] as const;
+
+export type ColorFormat = (typeof COLOR_FORMATS)[number];
+
+export function isColorFormat(value: string): value is ColorFormat {
+  return (COLOR_FORMATS as readonly string[]).includes(value);
+}
+
+/**
+ * Render one color in the requested notation.
+ *
+ * Presentation only: the caller keeps whatever identity key it already had, so
+ * dedup, drift comparison and ML features are unaffected by the choice. An
+ * unparseable input is returned verbatim rather than dropped, matching how the
+ * formatters already degrade.
+ *
+ * @param {string} colorString - any CSS color, or an already-authored token value
+ * @param {ColorFormat} format - target notation, default 'hex'
+ * @returns {string}
+ */
+export function formatColor(colorString, format: ColorFormat = 'hex'): string {
+  const input = String(colorString);
+  if (format === 'source') return input;
+  const converted = convertColor(input);
+  if (!converted) return input;
+  return converted[format];
 }
 
 /**

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -793,7 +793,10 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       guardExtractor('frameworks', detectFrameworks(page), [], extractorErrors),
       guardExtractor('siteName', extractSiteName(page), null, extractorErrors),
       guardExtractor('gradients', extractGradients(page), [], extractorErrors),
-      guardExtractor('motion', extractMotion(page), { durations: [], easings: [], byContext: {} }, extractorErrors),
+      // The fallback must satisfy Motion in full: the terminal renderer reads
+      // motion.animations, so a short default turned an extractor failure into a
+      // crash of the whole render.
+      guardExtractor('motion', extractMotion(page), { durations: [], easings: [], animations: [], contexts: {}, interactiveDeltas: [] }, extractorErrors),
     ]);
 
     const { logo, instances: logoInstances, favicons, manifest } = logoResult;

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -28,6 +28,8 @@ export function terminalLink(url, text = url) {
  * @param {Object} data - Extraction results from extractBranding()
  */
 export function displayResults(data: BrandingResult, options: { colorFormat?: ColorFormat } = {}) {
+  const colorFormat: ColorFormat = options.colorFormat || 'hex';
+
   console.log('\n' + chalk.bold.cyan('🎨 Brand Extraction'));
   console.log(chalk.dim('│'));
   console.log(chalk.dim('├─') + ' ' + chalk.blue(terminalLink(data.url)));
@@ -44,17 +46,17 @@ export function displayResults(data: BrandingResult, options: { colorFormat?: Co
 
   displayLogo(data.logo);
   displayFavicons(data.favicons);
-  displayColors(data.colors, options.colorFormat || 'hex');
+  displayColors(data.colors, colorFormat);
   displayTypography(data.typography);
   displaySpacing(data.spacing);
   displayBorderRadius(data.borderRadius);
-  displayBorders(data.borders);
+  displayBorders(data.borders, colorFormat);
   displayShadows(data.shadows);
   displayGradients(data.gradients);
-  displayButtons(data.components?.buttons);
-  displayBadges(data.components?.badges);
-  displayInputs(data.components?.inputs);
-  displayLinks(data.components?.links);
+  displayButtons(data.components?.buttons, colorFormat);
+  displayBadges(data.components?.badges, colorFormat);
+  displayInputs(data.components?.inputs, colorFormat);
+  displayLinks(data.components?.links, colorFormat);
   displayBreakpoints(data.breakpoints);
   displayIconSystem(data.iconSystem);
   displayFrameworks(data.frameworks);
@@ -125,6 +127,26 @@ function normalizeColorFormat(colorString) {
     oklch: colorString,
     hasAlpha: false
   };
+}
+
+// Swatch plus notation pair, as the component sections print a colour.
+// Same rules as the palette: the primary column follows --color-format, the
+// dim secondary never repeats it, and the swatch stays on hex because
+// chalk.bgHex needs one and the identity column must not move.
+function colorCell(colorString, colorFormat: ColorFormat = 'hex'): string {
+  const raw = String(colorString);
+  const formats = normalizeColorFormat(raw);
+  const primary = colorFormat === 'source' ? raw : (formats[colorFormat] || formats.hex);
+  const secondary = colorFormat === 'rgb' ? formats.hex : formats.rgb;
+
+  let swatch;
+  try {
+    swatch = chalk.bgHex(formats.hex)('  ');
+  } catch {
+    swatch = '  ';
+  }
+
+  return `${swatch} ${primary.padEnd(9)} ${secondary}`;
 }
 
 function displayColors(colors, colorFormat: ColorFormat = 'hex') {
@@ -440,7 +462,7 @@ function displayBorderRadius(borderRadius) {
   console.log(chalk.dim('│'));
 }
 
-function displayBorders(borders) {
+function displayBorders(borders, colorFormat: ColorFormat = 'hex') {
   if (!borders) return;
 
   const hasCombinations = borders.combinations && borders.combinations.length > 0;
@@ -456,30 +478,15 @@ function displayBorders(borders) {
     const branch = isLast ? '└─' : '├─';
     const conf = combo.confidence === 'high' ? color.success('●') : color.warning('●');
 
-    try {
-      const formats = normalizeColorFormat(combo.color);
-      const colorBlock = chalk.bgHex(formats.hex)('  ');
+    const elementsText = combo.elements && combo.elements.length > 0
+      ? chalk.dim(` (${combo.elements.join(', ')})`)
+      : '';
 
-      const elementsText = combo.elements && combo.elements.length > 0
-        ? chalk.dim(` (${combo.elements.join(', ')})`)
-        : '';
-
-      console.log(
-        chalk.dim(`│  ${branch}`) + ' ' +
-        `${conf} ${colorBlock} ${combo.width} ${combo.style} ${formats.hex.padEnd(9)} ${formats.rgb}` +
-        elementsText
-      );
-    } catch {
-      const elementsText = combo.elements && combo.elements.length > 0
-        ? chalk.dim(` (${combo.elements.join(', ')})`)
-        : '';
-
-      console.log(
-        chalk.dim(`│  ${branch}`) + ' ' +
-        `${conf} ${combo.width} ${combo.style} ${combo.color}` +
-        elementsText
-      );
-    }
+    console.log(
+      chalk.dim(`│  ${branch}`) + ' ' +
+      `${conf} ${combo.width} ${combo.style} ${colorCell(combo.color, colorFormat)}` +
+      elementsText
+    );
   });
 
   if (highConfCombos.length > 10) {
@@ -535,7 +542,7 @@ function displayGradients(gradients) {
   console.log(chalk.dim('│'));
 }
 
-function displayButtons(buttons) {
+function displayButtons(buttons, colorFormat: ColorFormat = 'hex') {
   if (!buttons || buttons.length === 0) return;
 
   const highConfButtons = buttons.filter(b => b.confidence === 'high');
@@ -556,9 +563,7 @@ function displayButtons(buttons) {
       if (isTransparent) {
         console.log(chalk.dim(`│  ${btnBranch}`) + ' ' + chalk.bold('Variant: transparent'));
       } else {
-        const formats = normalizeColorFormat(defaultBg);
-        const colorBlock = chalk.bgHex(formats.hex)('  ');
-        console.log(chalk.dim(`│  ${btnBranch}`) + ' ' + chalk.bold(`Variant: ${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}`));
+        console.log(chalk.dim(`│  ${btnBranch}`) + ' ' + chalk.bold(`Variant: ${colorCell(defaultBg, colorFormat)}`));
       }
     } catch {
       console.log(chalk.dim(`│  ${btnBranch}`) + ' ' + chalk.bold(`Variant: ${btn.states.default.backgroundColor}`));
@@ -586,23 +591,11 @@ function displayButtons(buttons) {
 
       // Only show properties that exist and are meaningful
       if (state.backgroundColor && state.backgroundColor !== 'rgba(0, 0, 0, 0)' && state.backgroundColor !== 'transparent') {
-        try {
-          const formats = normalizeColorFormat(state.backgroundColor);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          props.push({ key: 'bg', value: state.backgroundColor });
-        }
+        props.push({ key: 'bg', value: colorCell(state.backgroundColor, colorFormat) });
       }
 
       if (state.color) {
-        try {
-          const formats = normalizeColorFormat(state.color);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'text', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          props.push({ key: 'text', value: state.color });
-        }
+        props.push({ key: 'text', value: colorCell(state.color, colorFormat) });
       }
 
       if (stateInfo.key === 'default') {
@@ -655,7 +648,7 @@ function displayButtons(buttons) {
   console.log(chalk.dim('│'));
 }
 
-function displayBadges(badges) {
+function displayBadges(badges, colorFormat: ColorFormat = 'hex') {
   if (!badges || !badges.all || badges.all.length === 0) return;
 
   const highConfBadges = badges.all.filter(b => b.confidence === 'high');
@@ -705,24 +698,12 @@ function displayBadges(badges) {
 
       // Background color
       if (badge.backgroundColor && badge.backgroundColor !== 'rgba(0, 0, 0, 0)' && badge.backgroundColor !== 'transparent') {
-        try {
-          const formats = normalizeColorFormat(badge.backgroundColor);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          props.push({ key: 'bg', value: badge.backgroundColor });
-        }
+        props.push({ key: 'bg', value: colorCell(badge.backgroundColor, colorFormat) });
       }
 
       // Text color
       if (badge.color) {
-        try {
-          const formats = normalizeColorFormat(badge.color);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          props.push({ key: 'text', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          props.push({ key: 'text', value: badge.color });
-        }
+        props.push({ key: 'text', value: colorCell(badge.color, colorFormat) });
       }
 
       // Other properties
@@ -762,7 +743,7 @@ function displayBadges(badges) {
   console.log(chalk.dim('│'));
 }
 
-function displayInputs(inputs) {
+function displayInputs(inputs, colorFormat: ColorFormat = 'hex') {
   if (!inputs) return;
 
   const hasText = inputs.text && inputs.text.length > 0;
@@ -796,23 +777,11 @@ function displayInputs(inputs) {
       const defaultProps = [];
 
       if (defaultState.backgroundColor && defaultState.backgroundColor !== 'rgba(0, 0, 0, 0)' && defaultState.backgroundColor !== 'transparent') {
-        try {
-          const formats = normalizeColorFormat(defaultState.backgroundColor);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          defaultProps.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          defaultProps.push({ key: 'bg', value: defaultState.backgroundColor });
-        }
+        defaultProps.push({ key: 'bg', value: colorCell(defaultState.backgroundColor, colorFormat) });
       }
 
       if (defaultState.color) {
-        try {
-          const formats = normalizeColorFormat(defaultState.color);
-          const colorBlock = chalk.bgHex(formats.hex)('  ');
-          defaultProps.push({ key: 'text', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-        } catch {
-          defaultProps.push({ key: 'text', value: defaultState.color });
-        }
+        defaultProps.push({ key: 'text', value: colorCell(defaultState.color, colorFormat) });
       }
 
       if (defaultState.border && defaultState.border !== 'none' && !defaultState.border.includes('0px')) {
@@ -844,13 +813,7 @@ function displayInputs(inputs) {
         const focusProps = [];
 
         if (focusState.backgroundColor) {
-          try {
-            const formats = normalizeColorFormat(focusState.backgroundColor);
-            const colorBlock = chalk.bgHex(formats.hex)('  ');
-            focusProps.push({ key: 'bg', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-          } catch {
-            focusProps.push({ key: 'bg', value: focusState.backgroundColor });
-          }
+          focusProps.push({ key: 'bg', value: colorCell(focusState.backgroundColor, colorFormat) });
         }
 
         if (focusState.border) {
@@ -858,13 +821,7 @@ function displayInputs(inputs) {
         }
 
         if (focusState.borderColor) {
-          try {
-            const formats = normalizeColorFormat(focusState.borderColor);
-            const colorBlock = chalk.bgHex(formats.hex)('  ');
-            focusProps.push({ key: 'border-color', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-          } catch {
-            focusProps.push({ key: 'border-color', value: focusState.borderColor });
-          }
+          focusProps.push({ key: 'border-color', value: colorCell(focusState.borderColor, colorFormat) });
         }
 
         if (focusState.boxShadow && focusState.boxShadow !== 'none') {
@@ -935,7 +892,7 @@ function displayBreakpoints(breakpoints) {
   console.log(chalk.dim('│'));
 }
 
-function displayLinks(links) {
+function displayLinks(links, colorFormat: ColorFormat = 'hex') {
   if (!links || links.length === 0) return;
 
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Links'));
@@ -946,13 +903,7 @@ function displayLinks(links) {
     const linkIndent = isLastLink ? '   ' : '│  ';
 
     // Show link variant header with color
-    try {
-      const formats = normalizeColorFormat(link.color);
-      const colorBlock = chalk.bgHex(formats.hex)('  ');
-      console.log(chalk.dim(`│  ${linkBranch}`) + ' ' + `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}`);
-    } catch {
-      console.log(chalk.dim(`│  ${linkBranch}`) + ' ' + `${link.color}`);
-    }
+    console.log(chalk.dim(`│  ${linkBranch}`) + ' ' + colorCell(link.color, colorFormat));
 
     // Display default state
     if (link.states && link.states.default) {
@@ -978,13 +929,7 @@ function displayLinks(links) {
         const hoverProps = [];
 
         if (hoverState.color) {
-          try {
-            const formats = normalizeColorFormat(hoverState.color);
-            const colorBlock = chalk.bgHex(formats.hex)('  ');
-            hoverProps.push({ key: 'color', value: `${colorBlock} ${formats.hex.padEnd(9)} ${formats.rgb}` });
-          } catch {
-            hoverProps.push({ key: 'color', value: hoverState.color });
-          }
+          hoverProps.push({ key: 'color', value: colorCell(hoverState.color, colorFormat) });
         }
 
         if (hoverState.textDecoration) {

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -9,6 +9,7 @@ import type { BrandingResult } from '../types.js';
 import chalk from 'chalk';
 import { color } from './theme.js';
 import { convertColor } from '../colors.js';
+import type { ColorFormat } from '../colors.js';
 
 /**
  * Creates a clickable terminal link using ANSI escape codes
@@ -26,7 +27,7 @@ export function terminalLink(url, text = url) {
  * Main display function - outputs formatted extraction results to terminal
  * @param {Object} data - Extraction results from extractBranding()
  */
-export function displayResults(data: BrandingResult) {
+export function displayResults(data: BrandingResult, options: { colorFormat?: ColorFormat } = {}) {
   console.log('\n' + chalk.bold.cyan('🎨 Brand Extraction'));
   console.log(chalk.dim('│'));
   console.log(chalk.dim('├─') + ' ' + chalk.blue(terminalLink(data.url)));
@@ -43,7 +44,7 @@ export function displayResults(data: BrandingResult) {
 
   displayLogo(data.logo);
   displayFavicons(data.favicons);
-  displayColors(data.colors);
+  displayColors(data.colors, options.colorFormat || 'hex');
   displayTypography(data.typography);
   displaySpacing(data.spacing);
   displayBorderRadius(data.borderRadius);
@@ -126,7 +127,7 @@ function normalizeColorFormat(colorString) {
   };
 }
 
-function displayColors(colors) {
+function displayColors(colors, colorFormat: ColorFormat = 'hex') {
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Colors'));
 
   // All colors in one list with consistent formatting
@@ -144,6 +145,8 @@ function displayColors(colors) {
           lch: formats.lch,
           oklch: formats.oklch,
           hasAlpha: formats.hasAlpha,
+          source: String(color),
+          sourceRank: 1,
           label: role,
           type: 'semantic',
           confidence: 'high'
@@ -167,6 +170,8 @@ function displayColors(colors) {
           lch: (typeof varData === 'object' && varData.lch) || formats.lch,
           oklch: (typeof varData === 'object' && varData.oklch) || formats.oklch,
           hasAlpha: formats.hasAlpha,
+          source: String(colorValue),
+          sourceRank: 2,
           label: name,
           type: 'variable',
           confidence: 'high'
@@ -190,6 +195,8 @@ function displayColors(colors) {
         lch: c.lch || formats.lch,
         oklch: c.oklch || formats.oklch,
         hasAlpha: formats.hasAlpha,
+        source: String(c.color),
+        sourceRank: 1,
         label: '',
         type: 'palette',
         confidence: c.confidence,
@@ -216,6 +223,12 @@ function displayColors(colors) {
           existing.label = `${existing.label}, ${color.label}`;
         }
       }
+      // A declared custom property is the only true authored notation, so it
+      // outranks a computed value when both collapse to the same hex.
+      if (color.source && (color.sourceRank || 0) > (existing.sourceRank || 0)) {
+        existing.source = color.source;
+        existing.sourceRank = color.sourceRank;
+      }
       // Keep highest confidence
       const confidenceOrder = { high: 3, medium: 2, low: 1 };
       if (confidenceOrder[color.confidence] > confidenceOrder[existing.confidence]) {
@@ -230,7 +243,19 @@ function displayColors(colors) {
 
   // Display each color on a single line: swatch, hex, role, rgb, oklch.
   // lch is omitted here for compactness but remains in JSON output.
-  uniqueColors.forEach(({ hex, rgb, label, confidence, role, onColor, hover }, index) => {
+  const primaryOf = (c) => {
+    const notations = { hex: c.hex, rgb: c.rgb, lch: c.lch, oklch: c.oklch, source: c.source || c.hex };
+    return notations[colorFormat] || c.hex;
+  };
+  const primaryWidth = Math.max(7, ...uniqueColors.map((c) => primaryOf(c).length));
+
+  uniqueColors.forEach((entry, index) => {
+    const { hex, rgb, label, confidence, role, onColor, hover } = entry;
+    // Primary column follows --color-format; the swatch stays on hex because
+    // chalk.bgHex needs one, and the identity column must remain stable.
+    const primary = primaryOf(entry).padEnd(primaryWidth);
+    // Secondary dim column never repeats the primary notation.
+    const secondary = colorFormat === 'rgb' ? hex : rgb;
     const isLast = index === uniqueColors.length - 1;
     const branch = isLast ? '└─' : '├─';
 
@@ -257,13 +282,13 @@ function displayColors(colors) {
     // extend and push the rgb column right rather than getting clipped.
     const rawLabel = label || (role && role !== 'palette' ? role : '');
     const labelText = chalk.dim(rawLabel.length > 15 ? rawLabel + ' ' : rawLabel.padEnd(15));
-    const rgbText = chalk.dim((rgb || '').padEnd(20));
+    const rgbText = chalk.dim((secondary || '').padEnd(20));
 
     const hoverText = (hover && role === 'accent') ? chalk.dim(` hover:${hover}`) : '';
 
     console.log(
       chalk.dim(`│  ${branch}`) + ' ' +
-      `${conf} ${swatch} ${hex}  ` +
+      `${conf} ${swatch} ${primary}  ` +
       labelText + ' ' +
       rgbText +
       onSwatch +

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -8,7 +8,7 @@ import type { BrandingResult } from '../types.js';
 
 import chalk from 'chalk';
 import { color } from './theme.js';
-import { convertColor } from '../colors.js';
+import { convertColor, formatColor } from '../colors.js';
 import type { ColorFormat } from '../colors.js';
 
 /**
@@ -284,7 +284,10 @@ function displayColors(colors, colorFormat: ColorFormat = 'hex') {
     const labelText = chalk.dim(rawLabel.length > 15 ? rawLabel + ' ' : rawLabel.padEnd(15));
     const rgbText = chalk.dim((secondary || '').padEnd(20));
 
-    const hoverText = (hover && role === 'accent') ? chalk.dim(` hover:${hover}`) : '';
+    // Derived states follow the same notation as the colour they belong to.
+    const hoverText = (hover && role === 'accent')
+      ? chalk.dim(` hover:${formatColor(hover, colorFormat === 'source' ? 'hex' : colorFormat)}`)
+      : '';
 
     console.log(
       chalk.dim(`│  ${branch}`) + ' ' +

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -128,6 +128,7 @@ function normalizeColorFormat(colorString) {
 }
 
 function displayColors(colors, colorFormat: ColorFormat = 'hex') {
+  if (!colors) return;
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Colors'));
 
   // All colors in one list with consistent formatting
@@ -310,6 +311,7 @@ function displayColors(colors, colorFormat: ColorFormat = 'hex') {
 }
 
 function displayTypography(typography) {
+  if (!typography) return;
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Typography'));
 
   // Font sources with font-display
@@ -402,18 +404,24 @@ function displayTypography(typography) {
 }
 
 function displaySpacing(spacing) {
+  // Sections degrade to silence rather than crashing the whole render: a payload
+  // can reach here from a merge, the MCP tools or an App round trip, not just
+  // from a fresh extraction where the extractor guarantees the shape.
+  if (!spacing) return;
+  const values = Array.isArray(spacing.commonValues) ? spacing.commonValues : [];
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Spacing'));
-  console.log(chalk.dim('│  ├─') + ' ' + chalk.dim(`System: ${spacing.scaleType}`));
-  spacing.commonValues.slice(0, 15).forEach((v, index) => {
-    const isLast = index === Math.min(spacing.commonValues.length, 15) - 1;
+  console.log(chalk.dim('│  ├─') + ' ' + chalk.dim(`System: ${spacing.scaleType ?? 'unknown'}`));
+  values.slice(0, 15).forEach((v, index) => {
+    const isLast = index === Math.min(values.length, 15) - 1;
     const branch = isLast ? '└─' : '├─';
-    console.log(chalk.dim(`│  ${branch}`) + ' ' + `${v.px.padEnd(8)} ${chalk.dim(v.rem)}`);
+    // px is typed string | number; a merged payload can carry the number.
+    console.log(chalk.dim(`│  ${branch}`) + ' ' + `${String(v.px ?? '').padEnd(8)} ${chalk.dim(v.rem ?? '')}`);
   });
   console.log(chalk.dim('│'));
 }
 
 function displayBorderRadius(borderRadius) {
-  if (!borderRadius || borderRadius.values.length === 0) return;
+  if (!borderRadius || !Array.isArray(borderRadius.values) || borderRadius.values.length === 0) return;
 
   const highConfRadius = borderRadius.values.filter(r => r.confidence === 'high' || r.confidence === 'medium');
   if (highConfRadius.length === 0) return;
@@ -1034,19 +1042,25 @@ function displayFrameworks(frameworks) {
 }
 
 function displayMotion(motion) {
-  if (!motion || (motion.durations.length === 0 && motion.animations.length === 0)) return;
+  if (!motion) return;
+  // Defensive: a payload can arrive from a merge, the MCP tools or an older
+  // extraction where one of these lists is absent.
+  const durations = Array.isArray(motion.durations) ? motion.durations : [];
+  const easings = Array.isArray(motion.easings) ? motion.easings : [];
+  const animations = Array.isArray(motion.animations) ? motion.animations : [];
+  if (durations.length === 0 && animations.length === 0) return;
 
   console.log(chalk.dim('├─') + ' ' + chalk.bold('Motion'));
 
   // Duration scale
-  if (motion.durations.length > 0) {
-    const vals = motion.durations.map(d => chalk.bold(d.value)).join('  ');
+  if (durations.length > 0) {
+    const vals = durations.map(d => chalk.bold(d.value ?? d)).join('  ');
     console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Scale  ') + vals);
   }
 
   // Dominant easing
-  if (motion.easings.length > 0) {
-    const top = motion.easings[0];
+  if (easings.length > 0) {
+    const top = easings[0];
     const typeLabel = top.type && top.type !== 'custom' ? chalk.dim(` (${top.type})`) : '';
     console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Easing ') + top.value + typeLabel);
   }
@@ -1056,7 +1070,7 @@ function displayMotion(motion) {
   if (ctxEntries.length > 0) {
     console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('By context'));
     ctxEntries.forEach(([ctx, v], i) => {
-      const isLast = i === ctxEntries.length - 1 && (motion.interactiveDeltas || []).length === 0 && motion.animations.length === 0;
+      const isLast = i === ctxEntries.length - 1 && (motion.interactiveDeltas || []).length === 0 && animations.length === 0;
       const branch = isLast ? '└─' : '├─';
       const dur = v.durations.join(' / ');
       const easingLabel = v.easingType && v.easingType !== 'custom' ? ` · ${v.easingType}` : '';
@@ -1076,7 +1090,7 @@ function displayMotion(motion) {
     const unique = Array.from(seen.values());
     console.log(chalk.dim('│  ├─') + ' ' + chalk.dim('Hover patterns'));
     unique.slice(0, 6).forEach((d, i) => {
-      const isLast = i === Math.min(unique.length, 6) - 1 && motion.animations.length === 0;
+      const isLast = i === Math.min(unique.length, 6) - 1 && animations.length === 0;
       const branch = isLast ? '└─' : '├─';
       const label = d.text ? chalk.dim(` "${d.text}"`) : '';
       console.log(chalk.dim(`│  │  ${branch}`) + ' ' + chalk.bold(d.pattern) + chalk.dim(` ${d.tag}`) + label);
@@ -1084,10 +1098,10 @@ function displayMotion(motion) {
   }
 
   // Keyframe animations
-  if (motion.animations.length > 0) {
+  if (animations.length > 0) {
     console.log(chalk.dim('│  └─') + ' ' + chalk.dim('Keyframes'));
-    motion.animations.slice(0, 6).forEach((a, i) => {
-      const isLast = i === Math.min(motion.animations.length, 6) - 1;
+    animations.slice(0, 6).forEach((a, i) => {
+      const isLast = i === Math.min(animations.length, 6) - 1;
       const branch = isLast ? '└─' : '├─';
       const dur = a.duration ? chalk.dim(` ${a.duration}`) : '';
       const ctx = a.contexts?.length ? chalk.dim(` [${a.contexts.join(', ')}]`) : '';
@@ -1111,8 +1125,13 @@ function displayWcag(wcag) {
   const all = [...passing.slice(0, 5), ...failing.slice(0, 3)];
 
   function renderPair(pair, branch) {
-    const fgSwatch = chalk.bgHex(pair.fg)('  ');
-    const bgSwatch = chalk.bgHex(pair.bg)('  ');
+    // chalk.bgHex throws on anything that is not a hex string, and a pair can
+    // arrive from an older extraction or a hand-built payload without one.
+    const swatch = (v) => {
+      try { return chalk.bgHex(v)('  '); } catch { return '  '; }
+    };
+    const fgSwatch = swatch(pair.fg);
+    const bgSwatch = swatch(pair.bg);
     const grade = pair.aaa
       ? color.success('AAA')
       : pair.aa

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,14 +18,42 @@ export interface PaletteColor {
   /** CSS class/id sources */
   sources?: string[];
   confidence: Confidence;
+  /** Declared as a :root custom property, i.e. carries author provenance */
+  isToken?: boolean;
+  /** 'surface' | 'neutral' | 'accent', derived from saturation and confidence */
+  role?: string;
+  /** Best-contrast foreground for this colour */
+  onColor?: string;
+  /** Derived interactive-state variant, always toward better contrast */
+  hover?: string;
+  /** Set to 'primary' when this is an alpha/lightness variant of the primary */
+  variantOf?: string | null;
+  /** Precomputed notations of `normalized`; see convertColor() */
+  lch?: string;
+  oklch?: string;
+}
+
+/**
+ * A declared CSS custom property. `value` is the author's string verbatim, which
+ * is the only surviving provenance of the authored notation; the rest are
+ * computed from it so consumers never have to parse modern colour functions.
+ */
+export interface CssVariable {
+  value: string;
+  hex?: string;
+  lch?: string;
+  oklch?: string;
 }
 
 export interface Colors {
   palette: PaletteColor[];
   /** e.g. { primary: '#hex' } */
   semantic: Record<string, string>;
-  /** CSS custom properties */
-  cssVariables: Record<string, string>;
+  /**
+   * CSS custom properties. Older extractions carry a bare colour string; current
+   * ones carry a CssVariable object, so consumers must handle both.
+   */
+  cssVariables: Record<string, string | CssVariable>;
   rawColors?: PaletteColor[];
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -41,3 +41,24 @@ test('the missing-engine hint names the engine so the fix actually applies', asy
   assert.match(new PlaywrightMissingError('firefox').message, /install-browser firefox/);
   assert.match(new PlaywrightMissingError().message, /install-browser chromium/);
 });
+
+test('--color-format rejects an unknown notation with the valid values listed', () => {
+  const r = run(['dembrandt.com', '--color-format=hsl']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--color-format/);
+  for (const f of ['hex', 'rgb', 'oklch', 'lch', 'source']) {
+    assert.ok(r.stderr.includes(f), `${f} missing from the error: ${r.stderr}`);
+  }
+});
+
+test('--color-format appears in --help with its accepted values', () => {
+  const r = run(['--help']);
+  assert.match(r.stdout, /--color-format/);
+  assert.match(r.stdout, /hex\|rgb\|oklch\|lch\|source/);
+});
+
+test('--color-format is case-insensitive', () => {
+  // Validation lowercases before the check, so OKLCH must not be a hard error.
+  const r = run(['--color-format=OKLCH', '--help']);
+  assert.equal(r.status, 0);
+});

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -137,3 +137,23 @@ test('rendering never mutates the extraction payload', () => {
     assert.equal(JSON.stringify(COLORS), before, `${f} mutated the payload`);
   }
 });
+
+test('derived hover states follow the selected notation', () => {
+  const withHover: Colors = {
+    ...COLORS,
+    palette: [{ ...COLORS.palette[0], role: 'accent', hover: '#6f7e89' }],
+  };
+  const original = COLORS.palette;
+  try {
+    (COLORS as Colors).palette = withHover.palette;
+    const oklch = colorLines(render('oklch')).find((l) => l.includes('hover:'));
+    assert.ok(oklch, 'no hover row rendered');
+    assert.ok(oklch.includes('hover:oklch('), oklch);
+    // 'source' has no authored form for a derived value, so it degrades to hex
+    // rather than inventing provenance.
+    const src = colorLines(render('source')).find((l) => l.includes('hover:'));
+    assert.ok(src && src.includes('hover:#6f7e89'), String(src));
+  } finally {
+    (COLORS as Colors).palette = original;
+  }
+});

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { displayResults } from '../lib/formatters/terminal.js';
+import type { ColorFormat } from '../lib/colors.js';
+
+// --color-format is presentational: it selects the notation in the colour column
+// and must not alter identity, dedup, or which colours are shown.
+
+const COLORS = {
+  semantic: { primary: 'rgb(26, 115, 232)' },
+  palette: [
+    {
+      color: 'rgb(255, 210, 48)',
+      normalized: '#ffd230',
+      confidence: 'high',
+      role: 'accent',
+      oklch: 'oklch(87.81% 0.169 91.86)',
+      lch: 'lch(86.32% 78.47 85.7)',
+    },
+  ],
+  cssVariables: {
+    '--brand': {
+      value: 'oklch(57.37% 0.195 257.86)',
+      hex: '#1a73e8',
+      oklch: 'oklch(57.37% 0.195 257.86)',
+      lch: 'lch(48.77% 68.14 278.17)',
+    },
+  },
+};
+
+function render(colorFormat?: ColorFormat): string[] {
+  const data: any = {
+    url: 'https://example.test',
+    colors: COLORS,
+    typography: { styles: [], sources: {} },
+    spacing: { scaleType: 'unknown', commonValues: [] },
+    borderRadius: { values: [] },
+    borders: { combinations: [] },
+    shadows: [],
+    components: {},
+    breakpoints: [],
+    iconSystem: [],
+    frameworks: [],
+  };
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    displayResults(data, colorFormat ? { colorFormat } : {});
+  } finally {
+    console.log = original;
+  }
+  // Strip ANSI so assertions read the plain text.
+  return lines.map((l) => l.replace(/\[[0-9;]*m/g, ''));
+}
+
+const colorLines = (lines: string[]) => lines.filter((l) => l.includes('●'));
+
+test('default rendering is hex', () => {
+  const lines = colorLines(render());
+  assert.equal(lines.length, 2);
+  assert.ok(lines[0].includes('#1a73e8'), lines[0]);
+  assert.ok(lines[1].includes('#ffd230'), lines[1]);
+});
+
+test('oklch rendering replaces the primary column, not the row set', () => {
+  const lines = colorLines(render('oklch'));
+  assert.equal(lines.length, 2);
+  assert.ok(lines[0].includes('oklch(57.37% 0.195 257.86)'), lines[0]);
+  assert.ok(lines[1].includes('oklch(87.81% 0.169 91.86)'), lines[1]);
+});
+
+test('lch rendering uses the precomputed lch on each entry', () => {
+  const lines = colorLines(render('lch'));
+  assert.ok(lines[0].includes('lch(48.77% 68.14 278.17)'), lines[0]);
+  assert.ok(lines[1].includes('lch(86.32% 78.47 85.7)'), lines[1]);
+});
+
+test('rgb rendering swaps the secondary column to hex so no notation repeats', () => {
+  const lines = colorLines(render('rgb'));
+  assert.ok(lines[0].includes('rgb(26, 115, 232)'), lines[0]);
+  assert.ok(lines[0].includes('#1a73e8'), lines[0]);
+  // rgb must not be printed twice on the same row.
+  assert.equal(lines[0].split('rgb(26, 115, 232)').length - 1, 1, lines[0]);
+});
+
+test('source rendering prefers the authored declaration over a computed value', () => {
+  // The semantic primary and --brand collapse to the same hex, but only the
+  // custom property carries the author's notation, so it must win the merge.
+  const lines = colorLines(render('source'));
+  assert.ok(lines[0].includes('oklch(57.37% 0.195 257.86)'), lines[0]);
+  assert.ok(lines[0].includes('primary'), lines[0]);
+  assert.ok(lines[0].includes('--brand'), lines[0]);
+});
+
+test('source falls back to hex for entries with no authored notation', () => {
+  const lines = colorLines(render('source'));
+  // The palette entry was only ever a computed rgb string; it degrades to that
+  // rather than printing an empty column.
+  assert.ok(/rgb\(255, 210, 48\)|#ffd230/.test(lines[1]), lines[1]);
+});
+
+test('every format yields the same row count and the same labels', () => {
+  const formats: ColorFormat[] = ['hex', 'rgb', 'oklch', 'lch', 'source'];
+  const rows = formats.map((f) => colorLines(render(f)));
+  for (const r of rows) assert.equal(r.length, rows[0].length);
+  for (const r of rows) {
+    assert.ok(r[0].includes('primary'), r[0]);
+    assert.ok(r[1].includes('accent'), r[1]);
+  }
+});
+
+test('the label column stays aligned regardless of notation width', () => {
+  for (const f of ['hex', 'oklch', 'lch', 'source'] as ColorFormat[]) {
+    const lines = colorLines(render(f));
+    const at = lines.map((l) => l.indexOf('primary') >= 0 ? l.indexOf('primary') : l.indexOf('accent'));
+    assert.equal(at[0], at[1], `${f}: label columns at ${at.join(' vs ')}`);
+  }
+});
+
+test('an unknown format degrades to hex instead of printing undefined', () => {
+  const lines = colorLines(render('hsl' as ColorFormat));
+  assert.ok(lines[0].includes('#1a73e8'), lines[0]);
+  assert.ok(!lines[0].includes('undefined'), lines[0]);
+});

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -16,16 +16,16 @@ const COLORS: Colors = {
       count: 12,
       confidence: 'high',
       role: 'accent',
-      oklch: 'oklch(87.81% 0.169 91.86)',
-      lch: 'lch(86.32% 78.47 85.7)',
+      oklch: 'oklch(87.8106% 0.16876 91.857)',
+      lch: 'lch(86.322% 78.467 85.705)',
     },
   ],
   cssVariables: {
     '--brand': {
-      value: 'oklch(57.37% 0.195 257.86)',
+      value: 'oklch(57.3697% 0.1946 257.858)',
       hex: '#1a73e8',
-      oklch: 'oklch(57.37% 0.195 257.86)',
-      lch: 'lch(48.77% 68.14 278.17)',
+      oklch: 'oklch(57.3697% 0.1946 257.858)',
+      lch: 'lch(48.773% 68.144 278.173)',
     },
   },
 };
@@ -69,14 +69,14 @@ test('default rendering is hex', () => {
 test('oklch rendering replaces the primary column, not the row set', () => {
   const lines = colorLines(render('oklch'));
   assert.equal(lines.length, 2);
-  assert.ok(lines[0].includes('oklch(57.37% 0.195 257.86)'), lines[0]);
-  assert.ok(lines[1].includes('oklch(87.81% 0.169 91.86)'), lines[1]);
+  assert.ok(lines[0].includes('oklch(57.3697% 0.1946 257.858)'), lines[0]);
+  assert.ok(lines[1].includes('oklch(87.8106% 0.16876 91.857)'), lines[1]);
 });
 
 test('lch rendering uses the precomputed lch on each entry', () => {
   const lines = colorLines(render('lch'));
-  assert.ok(lines[0].includes('lch(48.77% 68.14 278.17)'), lines[0]);
-  assert.ok(lines[1].includes('lch(86.32% 78.47 85.7)'), lines[1]);
+  assert.ok(lines[0].includes('lch(48.773% 68.144 278.173)'), lines[0]);
+  assert.ok(lines[1].includes('lch(86.322% 78.467 85.705)'), lines[1]);
 });
 
 test('rgb rendering swaps the secondary column to hex so no notation repeats', () => {
@@ -91,7 +91,7 @@ test('source rendering prefers the authored declaration over a computed value', 
   // The semantic primary and --brand collapse to the same hex, but only the
   // custom property carries the author's notation, so it must win the merge.
   const lines = colorLines(render('source'));
-  assert.ok(lines[0].includes('oklch(57.37% 0.195 257.86)'), lines[0]);
+  assert.ok(lines[0].includes('oklch(57.3697% 0.1946 257.858)'), lines[0]);
   assert.ok(lines[0].includes('primary'), lines[0]);
   assert.ok(lines[0].includes('--brand'), lines[0]);
 });

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -126,3 +126,14 @@ test('an unknown format degrades to hex instead of printing undefined', () => {
   assert.ok(lines[0].includes('#1a73e8'), lines[0]);
   assert.ok(!lines[0].includes('undefined'), lines[0]);
 });
+
+test('rendering never mutates the extraction payload', () => {
+  // The flag is presentational, so the JSON that drift and the ML features read
+  // must be byte-identical before and after any render.
+  const formats: ColorFormat[] = ['hex', 'rgb', 'oklch', 'lch', 'source'];
+  for (const f of formats) {
+    const before = JSON.stringify(COLORS);
+    render(f);
+    assert.equal(JSON.stringify(COLORS), before, `${f} mutated the payload`);
+  }
+});

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -157,3 +157,97 @@ test('derived hover states follow the selected notation', () => {
     (COLORS as Colors).palette = original;
   }
 });
+
+// The palette was not the only place a colour is printed. Borders and the
+// component sections render the same swatch + notation pair, and a flag that
+// governed one list and not the others reads as a bug.
+
+const COMPONENT_DATA: BrandingResult = {
+  url: 'https://example.test',
+  extractedAt: '2026-08-05T00:00:00.000Z',
+  colors: { semantic: {}, palette: [], cssVariables: {} },
+  typography: { styles: [], sources: {} },
+  spacing: { scaleType: 'unknown', commonValues: [] },
+  borderRadius: { values: [] },
+  borders: {
+    combinations: [
+      { width: '1px', style: 'solid', color: 'rgb(26, 115, 232)', confidence: 'high', elements: ['card'] },
+    ],
+  },
+  shadows: [],
+  components: {
+    buttons: [
+      {
+        confidence: 'high',
+        states: {
+          default: { backgroundColor: 'rgb(26, 115, 232)', color: 'rgb(255, 255, 255)' },
+        },
+      },
+    ],
+    badges: {
+      all: [
+        { confidence: 'high', variant: 'info', backgroundColor: 'rgb(26, 115, 232)', color: 'rgb(255, 255, 255)' },
+      ],
+    },
+    inputs: {
+      text: [
+        {
+          specificType: 'text',
+          states: { default: { backgroundColor: 'rgb(26, 115, 232)', color: 'rgb(255, 255, 255)' } },
+        },
+      ],
+    },
+    links: [
+      { color: 'rgb(26, 115, 232)', states: { default: {}, hover: { color: 'rgb(26, 115, 232)' } } },
+    ],
+  },
+  breakpoints: [],
+  iconSystem: [],
+  frameworks: [],
+} as unknown as BrandingResult;
+
+function renderComponents(colorFormat?: ColorFormat): string[] {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    displayResults(COMPONENT_DATA, colorFormat ? { colorFormat } : {});
+  } finally {
+    console.log = original;
+  }
+  return lines.map((l) => l.replace(/\[[0-9;]*m/g, ''));
+}
+
+test('borders and component sections default to hex like the palette', () => {
+  const out = renderComponents().join('\n');
+  assert.ok(out.includes('#1a73e8'), out);
+  assert.ok(!out.includes('oklch('), out);
+});
+
+test('borders and component sections follow the selected notation', () => {
+  const out = renderComponents('oklch');
+  // Every section that prints a colour must show the chosen notation.
+  for (const section of ['Borders', 'Buttons', 'Badges', 'Inputs', 'Links']) {
+    const at = out.findIndex((l) => l.includes(section));
+    assert.ok(at >= 0, `${section} section missing`);
+    const body = out.slice(at + 1, at + 12).join('\n');
+    assert.ok(body.includes('oklch('), `${section} still prints hex:\n${body}`);
+  }
+});
+
+test('component colours never repeat one notation in both columns', () => {
+  const rgb = renderComponents('rgb').filter((l) => l.includes('rgb('));
+  assert.ok(rgb.length > 0);
+  for (const line of rgb) {
+    assert.ok(/#[0-9a-f]{6}/.test(line), `secondary column should fall back to hex: ${line}`);
+  }
+});
+
+test('rendering components never mutates the extraction payload', () => {
+  const formats: ColorFormat[] = ['hex', 'rgb', 'oklch', 'lch', 'source'];
+  const before = JSON.stringify(COMPONENT_DATA);
+  for (const f of formats) {
+    renderComponents(f);
+    assert.equal(JSON.stringify(COMPONENT_DATA), before, `${f} mutated the payload`);
+  }
+});

--- a/test/color-format-display.test.ts
+++ b/test/color-format-display.test.ts
@@ -2,16 +2,18 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { displayResults } from '../lib/formatters/terminal.js';
 import type { ColorFormat } from '../lib/colors.js';
+import type { BrandingResult, Colors } from '../lib/types.js';
 
 // --color-format is presentational: it selects the notation in the colour column
 // and must not alter identity, dedup, or which colours are shown.
 
-const COLORS = {
+const COLORS: Colors = {
   semantic: { primary: 'rgb(26, 115, 232)' },
   palette: [
     {
       color: 'rgb(255, 210, 48)',
       normalized: '#ffd230',
+      count: 12,
       confidence: 'high',
       role: 'accent',
       oklch: 'oklch(87.81% 0.169 91.86)',
@@ -29,15 +31,16 @@ const COLORS = {
 };
 
 function render(colorFormat?: ColorFormat): string[] {
-  const data: any = {
+  const data: BrandingResult = {
     url: 'https://example.test',
+    extractedAt: '2026-08-05T00:00:00.000Z',
     colors: COLORS,
     typography: { styles: [], sources: {} },
     spacing: { scaleType: 'unknown', commonValues: [] },
     borderRadius: { values: [] },
     borders: { combinations: [] },
     shadows: [],
-    components: {},
+    components: { buttons: [], inputs: [], links: [], badges: [] },
     breakpoints: [],
     iconSystem: [],
     frameworks: [],

--- a/test/color-format-drift.test.ts
+++ b/test/color-format-drift.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { computeDrift } from '../lib/drift.js';
+import { formatColor, COLOR_FORMATS } from '../lib/colors.js';
+import type { ColorFormat } from '../lib/colors.js';
+
+// --color-format must never be able to fabricate drift. A baseline captured
+// while one notation was selected has to compare clean against a run captured
+// under any other, because both sides carry the same hex identity.
+
+function extraction(paletteFormat: ColorFormat) {
+  const hexes = ['#1a73e8', '#ffd230', '#0f172a'];
+  return {
+    url: 'https://example.test',
+    extractedAt: '2026-08-05T00:00:00.000Z',
+    colors: {
+      semantic: { primary: formatColor(hexes[0], paletteFormat) },
+      // `normalized` is the identity drift compares on; `color` carries whatever
+      // notation the run happened to emit.
+      palette: hexes.map((h, i) => ({
+        color: formatColor(h, paletteFormat),
+        normalized: h,
+        count: 10 - i,
+        confidence: 'high' as const,
+      })),
+      cssVariables: {},
+    },
+    typography: { styles: [], sources: {} },
+    spacing: { scaleType: 'unknown', commonValues: [] },
+    borderRadius: { values: [] },
+    borders: { combinations: [] },
+    shadows: [],
+    components: { buttons: [], inputs: [], links: [], badges: [] },
+    breakpoints: [],
+    iconSystem: [],
+    frameworks: [],
+  };
+}
+
+test('a hex baseline shows no drift against any other emitted notation', () => {
+  const baseline = extraction('hex');
+  for (const f of COLOR_FORMATS) {
+    const report = computeDrift(baseline as never, extraction(f) as never);
+    assert.equal(report.changes.filter((c) => c.category === 'color').length, 0, `${f} produced colour drift`);
+  }
+});
+
+test('drift still fires on a real colour change, so the guard is not vacuous', () => {
+  const baseline = extraction('hex');
+  const changed = extraction('hex');
+  changed.colors.palette[0].normalized = '#e81a73';
+  changed.colors.palette[0].color = '#e81a73';
+  const report = computeDrift(baseline as never, changed as never);
+  assert.ok(report.changes.some((c) => c.category === 'color'), 'expected colour drift');
+});

--- a/test/color-roundtrip.test.ts
+++ b/test/color-roundtrip.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { rgbToLch, rgbToOklch, formatLch, formatOklch, formatColor, COLOR_FORMATS } from '../lib/colors.js';
+import { parseCssColor } from '../lib/color-parse.js';
+
+// Safety net for the colour serialisers. These are exhaustive-ish sweeps rather
+// than hand-picked cases: the failure mode they exist for is a rounding change
+// that looks harmless and silently shifts every emitted colour.
+
+/** Deterministic sweep over the sRGB cube. ~40k samples, still fast. */
+function* srgbSweep() {
+  for (let r = 0; r < 256; r += 7) {
+    for (let g = 0; g < 256; g += 5) {
+      for (let b = 0; b < 256; b += 11) yield [r, g, b] as [number, number, number];
+    }
+  }
+}
+
+test('oklch() round-trips exactly across the sRGB cube', () => {
+  // A user pasting our oklch() into their stylesheet must get the colour we
+  // extracted, not one up to 6/255 away from it.
+  for (const [r, g, b] of srgbSweep()) {
+    const emitted = formatOklch(rgbToOklch(r, g, b));
+    const back = parseCssColor(emitted);
+    assert.ok(back, `unparseable: ${emitted}`);
+    assert.deepEqual(
+      { r: back.r, g: back.g, b: back.b },
+      { r, g, b },
+      `${emitted} re-parsed to ${back.r},${back.g},${back.b} from ${r},${g},${b}`,
+    );
+  }
+});
+
+test('lch() round-trips exactly across the sRGB cube', () => {
+  for (const [r, g, b] of srgbSweep()) {
+    const emitted = formatLch(rgbToLch(r, g, b));
+    const back = parseCssColor(emitted);
+    assert.ok(back, `unparseable: ${emitted}`);
+    assert.deepEqual({ r: back.r, g: back.g, b: back.b }, { r, g, b }, emitted);
+  }
+});
+
+test('achromatic colours emit hue 0 in oklch instead of float noise', () => {
+  // OKLab is defined on a D65 white point that matches sRGB's, so a grey lands
+  // on exactly zero chroma and the hue must not carry an arbitrary angle.
+  for (const v of [0, 1, 64, 128, 200, 254, 255]) {
+    const ok = formatOklch(rgbToOklch(v, v, v));
+    assert.match(ok, /^oklch\([\d.]+% 0 0\)$/, ok);
+  }
+});
+
+test('greys keep a residual chroma in lch, which is D50 and not a bug', () => {
+  // lch() is emitted at D50 as the CSS spec requires, and sRGB grey is not
+  // neutral under D50: chroma lands near 0.01-0.03 with a constant hue. Zeroing
+  // it would break the exact round trip above, so it is preserved and pinned
+  // here so nobody "fixes" it into a colour shift.
+  for (const v of [64, 128, 200, 255]) {
+    const lch = formatLch(rgbToLch(v, v, v));
+    const m = lch.match(/^lch\([\d.]+% ([\d.]+) ([\d.]+)\)$/);
+    assert.ok(m, lch);
+    assert.ok(parseFloat(m[1]) < 0.05, `chroma drifted: ${lch}`);
+    assert.ok(Math.abs(parseFloat(m[2]) - 53.346) < 0.01, `hue drifted: ${lch}`);
+  }
+});
+
+test('every format returns a non-empty string for every colour, and never throws', () => {
+  for (const [r, g, b] of srgbSweep()) {
+    const hex = `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+    for (const f of COLOR_FORMATS) {
+      const out = formatColor(hex, f);
+      assert.ok(typeof out === 'string' && out.length > 0, `${f} on ${hex}`);
+      assert.ok(!out.includes('NaN') && !out.includes('undefined'), `${f} on ${hex}: ${out}`);
+    }
+  }
+});
+
+test('alpha survives the round trip at 2-decimal fidelity', () => {
+  for (const a of [0.01, 0.1, 0.25, 0.4, 0.5, 0.75, 0.9, 0.99]) {
+    for (const f of ['rgb', 'oklch', 'lch'] as const) {
+      const emitted = formatColor(`rgba(26, 115, 232, ${a})`, f);
+      const back = parseCssColor(emitted);
+      assert.ok(back, emitted);
+      assert.ok(Math.abs(back.a - a) < 0.005, `${f}: ${emitted} gave alpha ${back.a}`);
+    }
+  }
+});
+
+test('unparseable input is echoed back, never rewritten or fabricated', () => {
+  const unparseable = ['', ' ', 'currentcolor', 'var(--x)', 'oklch()', 'oklch(NaN NaN NaN)',
+    '#', '#12345', 'rgb(1,2)', 'color(unknownspace 1 1 1)', '\n\t', 'javascript:alert(1)'];
+  for (const j of unparseable) {
+    for (const f of COLOR_FORMATS) {
+      const out = formatColor(j, f);
+      assert.equal(typeof out, 'string', `${f} on ${JSON.stringify(j)}`);
+      // The contract is echo-on-failure: unparseable input comes back verbatim
+      // so the caller can still show what the site declared. What must never
+      // happen is a fabricated value, i.e. NaN we introduced ourselves.
+      assert.equal(out, j, `${f} on ${JSON.stringify(j)} rewrote it to ${out}`);
+    }
+  }
+});
+
+test('out-of-range but valid input is clamped and gamut-mapped, not echoed', () => {
+  // These parse, so they must come back as real colours rather than verbatim.
+  assert.equal(formatColor('rgb(999,999,999)', 'hex'), '#ffffff');
+  const mapped = formatColor('oklch(200% 99 9999)', 'hex');
+  assert.match(mapped, /^#[0-9a-f]{6}$/, mapped);
+});

--- a/test/color-serialize.test.ts
+++ b/test/color-serialize.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { rgbToLch, rgbToOklch, formatLch, formatOklch, convertColor } from '../lib/colors.js';
+import { rgbToLch, rgbToOklch, formatLch, formatOklch, convertColor, formatColor, isColorFormat, COLOR_FORMATS } from '../lib/colors.js';
 import { parseCssColor } from '../lib/color-parse.js';
 
 // Pins the serialisation half of the colour engine: rgbToLch / rgbToOklch and
@@ -29,19 +29,19 @@ test('rgbToOklch: mid grey is achromatic with a residual float hue', () => {
   // emitted string is oklch(59.99% 0 89.88) and the hue channel is inert.
   const grey = rgbToOklch(128, 128, 128);
   assert.ok(grey.c < 1e-6, String(grey.c));
-  assert.equal(formatOklch(grey, undefined), 'oklch(59.99% 0 89.88)');
+  assert.equal(formatOklch(grey), 'oklch(59.99% 0 89.88)');
 });
 
 test('formatOklch: lightness as percent, chroma to 3dp, hue to 2dp', () => {
-  assert.equal(formatOklch({ l: 0.6279553606, c: 0.2576833077, h: 29.2338851 }, undefined), 'oklch(62.8% 0.258 29.23)');
-  assert.equal(formatOklch({ l: 0.8781060522, c: 0.1687623350, h: 91.8567430 }, undefined), 'oklch(87.81% 0.169 91.86)');
+  assert.equal(formatOklch({ l: 0.6279553606, c: 0.2576833077, h: 29.2338851 }), 'oklch(62.8% 0.258 29.23)');
+  assert.equal(formatOklch({ l: 0.8781060522, c: 0.1687623350, h: 91.8567430 }), 'oklch(87.81% 0.169 91.86)');
 });
 
 test('formatOklch: alpha emitted only below 1', () => {
   const red = rgbToOklch(255, 0, 0);
   assert.equal(formatOklch(red, 0.5), 'oklch(62.8% 0.258 29.23 / 0.5)');
   assert.equal(formatOklch(red, 1), 'oklch(62.8% 0.258 29.23)');
-  assert.equal(formatOklch(red, undefined), 'oklch(62.8% 0.258 29.23)');
+  assert.equal(formatOklch(red), 'oklch(62.8% 0.258 29.23)');
 });
 
 test('formatLch: alpha emitted only below 1', () => {
@@ -65,7 +65,7 @@ test('emitted oklch() re-parses to within 3 channel steps of the source', () => 
   let worst = 0;
   for (let i = 0; i < 600; i++) {
     const r = (i * 97) % 256, g = (i * 53) % 256, b = (i * 29) % 256;
-    const back = parseCssColor(formatOklch(rgbToOklch(r, g, b), undefined));
+    const back = parseCssColor(formatOklch(rgbToOklch(r, g, b)));
     assert.ok(back, `unparseable at ${r},${g},${b}`);
     worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
   }
@@ -76,7 +76,7 @@ test('emitted lch() re-parses to within 3 channel steps of the source', () => {
   let worst = 0;
   for (let i = 0; i < 600; i++) {
     const r = (i * 89) % 256, g = (i * 41) % 256, b = (i * 17) % 256;
-    const back = parseCssColor(formatLch(rgbToLch(r, g, b), undefined));
+    const back = parseCssColor(formatLch(rgbToLch(r, g, b)));
     assert.ok(back, `unparseable at ${r},${g},${b}`);
     worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
   }
@@ -126,4 +126,50 @@ test('convertColor returns null rather than a partial record', () => {
   assert.equal(convertColor('currentcolor'), null);
   assert.equal(convertColor('var(--brand)'), null);
   assert.equal(convertColor(''), null);
+});
+
+test('formatColor renders each notation from one input', () => {
+  assert.equal(formatColor('#1a73e8', 'hex'), '#1a73e8');
+  assert.equal(formatColor('#1a73e8', 'rgb'), 'rgb(26, 115, 232)');
+  assert.equal(formatColor('#1a73e8', 'oklch'), 'oklch(57.37% 0.195 257.86)');
+  assert.equal(formatColor('#1a73e8', 'lch'), 'lch(48.77% 68.14 278.17)');
+});
+
+test('formatColor defaults to hex', () => {
+  assert.equal(formatColor('rgb(26, 115, 232)'), '#1a73e8');
+});
+
+test('formatColor source returns the authored string untouched', () => {
+  // Provenance mode: no parse, no normalisation, no gamut mapping. This is what
+  // preserves a declared token like --brand: oklch(...) exactly as written.
+  assert.equal(formatColor('oklch(57.37% 0.195 257.86)', 'source'), 'oklch(57.37% 0.195 257.86)');
+  assert.equal(formatColor('#ABC', 'source'), '#ABC');
+  assert.equal(formatColor('var(--brand)', 'source'), 'var(--brand)');
+});
+
+test('formatColor returns unparseable input verbatim instead of dropping it', () => {
+  assert.equal(formatColor('currentcolor', 'oklch'), 'currentcolor');
+  assert.equal(formatColor('var(--brand)', 'hex'), 'var(--brand)');
+});
+
+test('formatColor preserves alpha in every computed notation', () => {
+  assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'rgb'), 'rgba(26, 115, 232, 0.4)');
+  assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'oklch'), 'oklch(57.37% 0.195 257.86 / 0.4)');
+  // hex is the opaque identity, so alpha is intentionally dropped there.
+  assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'hex'), '#1a73e8');
+});
+
+test('every declared format is renderable and distinct where it should be', () => {
+  const rendered = COLOR_FORMATS.map((f) => formatColor('#1a73e8', f));
+  assert.equal(rendered.length, 5);
+  for (const r of rendered) assert.ok(typeof r === 'string' && r.length > 0);
+  // source and hex coincide only because the input was already hex.
+  assert.equal(new Set(rendered).size, 4);
+});
+
+test('isColorFormat gates the CLI value', () => {
+  for (const f of COLOR_FORMATS) assert.equal(isColorFormat(f), true);
+  assert.equal(isColorFormat('HEX'), false);
+  assert.equal(isColorFormat('hsl'), false);
+  assert.equal(isColorFormat(''), false);
 });

--- a/test/color-serialize.test.ts
+++ b/test/color-serialize.test.ts
@@ -23,31 +23,33 @@ test('rgbToOklch: white is L=1 C=0, black is all zero', () => {
   assert.deepEqual(rgbToOklch(0, 0, 0), { l: 0, c: 0, h: 0 });
 });
 
-test('rgbToOklch: mid grey is achromatic with a residual float hue', () => {
-  // Documented quirk, not a defect: atan2 on denormal a/b yields a stable but
-  // meaningless hue for neutrals. Harmless because chroma rounds to 0, so the
-  // emitted string is oklch(59.99% 0 89.88) and the hue channel is inert.
+test('rgbToOklch: mid grey is achromatic and the hue is pinned to 0', () => {
+  // atan2 on denormal a/b yields a stable but meaningless hue for neutrals, so
+  // the formatter pins hue to 0 whenever chroma rounds away. Without that, mid
+  // grey emitted oklch(59.99% 0 89.88) — a hue angle on a colourless colour.
   const grey = rgbToOklch(128, 128, 128);
   assert.ok(grey.c < 1e-6, String(grey.c));
-  assert.equal(formatOklch(grey), 'oklch(59.99% 0 89.88)');
+  assert.equal(formatOklch(grey), 'oklch(59.9871% 0 0)');
 });
 
-test('formatOklch: lightness as percent, chroma to 3dp, hue to 2dp', () => {
-  assert.equal(formatOklch({ l: 0.6279553606, c: 0.2576833077, h: 29.2338851 }), 'oklch(62.8% 0.258 29.23)');
-  assert.equal(formatOklch({ l: 0.8781060522, c: 0.1687623350, h: 91.8567430 }), 'oklch(87.81% 0.169 91.86)');
+test('formatOklch precision is set for a lossless sRGB round trip', () => {
+  // L to 4dp of a percent, C to 5dp, H to 3dp. Coarser rounding shifted a
+  // channel by up to 6/255 on re-parse; see color-roundtrip.test.ts.
+  assert.equal(formatOklch({ l: 0.6279553606, c: 0.2576833077, h: 29.2338851 }), 'oklch(62.7955% 0.25768 29.234)');
+  assert.equal(formatOklch({ l: 0.8781060522, c: 0.1687623350, h: 91.8567430 }), 'oklch(87.8106% 0.16876 91.857)');
 });
 
 test('formatOklch: alpha emitted only below 1', () => {
   const red = rgbToOklch(255, 0, 0);
-  assert.equal(formatOklch(red, 0.5), 'oklch(62.8% 0.258 29.23 / 0.5)');
-  assert.equal(formatOklch(red, 1), 'oklch(62.8% 0.258 29.23)');
-  assert.equal(formatOklch(red), 'oklch(62.8% 0.258 29.23)');
+  assert.equal(formatOklch(red, 0.5), 'oklch(62.7955% 0.25768 29.234 / 0.5)');
+  assert.equal(formatOklch(red, 1), 'oklch(62.7955% 0.25768 29.234)');
+  assert.equal(formatOklch(red), 'oklch(62.7955% 0.25768 29.234)');
 });
 
 test('formatLch: alpha emitted only below 1', () => {
   const red = rgbToLch(255, 0, 0);
-  assert.equal(formatLch(red, 0.5), 'lch(54.29% 106.85 40.86 / 0.5)');
-  assert.equal(formatLch(red, 1), 'lch(54.29% 106.85 40.86)');
+  assert.equal(formatLch(red, 0.5), 'lch(54.294% 106.852 40.855 / 0.5)');
+  assert.equal(formatLch(red, 1), 'lch(54.294% 106.852 40.855)');
 });
 
 test('rgbToLch: black and white anchor the L axis', () => {
@@ -58,7 +60,7 @@ test('rgbToLch: black and white anchor the L axis', () => {
   assert.ok(white.c < 0.05, String(white.c));
 });
 
-test('emitted oklch() re-parses to within 3 channel steps of the source', () => {
+test('emitted oklch() re-parses without drift (bound check; exact sweep lives in color-roundtrip)', () => {
   // Rounding in formatOklch (L 2dp, C 3dp) is lossy: a serialise/parse cycle can
   // shift a channel by up to 3/255. Pinned as a bound, because it is the reason
   // hex must stay the identity key even when oklch is the emitted form.
@@ -69,10 +71,10 @@ test('emitted oklch() re-parses to within 3 channel steps of the source', () => 
     assert.ok(back, `unparseable at ${r},${g},${b}`);
     worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
   }
-  assert.ok(worst <= 3, `max channel drift ${worst}`);
+  assert.equal(worst, 0, `max channel drift ${worst}`);
 });
 
-test('emitted lch() re-parses to within 3 channel steps of the source', () => {
+test('emitted lch() re-parses without drift (bound check; exact sweep lives in color-roundtrip)', () => {
   let worst = 0;
   for (let i = 0; i < 600; i++) {
     const r = (i * 89) % 256, g = (i * 41) % 256, b = (i * 17) % 256;
@@ -80,15 +82,15 @@ test('emitted lch() re-parses to within 3 channel steps of the source', () => {
     assert.ok(back, `unparseable at ${r},${g},${b}`);
     worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
   }
-  assert.ok(worst <= 3, `max channel drift ${worst}`);
+  assert.equal(worst, 0, `max channel drift ${worst}`);
 });
 
 test('convertColor emits all four notations for one input', () => {
   const c = convertColor('#1a73e8');
   assert.equal(c.hex, '#1a73e8');
   assert.equal(c.rgb, 'rgb(26, 115, 232)');
-  assert.equal(c.oklch, 'oklch(57.37% 0.195 257.86)');
-  assert.equal(c.lch, 'lch(48.77% 68.14 278.17)');
+  assert.equal(c.oklch, 'oklch(57.3697% 0.1946 257.858)');
+  assert.equal(c.lch, 'lch(48.773% 68.144 278.173)');
   assert.equal(c.hasAlpha, false);
 });
 
@@ -96,8 +98,8 @@ test('convertColor carries alpha into every notation', () => {
   const c = convertColor('rgba(26, 115, 232, 0.4)');
   assert.equal(c.hex, '#1a73e8');
   assert.equal(c.rgb, 'rgba(26, 115, 232, 0.4)');
-  assert.equal(c.oklch, 'oklch(57.37% 0.195 257.86 / 0.4)');
-  assert.equal(c.lch, 'lch(48.77% 68.14 278.17 / 0.4)');
+  assert.equal(c.oklch, 'oklch(57.3697% 0.1946 257.858 / 0.4)');
+  assert.equal(c.lch, 'lch(48.773% 68.144 278.173 / 0.4)');
   assert.equal(c.hasAlpha, true);
 });
 
@@ -131,8 +133,8 @@ test('convertColor returns null rather than a partial record', () => {
 test('formatColor renders each notation from one input', () => {
   assert.equal(formatColor('#1a73e8', 'hex'), '#1a73e8');
   assert.equal(formatColor('#1a73e8', 'rgb'), 'rgb(26, 115, 232)');
-  assert.equal(formatColor('#1a73e8', 'oklch'), 'oklch(57.37% 0.195 257.86)');
-  assert.equal(formatColor('#1a73e8', 'lch'), 'lch(48.77% 68.14 278.17)');
+  assert.equal(formatColor('#1a73e8', 'oklch'), 'oklch(57.3697% 0.1946 257.858)');
+  assert.equal(formatColor('#1a73e8', 'lch'), 'lch(48.773% 68.144 278.173)');
 });
 
 test('formatColor defaults to hex', () => {
@@ -154,7 +156,7 @@ test('formatColor returns unparseable input verbatim instead of dropping it', ()
 
 test('formatColor preserves alpha in every computed notation', () => {
   assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'rgb'), 'rgba(26, 115, 232, 0.4)');
-  assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'oklch'), 'oklch(57.37% 0.195 257.86 / 0.4)');
+  assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'oklch'), 'oklch(57.3697% 0.1946 257.858 / 0.4)');
   // hex is the opaque identity, so alpha is intentionally dropped there.
   assert.equal(formatColor('rgba(26, 115, 232, 0.4)', 'hex'), '#1a73e8');
 });

--- a/test/color-serialize.test.ts
+++ b/test/color-serialize.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { rgbToLch, rgbToOklch, formatLch, formatOklch, convertColor } from '../lib/colors.js';
+import { parseCssColor } from '../lib/color-parse.js';
+
+// Pins the serialisation half of the colour engine: rgbToLch / rgbToOklch and
+// their CSS formatters. Parsing is covered by color-parse.test.ts; these are the
+// emitters a --color-format flag would select between, so their current output
+// is fixed here before anything is wired on top of it.
+
+test('rgbToOklch: sRGB red matches the reference OKLCH triple', () => {
+  const red = rgbToOklch(255, 0, 0);
+  assert.ok(Math.abs(red.l - 0.62796) < 1e-4, String(red.l));
+  assert.ok(Math.abs(red.c - 0.25768) < 1e-4, String(red.c));
+  assert.ok(Math.abs(red.h - 29.2339) < 1e-3, String(red.h));
+});
+
+test('rgbToOklch: white is L=1 C=0, black is all zero', () => {
+  const white = rgbToOklch(255, 255, 255);
+  assert.ok(Math.abs(white.l - 1) < 1e-6, String(white.l));
+  assert.ok(white.c < 1e-6, String(white.c));
+
+  assert.deepEqual(rgbToOklch(0, 0, 0), { l: 0, c: 0, h: 0 });
+});
+
+test('rgbToOklch: mid grey is achromatic with a residual float hue', () => {
+  // Documented quirk, not a defect: atan2 on denormal a/b yields a stable but
+  // meaningless hue for neutrals. Harmless because chroma rounds to 0, so the
+  // emitted string is oklch(59.99% 0 89.88) and the hue channel is inert.
+  const grey = rgbToOklch(128, 128, 128);
+  assert.ok(grey.c < 1e-6, String(grey.c));
+  assert.equal(formatOklch(grey, undefined), 'oklch(59.99% 0 89.88)');
+});
+
+test('formatOklch: lightness as percent, chroma to 3dp, hue to 2dp', () => {
+  assert.equal(formatOklch({ l: 0.6279553606, c: 0.2576833077, h: 29.2338851 }, undefined), 'oklch(62.8% 0.258 29.23)');
+  assert.equal(formatOklch({ l: 0.8781060522, c: 0.1687623350, h: 91.8567430 }, undefined), 'oklch(87.81% 0.169 91.86)');
+});
+
+test('formatOklch: alpha emitted only below 1', () => {
+  const red = rgbToOklch(255, 0, 0);
+  assert.equal(formatOklch(red, 0.5), 'oklch(62.8% 0.258 29.23 / 0.5)');
+  assert.equal(formatOklch(red, 1), 'oklch(62.8% 0.258 29.23)');
+  assert.equal(formatOklch(red, undefined), 'oklch(62.8% 0.258 29.23)');
+});
+
+test('formatLch: alpha emitted only below 1', () => {
+  const red = rgbToLch(255, 0, 0);
+  assert.equal(formatLch(red, 0.5), 'lch(54.29% 106.85 40.86 / 0.5)');
+  assert.equal(formatLch(red, 1), 'lch(54.29% 106.85 40.86)');
+});
+
+test('rgbToLch: black and white anchor the L axis', () => {
+  const black = rgbToLch(0, 0, 0);
+  assert.ok(Math.abs(black.l) < 1e-6, String(black.l));
+  const white = rgbToLch(255, 255, 255);
+  assert.ok(Math.abs(white.l - 100) < 1e-3, String(white.l));
+  assert.ok(white.c < 0.05, String(white.c));
+});
+
+test('emitted oklch() re-parses to within 3 channel steps of the source', () => {
+  // Rounding in formatOklch (L 2dp, C 3dp) is lossy: a serialise/parse cycle can
+  // shift a channel by up to 3/255. Pinned as a bound, because it is the reason
+  // hex must stay the identity key even when oklch is the emitted form.
+  let worst = 0;
+  for (let i = 0; i < 600; i++) {
+    const r = (i * 97) % 256, g = (i * 53) % 256, b = (i * 29) % 256;
+    const back = parseCssColor(formatOklch(rgbToOklch(r, g, b), undefined));
+    assert.ok(back, `unparseable at ${r},${g},${b}`);
+    worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
+  }
+  assert.ok(worst <= 3, `max channel drift ${worst}`);
+});
+
+test('emitted lch() re-parses to within 3 channel steps of the source', () => {
+  let worst = 0;
+  for (let i = 0; i < 600; i++) {
+    const r = (i * 89) % 256, g = (i * 41) % 256, b = (i * 17) % 256;
+    const back = parseCssColor(formatLch(rgbToLch(r, g, b), undefined));
+    assert.ok(back, `unparseable at ${r},${g},${b}`);
+    worst = Math.max(worst, Math.abs(back.r - r), Math.abs(back.g - g), Math.abs(back.b - b));
+  }
+  assert.ok(worst <= 3, `max channel drift ${worst}`);
+});
+
+test('convertColor emits all four notations for one input', () => {
+  const c = convertColor('#1a73e8');
+  assert.equal(c.hex, '#1a73e8');
+  assert.equal(c.rgb, 'rgb(26, 115, 232)');
+  assert.equal(c.oklch, 'oklch(57.37% 0.195 257.86)');
+  assert.equal(c.lch, 'lch(48.77% 68.14 278.17)');
+  assert.equal(c.hasAlpha, false);
+});
+
+test('convertColor carries alpha into every notation', () => {
+  const c = convertColor('rgba(26, 115, 232, 0.4)');
+  assert.equal(c.hex, '#1a73e8');
+  assert.equal(c.rgb, 'rgba(26, 115, 232, 0.4)');
+  assert.equal(c.oklch, 'oklch(57.37% 0.195 257.86 / 0.4)');
+  assert.equal(c.lch, 'lch(48.77% 68.14 278.17 / 0.4)');
+  assert.equal(c.hasAlpha, true);
+});
+
+test('convertColor: hex is alpha-stripped, so hex and rgb disagree on transparency', () => {
+  // The hex field is the opaque identity used for dedup and drift; alpha lives
+  // only in the rgb/lch/oklch forms and in hasAlpha.
+  const c = convertColor('rgba(255, 0, 0, 0.25)');
+  assert.equal(c.hex, '#ff0000');
+  assert.equal(c.rgb, 'rgba(255, 0, 0, 0.25)');
+  assert.equal(c.hasAlpha, true);
+});
+
+test('convertColor: notation of the input does not change the output', () => {
+  const forms = ['#ff0000', 'red', 'rgb(255 0 0)', 'hsl(0 100% 50%)', 'oklch(62.8% 0.258 29.23)'];
+  const emitted = forms.map((f) => convertColor(f));
+  for (const c of emitted) {
+    assert.ok(c, 'parse failed');
+    assert.equal(c.hex, '#ff0000');
+  }
+  // Every input notation collapses to one identity, which is what lets a format
+  // flag stay purely presentational.
+  assert.equal(new Set(emitted.map((c) => c.oklch)).size, 1);
+});
+
+test('convertColor returns null rather than a partial record', () => {
+  assert.equal(convertColor('currentcolor'), null);
+  assert.equal(convertColor('var(--brand)'), null);
+  assert.equal(convertColor(''), null);
+});

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -214,3 +214,159 @@ test('mergeResults sorts merged font urls so page order never reaches the output
     'https://a.test/d.woff2',
   ]);
 });
+
+// ─── Per-category union rules ────────────────────────────────────────────────
+// Everything below was previously unexercised: the crawl merge is the least
+// visible code path in the CLI (one flag, no CI coverage) and the most trusted,
+// since its output is what --save-output writes and what drift compares.
+
+test('typography styles dedup on family|size|weight and count occurrences', () => {
+  const style = (family, size, weight) => ({ context: 'body', family, size, weight });
+  const a = page('https://a.com/', { typography: { styles: [style('Inter', '16px', '400')], sources: { googleFonts: ['Inter'] } } });
+  const b = page('https://a.com/x', {
+    typography: {
+      styles: [style('Inter', '16px', '400'), style('Inter', '48px', '700')],
+      sources: { googleFonts: ['Lora'], fontDisplay: 'swap' },
+    },
+  });
+
+  const merged = mergeResults([a, b]);
+  assert.equal(merged.typography.styles.length, 2, 'identical tuples collapse');
+  const body = merged.typography.styles.find(s => s.size === '16px');
+  assert.equal(body.count, 2, 'repeat across pages is counted');
+  assert.deepEqual(merged.typography.sources.googleFonts, ['Inter', 'Lora'], 'font source arrays union');
+  assert.equal(merged.typography.sources.fontDisplay, 'swap', 'a scalar the home page lacked is adopted');
+});
+
+test('spacing values union by px and sum counts', () => {
+  const a = page('https://a.com/', { spacing: { scaleType: '8px', commonValues: [{ px: '16px', count: 4 }] } });
+  const b = page('https://a.com/x', { spacing: { scaleType: '8px', commonValues: [{ px: '16px', count: 3 }, { px: '24px', count: 9 }] } });
+
+  const merged = mergeResults([a, b]);
+  assert.equal(merged.spacing.scaleType, '8px', 'home scale type wins');
+  const px16 = merged.spacing.commonValues.find(v => v.px === '16px');
+  assert.equal(px16.count, 7);
+  assert.equal(merged.spacing.commonValues[0].px, '24px', 'sorted by count desc');
+});
+
+test('border radius confidence is recomputed from the aggregated count', () => {
+  // A value that is low-confidence on every page can be high-confidence across
+  // the site. This promotion is the whole point of crawling.
+  const a = page('https://a.com/', { borderRadius: { values: [{ value: '8px', count: 6, confidence: 'low' }] } });
+  const b = page('https://a.com/x', { borderRadius: { values: [{ value: '8px', count: 6, confidence: 'low' }] } });
+
+  const merged = mergeResults([a, b]);
+  const r = merged.borderRadius.values[0];
+  assert.equal(r.count, 12);
+  assert.equal(r.confidence, 'high', 'count > 10 promotes to high');
+});
+
+test('borders union on width|style|color, cap elements at 5 and promote confidence', () => {
+  const combo = (count, elements) => ({ width: '1px', style: 'solid', color: '#242424', count, elements, confidence: 'low' });
+  const a = page('https://a.com/', { borders: { combinations: [combo(3, ['div', 'span', 'a'])] } });
+  const b = page('https://a.com/x', { borders: { combinations: [combo(9, ['section', 'footer', 'nav'])] } });
+
+  const merged = mergeResults([a, b]);
+  const c = merged.borders.combinations[0];
+  assert.equal(c.count, 12);
+  assert.equal(c.confidence, 'high');
+  assert.equal(c.elements.length, 5, 'element list is capped');
+});
+
+test('shadows union on the shadow string and recompute confidence', () => {
+  const a = page('https://a.com/', { shadows: [{ shadow: '0 1px 2px #000', count: 2, confidence: 'low' }] });
+  const b = page('https://a.com/x', { shadows: [{ shadow: '0 1px 2px #000', count: 3, confidence: 'low' }, { shadow: '0 0 0 red', count: 1 }] });
+
+  const merged = mergeResults([a, b]);
+  assert.equal(merged.shadows.length, 2);
+  assert.equal(merged.shadows[0].count, 5);
+  assert.equal(merged.shadows[0].confidence, 'medium', 'count > 3 but <= 10');
+});
+
+test('components dedup by fingerprint and sum counts', () => {
+  const btn = (bg) => ({ variant: 'primary', backgroundColor: bg, color: '#fff', borderRadius: '8px' });
+  const a = page('https://a.com/', { components: { buttons: [btn('#1a73e8')], inputs: {}, links: [], badges: {} } });
+  const b = page('https://a.com/x', { components: { buttons: [btn('#1a73e8'), btn('#ff0000')], inputs: {}, links: [], badges: {} } });
+
+  const merged = mergeResults([a, b]);
+  assert.equal(merged.components.buttons.length, 2, 'identical buttons collapse');
+  assert.equal(merged.components.buttons[0].count, 2, 'the repeated variant leads');
+});
+
+test('grouped components keep their grouping keys through the merge', () => {
+  const inputs = { text: [{ backgroundColor: '#fff', borderColor: '#ddd' }], checkbox: [{ backgroundColor: '#fff' }] };
+  const badges = { all: [{ backgroundColor: '#ffd230' }], byVariant: { error: [{ backgroundColor: '#ff0000' }] } };
+  const a = page('https://a.com/', { components: { buttons: [], links: [], inputs, badges } });
+  const b = page('https://a.com/x', { components: { buttons: [], links: [], inputs, badges } });
+
+  const merged = mergeResults([a, b]);
+  assert.ok(Array.isArray(merged.components.inputs.text), 'text group survives');
+  assert.ok(Array.isArray(merged.components.inputs.checkbox), 'checkbox group survives');
+  assert.equal(merged.components.inputs.text[0].count, 2);
+  assert.ok(Array.isArray(merged.components.badges.byVariant.error), 'nested byVariant group survives');
+});
+
+test('icon systems and frameworks dedup by name, first occurrence wins', () => {
+  const a = page('https://a.com/', { iconSystem: [{ name: 'Heroicons', type: 'svg' }], frameworks: [{ name: 'Tailwind', confidence: 'high' }] });
+  const b = page('https://a.com/x', { iconSystem: [{ name: 'Heroicons', type: 'font' }], frameworks: [{ name: 'Tailwind', confidence: 'low' }, { name: 'MUI' }] });
+
+  const merged = mergeResults([a, b]);
+  assert.equal(merged.iconSystem.length, 1);
+  assert.equal(merged.iconSystem[0].type, 'svg', 'home page detection is kept');
+  assert.deepEqual(merged.frameworks.map(f => f.name), ['Tailwind', 'MUI']);
+});
+
+test('motion unions durations by value, easings and animations by count', () => {
+  const a = page('https://a.com/', {
+    motion: { durations: [{ value: '150ms', ms: 150, count: 1 }], easings: [{ value: 'ease-out', count: 1 }], animations: [{ name: 'fade', count: 1 }], contexts: {}, interactiveDeltas: [] },
+  });
+  const b = page('https://a.com/x', {
+    motion: { durations: [{ value: '150ms', ms: 150, count: 2 }, { value: '80ms', ms: 80, count: 1 }], easings: [{ value: 'ease-out', count: 4 }], animations: [{ name: 'fade', count: 2 }], contexts: {}, interactiveDeltas: [] },
+  });
+
+  const merged = mergeResults([a, b]);
+  assert.deepEqual(merged.motion.durations.map(d => d.value), ['80ms', '150ms'], 'durations sort fastest first');
+  assert.equal(merged.motion.durations.find(d => d.value === '150ms').count, 3);
+  assert.equal(merged.motion.easings[0].count, 5);
+  assert.equal(merged.motion.animations[0].count, 3);
+});
+
+test('wcag pairs dedup order-insensitively and state pairs stay separate', () => {
+  const a = page('https://a.com/', { wcag: [{ fg: '#fff', bg: '#000', ratio: 21, aa: true, count: 2 }] });
+  const b = page('https://a.com/x', {
+    wcag: [
+      { fg: '#000', bg: '#fff', ratio: 21, aa: true, count: 3 },
+      { fg: '#fff', bg: '#000', ratio: 21, aa: true, count: 1, source: 'state', state: 'hover', tag: 'a' },
+    ],
+  });
+
+  const merged = mergeResults([a, b]);
+  const statics = merged.wcag.filter(p => !p.source);
+  assert.equal(statics.length, 1, 'fg/bg swapped is the same pair');
+  assert.equal(statics[0].count, 5);
+  assert.equal(merged.wcag.filter(p => p.source === 'state').length, 1, 'state pair is not folded into the static one');
+  assert.equal(merged.wcag[merged.wcag.length - 1].source, 'state', 'state pairs are appended last');
+});
+
+test('gradients union on the gradient string', () => {
+  const g = { gradient: 'linear-gradient(#000, #fff)', type: 'linear-gradient', count: 1 };
+  const merged = mergeResults([
+    page('https://a.com/', { gradients: [{ ...g }] }),
+    page('https://a.com/x', { gradients: [{ ...g }] }),
+  ]);
+  assert.equal(merged.gradients.length, 1);
+  assert.equal(merged.gradients[0].count, 2);
+});
+
+test('a page missing whole sections does not break the merge', () => {
+  // Pages fail individually during a crawl and are pushed with whatever the
+  // guarded extractors returned, so absent sections are normal input here.
+  const merged = mergeResults([
+    page('https://a.com/'),
+    { url: 'https://a.com/x', extractedAt: 't' },
+  ] as never);
+  assert.equal(merged.pages.length, 2, 'both pages are recorded');
+  assert.ok(Array.isArray(merged.shadows));
+  assert.ok(Array.isArray(merged.colors.palette));
+  assert.ok(Array.isArray(merged.components.buttons));
+});

--- a/test/terminal-display.test.ts
+++ b/test/terminal-display.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { displayResults, terminalLink } from '../lib/formatters/terminal.js';
+import type { BrandingResult } from '../lib/types.js';
+
+// The terminal renderer is the only output path CI never exercises: liveness runs
+// with --json-only. These tests are that path's guard. Two jobs: every section
+// renders its data, and a partial or foreign-shaped payload degrades to silence
+// instead of taking the whole render down.
+
+function render(data: Partial<BrandingResult>): string[] {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    displayResults(data as BrandingResult);
+  } finally {
+    console.log = original;
+  }
+  return lines.map((l) => l.replace(/\[[0-9;]*m/g, ''));
+}
+
+const MINIMAL: Partial<BrandingResult> = {
+  url: 'https://example.test',
+  extractedAt: '2026-08-05T12:30:45.000Z',
+};
+
+/** Everything populated, so each section has something to print. */
+const FULL: Partial<BrandingResult> = {
+  ...MINIMAL,
+  logo: { source: 'svg', url: '/logo.svg', width: 120, height: 32, inline: true, color: '#1a73e8',
+    safeZone: { top: 8, right: 8, bottom: 8, left: 8 } } as never,
+  favicons: [{ type: 'icon', url: 'https://example.test/favicon.ico', sizes: '32x32' }],
+  colors: {
+    semantic: { primary: '#1a73e8' },
+    palette: [{ color: '#1a73e8', normalized: '#1a73e8', count: 40, confidence: 'high', role: 'accent' }],
+    cssVariables: { '--brand': { value: '#1a73e8', hex: '#1a73e8' } },
+  },
+  typography: {
+    styles: [{ context: 'heading-1', family: 'Inter', size: '48px', weight: '700', lineHeight: '1.1' }],
+    sources: { googleFonts: ['Inter', 'Lora', 'Mono', 'Extra'], fontDisplay: 'swap' },
+  } as never,
+  spacing: { scaleType: '8px', commonValues: [{ px: '16px', rem: '1rem' }] } as never,
+  borderRadius: { values: [{ value: '8px', confidence: 'high', elements: ['button', 'card'] }] } as never,
+  borders: { combinations: [{ width: '1px', style: 'solid', color: '#242424', count: 12, confidence: 'high' }] } as never,
+  shadows: [{ shadow: '0 1px 2px rgba(0,0,0,.1)', confidence: 'high', count: 9 }] as never,
+  gradients: [{ type: 'linear-gradient', stopColors: ['rgb(26, 115, 232)', 'rgb(255, 210, 48)'] }] as never,
+  motion: { durations: ['150ms'], easings: ['ease-out'], byContext: {} } as never,
+  components: {
+    buttons: [{ variant: 'primary', backgroundColor: '#1a73e8', color: '#ffffff', borderRadius: '8px', fontSize: '14px' }],
+    inputs: [{ backgroundColor: '#ffffff', borderColor: '#dddddd', borderRadius: '4px' }],
+    links: [{ color: '#1a73e8', textDecoration: 'none' }],
+    badges: { all: [{ backgroundColor: '#ffd230', color: '#000000' }], byVariant: {} },
+  } as never,
+  breakpoints: [{ px: '1024px' }, { px: '768px' }] as never,
+  iconSystem: [{ name: 'Heroicons', type: 'svg', sizes: ['24'] }] as never,
+  frameworks: [{ name: 'Tailwind', confidence: 'high', evidence: 'utility classes' }] as never,
+  wcag: [{ fg: '#ffffff', bg: '#1a73e8', ratio: 4.6, aa: true, aaa: false }] as never,
+};
+
+test('a malformed wcag pair renders without a swatch instead of throwing', () => {
+  const out = render({ ...MINIMAL, wcag: [{ ratio: 3.2, aa: false }] as never }).join('\n');
+  assert.ok(out.includes('WCAG Contrast'), out);
+  assert.ok(out.includes('✓ Complete'), out);
+});
+
+test('a full payload renders every section', () => {
+  const out = render(FULL).join('\n');
+  for (const section of ['Logo', 'Favicons', 'Colors', 'Typography', 'Spacing', 'Border Radius',
+    'Borders', 'Shadows', 'Gradients', 'Breakpoints', 'Icon System', 'Frameworks']) {
+    assert.ok(out.includes(section), `missing section: ${section}`);
+  }
+  assert.ok(out.includes('✓ Complete'), 'missing completion line');
+});
+
+test('section data reaches the output, not just the headings', () => {
+  const out = render(FULL).join('\n');
+  assert.ok(out.includes('120×32px'), 'logo dimensions');
+  assert.ok(out.includes('Safe zone: 8px 8px 8px 8px'), 'logo safe zone');
+  assert.ok(out.includes('32x32'), 'favicon size');
+  assert.ok(out.includes('Inter'), 'font family');
+  assert.ok(out.includes('font-display: swap'), 'font-display');
+  assert.ok(out.includes('System: 8px'), 'spacing scale');
+  assert.ok(out.includes('16px'), 'spacing value');
+  assert.ok(out.includes('1px solid'), 'border combination');
+  assert.ok(out.includes('0 1px 2px'), 'shadow');
+  assert.ok(out.includes('1024px'), 'breakpoint');
+  assert.ok(out.includes('Heroicons'), 'icon system');
+  assert.ok(out.includes('Tailwind'), 'framework');
+});
+
+test('a fourth font source collapses into a "+N more" line', () => {
+  const out = render(FULL).join('\n');
+  assert.ok(out.includes('+1 more'), 'expected the font overflow line');
+});
+
+test('breakpoints render largest first regardless of input order', () => {
+  const out = render(FULL).join('\n');
+  const line = out.split('\n').find((l) => l.includes('→'));
+  assert.ok(line, 'no breakpoint line');
+  assert.ok(line.indexOf('1024px') < line.indexOf('768px'), line);
+});
+
+test('a bare payload renders without a single section', () => {
+  const out = render(MINIMAL).join('\n');
+  assert.ok(out.includes('✓ Complete'), out);
+  for (const section of ['Logo', 'Colors', 'Typography', 'Spacing', 'Shadows', 'Frameworks']) {
+    assert.ok(!out.includes(section), `unexpected section on empty data: ${section}`);
+  }
+});
+
+test('each section is independently optional', () => {
+  // Drop one key at a time from the full payload: nothing may throw, and the
+  // remaining sections must still render.
+  for (const key of Object.keys(FULL).filter((k) => k !== 'url' && k !== 'extractedAt')) {
+    const partial = { ...FULL, [key]: undefined };
+    const out = render(partial).join('\n');
+    assert.ok(out.includes('✓ Complete'), `dropping ${key} broke the render`);
+  }
+});
+
+test('numeric spacing px from a merged payload does not crash the render', () => {
+  // mergeResults types px as string | number; the renderer used to call
+  // .padEnd() on it, which throws on a number.
+  const out = render({ ...FULL, spacing: { scaleType: '8px', commonValues: [{ px: 16, rem: '1rem' }] } as never });
+  assert.ok(out.join('\n').includes('16'), 'numeric px did not render');
+});
+
+test('empty arrays and empty objects are treated as no data', () => {
+  const out = render({
+    ...MINIMAL,
+    favicons: [], shadows: [], gradients: [], breakpoints: [], iconSystem: [], frameworks: [],
+    borderRadius: { values: [] } as never,
+    borders: { combinations: [] } as never,
+    colors: { semantic: {}, palette: [], cssVariables: {} },
+  }).join('\n');
+  for (const section of ['Favicons', 'Shadows', 'Gradients', 'Breakpoints', 'Icon System', 'Frameworks', 'Border Radius', 'Borders']) {
+    assert.ok(!out.includes(section), `empty ${section} still printed a heading`);
+  }
+});
+
+test('low-confidence radii, borders and shadows are filtered out', () => {
+  const out = render({
+    ...MINIMAL,
+    borderRadius: { values: [{ value: '3px', confidence: 'low' }] } as never,
+    shadows: [{ shadow: '0 0 1px red', confidence: 'low' }] as never,
+  }).join('\n');
+  assert.ok(!out.includes('Border Radius'), 'low-confidence radius leaked');
+  assert.ok(!out.includes('Shadows'), 'low-confidence shadow leaked');
+});
+
+test('a multi-page merge lists the crawled paths', () => {
+  const out = render({
+    ...FULL,
+    pages: [{ url: 'https://example.test/' }, { url: 'https://example.test/pricing' }],
+  } as never).join('\n');
+  assert.ok(out.includes('2 pages'), out);
+  assert.ok(out.includes('/pricing'), out);
+});
+
+test('a single-page result does not claim to be a crawl', () => {
+  const out = render({ ...FULL, pages: [{ url: 'https://example.test/' }] } as never).join('\n');
+  assert.ok(!out.includes('1 pages'), out);
+});
+
+test('an inline logo without a usable url still reports its source and colour', () => {
+  const out = render({ ...MINIMAL, logo: { inline: true, source: 'svg', url: '/', color: '#ff0000' } as never }).join('\n');
+  assert.ok(out.includes('inline svg'), out);
+  assert.ok(out.includes('#ff0000'), out);
+});
+
+test('terminalLink degrades to plain text when the terminal cannot hyperlink', () => {
+  const link = terminalLink('https://example.test', 'label');
+  assert.ok(link.includes('example.test') || link.includes('label'), link);
+});


### PR DESCRIPTION
Requested in a GitHub discussion: pick the output colour notation instead of converting by hand.

--color-format=hex|rgb|oklch|lch|source, default hex. lch came free, and source keeps a declared token as authored. It is presentational: the payload is untouched, hex keeps its meaning, no schema bump. Guarded by a drift-invariance test with a negative control, plus a payload-immutability test, because a display flag that moves a baseline would destroy trust in the drift gate.

The notation now covers every place the terminal prints a colour, not just the palette: borders, buttons, badges, inputs and links all render through one shared swatch-plus-notation helper. Shadows and gradients keep their authored CSS strings. The export paths (--json-only, --save-output, --dtcg, --design-md, --html, --brand-guide) do not follow the flag, the CLI warns when you combine them, and README plus docs/FLAGS.md state that scope. Types caught up with the extractor too: PaletteColor gained isToken, role, onColor, hover, variantOf, lch and oklch, and cssVariables became a record of string or CssVariable.

499 tests pass, lint clean, dogfooded on dembrandt.com in every notation.

Counterparts: dembrandt-next#114, dembrandt-skills#51. If some other display value deserves the same treatment, say which and why.
