### PR TITLE
Export colors and markdown subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,18 @@
       "types": "./dist/lib/dtcg/validate.d.ts",
       "default": "./dist/lib/dtcg/validate.js"
     },
+    "./colors": {
+      "types": "./dist/lib/colors.d.ts",
+      "require": "./dist/lib/colors.js",
+      "import": "./dist/lib/colors.js",
+      "default": "./dist/lib/colors.js"
+    },
+    "./markdown": {
+      "types": "./dist/lib/formatters/markdown.d.ts",
+      "require": "./dist/lib/formatters/markdown.js",
+      "import": "./dist/lib/formatters/markdown.js",
+      "default": "./dist/lib/formatters/markdown.js"
+    },
     "./dtcg-export": {
       "types": "./dist/lib/formatters/dtcg.d.ts",
       "require": "./dist/lib/formatters/dtcg.js",


### PR DESCRIPTION
## Summary
- Add ./colors subpath exporting lib/colors.ts
- Add ./markdown subpath exporting lib/formatters/markdown.ts (generateDesignMd)

Follow-up to #158. dembrandt-next/lib/dembrandt/ still vendors colors.js and markdown.js because neither had a public export. With these two, the vendored directory has no remaining reason to exist: drift, findings, normalize, types, dtcg-export, version, colors, markdown all cover what it duplicates.

## Test plan
- npm run build
- npm test (pre-existing unrelated terminal-display failures only)