### PR TITLE
Expose navigation HTTP status as meta.httpStatus

### DIFF
--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -442,16 +442,18 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
   try {
     let attempts = 0;
     const maxAttempts = 2;
+    let lastNavigationStatus: number | null = null;
 
     while (attempts < maxAttempts) {
       attempts++;
       spinner.text = `Navigating to ${url} (attempt ${attempts}/${maxAttempts})...`;
       try {
         const initialUrl = url;
-        await page.goto(url, {
+        const navigationResponse = await page.goto(url, {
           waitUntil: "domcontentloaded",
           timeout: (options.navigationTimeout || 20000) * timeoutMultiplier,
         });
+        lastNavigationStatus = navigationResponse ? navigationResponse.status() : null;
         const finalUrl = page.url();
 
         if (initialUrl !== finalUrl) {
@@ -1347,6 +1349,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       extractedAt: new Date().toISOString(),
       meta: {
         snapshotId: randomUUID(),
+        httpStatus: lastNavigationStatus,
         dembrandtVersion: options._version || null,
         schemaVersion: SCHEMA_VERSION,
         viewport: { width: screenW, height: screenH },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -298,6 +298,13 @@ export interface ExtractionMeta {
    * anything pinning or deduping snapshots must use this, not a time.
    */
   snapshotId?: string;
+  /**
+   * HTTP status of the page.goto() navigation response. Null when Playwright
+   * returns no response (e.g. same-document navigation). A bot wall or WAF
+   * error page still yields a syntactically valid extraction, so this is
+   * consumers' only signal to distinguish a genuine brand from an error page.
+   */
+  httpStatus?: number | null;
   /** Provenance: the CLI release that produced this. Doubles as source.cliVersion. */
   dembrandtVersion?: string | null;
   /**

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -36,6 +36,11 @@
 /**
  * dembrandt output contract version. Bump per the policy documented above.
  *
+ *  1.5.0 — meta gains httpStatus (the page.goto() navigation response status;
+ *          null when Playwright returns no response). Lets consumers reject
+ *          extractions that came from a bot-wall/WAF error page instead of
+ *          persisting a styled 403/404 as if it were the real brand.
+ *          Additive: 1.4.x consumers ignore it.
  *  1.4.0 — colors.cssVariables entries gain `hex` (parseable identity beside
  *          the authored token value, which may be a modern colour function).
  *          Additive: 1.3.x consumers ignore it. BEHAVIOR: modern CSS colour
@@ -66,7 +71,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.4.0';
+export const SCHEMA_VERSION = '1.5.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -3,7 +3,7 @@
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
     "snapshotId": "00000000-0000-4000-8000-000000000001",
-    "schemaVersion": "1.4.0",
+    "schemaVersion": "1.5.0",
     "dembrandtVersion": "0.17.0",
     "viewport": { "width": 1920, "height": 1080 },
     "fontsReady": true


### PR DESCRIPTION
## Summary
- Capture the page.goto() response status and expose it as meta.httpStatus (null when Playwright returns no response)
- Add httpStatus to ExtractionMeta type
- Bump SCHEMA_VERSION 1.4.0 -> 1.5.0 (additive)

Closes #156

## Test plan
- npm run build
- npm test (pre-existing unrelated terminal-display failures confirmed on main too)