### PR TITLE
Fix first-run dead ends: browser install hint and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ Extract a website's design system into design tokens in a few seconds: logo, col
 
 ## Install
 
-Install globally: `npm install -g dembrandt`
-
 ```bash
+npm install -g dembrandt
+dembrandt install-browser        # one-time: fetches the matching Chromium
 dembrandt dembrandt.com
 ```
 
-Or use npx without installing: `npx dembrandt dembrandt.com`
+The browser step is required. dembrandt drives Chromium through `playwright-core`,
+which ships no browser binaries, so a fresh install has nothing to launch until you
+run it. Skipping it fails with `browser engine not available`.
+
+Or use npx without installing: `npx dembrandt dembrandt.com`. The browser step applies
+here too — run `npx dembrandt install-browser` first. Browsers land in a shared
+Playwright cache, so either route only needs it once.
 
 Requires Node.js 18+
 
@@ -62,7 +68,7 @@ Load extractions, track token drift, and compare snapshots. **[dembrandt.com/app
 * **Copy tokens.** Paste values straight into Copilot, Claude, or Cursor.
 * **No login required for local use.** Data stays in the browser. Sign in with GitHub to enable cloud sync.
 
-## Recipes
+## Recipe library
 
 **[dembrandt.com/recipes](https://www.dembrandt.com/recipes)** — ready-to-run workflows. Copy a command, paste a prompt, get a result. Covers competitor benchmarking, WCAG audits, CI/CD drift detection, Figma token push, and agentic design system builds. Filterable by role.
 
@@ -136,6 +142,9 @@ Pages are fetched sequentially with polite delays. Failed pages are skipped with
 By default, dembrandt uses Chromium. If you encounter bot detection or timeouts (especially on sites behind Cloudflare), try Firefox which is often more successful at bypassing these protections:
 
 ```bash
+# One-time: install-browser defaults to chromium, so fetch firefox explicitly
+dembrandt install-browser firefox
+
 # Use Firefox instead of Chromium
 dembrandt dembrandt.com --browser=firefox
 

--- a/docs/type-model.mermaid.md
+++ b/docs/type-model.mermaid.md
@@ -28,10 +28,16 @@ classDiagram
   }
 
   class ExtractionMeta {
+    +string snapshotId
+    +number httpStatus
     +string dembrandtVersion
     +string schemaVersion
     +Record flags
+    +Viewport viewport
+    +boolean fontsReady
+    +string[] pendingFonts
     +string[] degraded
+    +ExtractorError[] errors
   }
   class Colors {
     +PaletteColor[] palette

--- a/index.ts
+++ b/index.ts
@@ -173,7 +173,7 @@ program
             // browser *binary*, which only surfaces here, as raw Playwright
             // text. Translate it into our own instruction instead.
             if (/Executable doesn't exist/i.test(launchErr?.message ?? "")) {
-              throw new PlaywrightMissingError();
+              throw new PlaywrightMissingError(opts.browser === 'firefox' ? 'firefox' : 'chromium');
             }
             throw launchErr;
           }

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -12,8 +12,13 @@
  */
 
 export class PlaywrightMissingError extends Error {
-  constructor() {
-    super('browser engine not available, run: dembrandt install-browser');
+  /**
+   * Names the engine in the recovery command. `install-browser` defaults to
+   * chromium, so a bare hint sends a `--browser firefox` user to a command that
+   * reinstalls chromium and leaves them on the identical error.
+   */
+  constructor(engine = 'chromium') {
+    super(`browser engine not available, run: dembrandt install-browser ${engine}`);
     this.name = 'PlaywrightMissingError';
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test": "npm run build && node --test dist/test/*.test.js",
     "install-browser": "node tools/install-browser.mjs",
     "dev": "tsc --watch",
-    "build": "tsc && cp package.json dist/package.json && mkdir -p dist/lib/ml && cp lib/ml/model.onnx lib/ml/meta.json dist/lib/ml/",
+    "build": "rm -rf dist && tsc && cp package.json dist/package.json && mkdir -p dist/lib/ml && cp lib/ml/model.onnx lib/ml/meta.json dist/lib/ml/",
     "lint": "eslint . --max-warnings 0",
     "liveness": "npm run build && node test/liveness.mjs sites-smoke.json",
     "release:churn": "npm run build && node tools/release-churn.mjs"

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -33,3 +33,11 @@ test('reveal is standard (no enable flag exposed)', () => {
   // Reveal runs by default; there must be no --menus/--reveal opt-in flag.
   assert.doesNotMatch(r.stdout, /--menus|--reveal\b/);
 });
+
+test('the missing-engine hint names the engine so the fix actually applies', async () => {
+  const { PlaywrightMissingError } = await import('../lib/browser.js');
+  // install-browser defaults to chromium, so a bare hint sends a firefox user
+  // to a command that reinstalls chromium and leaves the same error standing.
+  assert.match(new PlaywrightMissingError('firefox').message, /install-browser firefox/);
+  assert.match(new PlaywrightMissingError().message, /install-browser chromium/);
+});


### PR DESCRIPTION
First-run friction found while smoke-testing every flag on 0.27.0.

## 1. The missing-engine hint sent users to the wrong command
`--browser firefox` without the firefox binary threw `run: dembrandt install-browser`, which installs chromium only — retry, identical error. The hint now names the engine; `installBrowsers` already accepted targets.

## 2. The README's first example could not work
`npm install -g dembrandt` then `dembrandt dembrandt.com`, with no browser step. `playwright-core` ships no binaries and there is no `postinstall`, so a fresh install fails with `browser engine not available`. `install-browser` was documented 140 lines further down. Now front-loaded in the Install block, and noted for the npx route.

## 3. Smaller docs fixes
- Firefox section names its `install-browser firefox` prerequisite
- Duplicate `## Recipes` heading renamed to `## Recipe library` (two sections shared the name and the anchor)
- `docs/type-model.mermaid.md` `ExtractionMeta` synced: was missing `snapshotId`, `viewport`, `fontsReady`, `pendingFonts`, `errors` since schema 1.3.0, plus `httpStatus`

## Verification
- 424 pass, 0 fail; lint 0 warnings (raw exit codes)
- All 30 `--help` flags cross-checked against `docs/FLAGS.md`: complete
- `dembrandt install-browser` exit 0