### PR TITLE
Export dtcg-export and version subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,18 @@
       "types": "./dist/lib/dtcg/validate.d.ts",
       "default": "./dist/lib/dtcg/validate.js"
     },
+    "./dtcg-export": {
+      "types": "./dist/lib/formatters/dtcg.d.ts",
+      "require": "./dist/lib/formatters/dtcg.js",
+      "import": "./dist/lib/formatters/dtcg.js",
+      "default": "./dist/lib/formatters/dtcg.js"
+    },
+    "./version": {
+      "types": "./dist/lib/version.d.ts",
+      "require": "./dist/lib/version.js",
+      "import": "./dist/lib/version.js",
+      "default": "./dist/lib/version.js"
+    },
     "./drift": {
       "types": "./dist/lib/drift.d.ts",
       "require": "./dist/lib/drift.js",


### PR DESCRIPTION
## Summary
- Add ./dtcg-export subpath exporting toDtcgTokens (lib/formatters/dtcg.ts)
- Add ./version subpath exporting lib/version.ts (SCHEMA_VERSION, checkSchemaCompatibility, buildDembrandtProvenance, DTCG_SPEC_VERSION)

dembrandt-next currently vendors both of these (lib/dembrandt/dtcgExport.ts hardcodes its own stale SCHEMA_VERSION). This lets it import from the published package instead and delete the vendored copy.

## Test plan
- npm run build
- npm test (pre-existing unrelated terminal-display failures only)