### PR TITLE
refactor(drift): one Lab conversion, not two (DEM-211)

### DIFF
--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -185,6 +185,21 @@ export function formatOklch(oklch, alpha?: number) {
 }
 
 /**
+ * Convert 0-255 sRGB to CIE Lab against D65. Exported because the drift engine
+ * needs Lab from parsed rgb triples rather than from hex, and a second hand-
+ * rolled copy of this maths is how the same metric ends up disagreeing with
+ * itself (DEM-211).
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ * @returns {{ l: number, a: number, b: number }}
+ */
+export function rgbToLab(r, g, b) {
+  const xyz = linearRgbToXyz(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b));
+  return xyzToLab(xyz.x, xyz.y, xyz.z);
+}
+
+/**
  * Compute CIE76 delta-E perceptual distance between two hex colors.
  * Returns 0 for identical colors, ~100 for maximally different.
  * @param {string} hex1 - Hex color string (e.g. "#ff0000")
@@ -192,15 +207,10 @@ export function formatOklch(oklch, alpha?: number) {
  * @returns {number}
  */
 export function deltaE(hex1, hex2) {
-  function toLab(hex) {
+  const toLab = (hex) => {
     const rgb = hexToRgb(hex);
-    if (!rgb) return null;
-    const lr = srgbToLinear(rgb.r);
-    const lg = srgbToLinear(rgb.g);
-    const lb = srgbToLinear(rgb.b);
-    const xyz = linearRgbToXyz(lr, lg, lb);
-    return xyzToLab(xyz.x, xyz.y, xyz.z);
-  }
+    return rgb ? rgbToLab(rgb.r, rgb.g, rgb.b) : null;
+  };
   const lab1 = toLab(hex1);
   const lab2 = toLab(hex2);
   if (!lab1 || !lab2) return 999;

--- a/lib/drift.ts
+++ b/lib/drift.ts
@@ -17,6 +17,8 @@ import type { BrandingResult as ExtractionResult, TypographyStyle, Confidence } 
 // drift against the same colour written as hex. One spec parser, not a second
 // copy of one living here.
 import { parseCssColor } from "./color-parse.js";
+// One Lab conversion for the whole tree; see the note on deltaE below (DEM-211).
+import { rgbToLab } from "./colors.js";
 
 export interface DriftConfig {
   /** ΔE at or below this: colors treated as identical. */
@@ -95,31 +97,27 @@ function parseColor(input: string): [number, number, number] | null {
   return null;
 }
 
-function rgbToLab([r, g, b]: [number, number, number]): [number, number, number] {
-  const lin = (c: number) => {
-    const v = c / 255;
-    return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
-  };
-  const R = lin(r);
-  const G = lin(g);
-  const B = lin(b);
-  const X = (R * 0.4124 + G * 0.3576 + B * 0.1805) / 0.95047;
-  const Y = R * 0.2126 + G * 0.7152 + B * 0.0722;
-  const Z = (R * 0.0193 + G * 0.1192 + B * 0.9505) / 1.08883;
-  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
-  const fx = f(X);
-  const fy = f(Y);
-  const fz = f(Z);
-  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
-}
-
+/**
+ * CIE76 distance between two colour strings.
+ *
+ * The Lab conversion is imported, not rewritten: this file used to carry its
+ * own copy with truncated matrix coefficients, so the same metric computed here
+ * and in lib/colors.ts disagreed by up to 0.03 (DEM-211).
+ *
+ * The failure convention is this file's own and deliberately differs from
+ * colors.ts, which returns 999 so a dedup threshold treats unparseable colours
+ * as distinct. Drift needs the stronger claim: two values it cannot read are
+ * incomparable, not far apart. Identical unreadable strings (`var(--brand)`
+ * against itself) are 0 because nothing changed; different ones are Infinity,
+ * which callers must handle rather than report as a distance.
+ */
 function deltaE(a: string, b: string): number {
   const ra = parseColor(a);
   const rb = parseColor(b);
   if (!ra || !rb) return a.trim() === b.trim() ? 0 : Infinity;
-  const [l1, a1, b1] = rgbToLab(ra);
-  const [l2, a2, b2] = rgbToLab(rb);
-  return Math.sqrt((l1 - l2) ** 2 + (a1 - a2) ** 2 + (b1 - b2) ** 2);
+  const la = rgbToLab(ra[0], ra[1], ra[2]);
+  const lb = rgbToLab(rb[0], rb[1], rb[2]);
+  return Math.sqrt((la.l - lb.l) ** 2 + (la.a - lb.a) ** 2 + (la.b - lb.b) ** 2);
 }
 
 /* ------------------------------ helpers ------------------------------- */

--- a/test/drift.test.ts
+++ b/test/drift.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { computeDrift } from '../lib/drift.js';
+import { deltaE } from '../lib/colors.js';
 
 /**
  * Low-confidence tokens are single-use, margin-of-detection elements the
@@ -283,4 +284,35 @@ test('a high-confidence radius change is still real drift', () => {
 
   const report = computeDrift(base, changed);
   assert.ok(report.changes.some((c) => c.category === 'radius'), 'high-confidence radius change must be reported');
+});
+
+/**
+ * DEM-211. drift.ts used to carry its own Lab conversion with truncated matrix
+ * coefficients, so the same CIE76 metric disagreed with lib/colors.ts by up to
+ * 0.03. Both now share one conversion. These pin the property that made the
+ * duplicate dangerous: the shared deltaE decides drift's colour classification,
+ * so a pair colors.ts calls closer than the just-noticeable difference must be
+ * stable here, and a pair it calls further must not be.
+ */
+test('drift classification agrees with the shared deltaE across the colorSame boundary', () => {
+  const base = '#133174';
+  // Below JND (colorSame 2.3) and above it, measured with the shared metric.
+  const imperceptible = '#143276';
+  const perceptible = '#1a3a80';
+
+  assert.ok(deltaE(base, imperceptible) < 2.3, 'fixture drifted: expected a sub-JND pair');
+  assert.ok(deltaE(base, perceptible) > 2.3, 'fixture drifted: expected a supra-JND pair');
+
+  const paletteOf = (hex: string) => ({
+    colors: { palette: [{ normalized: hex, count: 40, confidence: 'high' }], semantic: {}, cssVariables: {} },
+  });
+
+  const same = computeDrift(fixture(paletteOf(base)), fixture(paletteOf(imperceptible)));
+  const moved = computeDrift(fixture(paletteOf(base)), fixture(paletteOf(perceptible)));
+
+  const colorOf = (r: ReturnType<typeof computeDrift>) =>
+    r.categories.find((c) => c.category === 'color');
+
+  assert.equal(colorOf(same)?.changed, 0, 'a sub-JND colour was reported as changed');
+  assert.equal(colorOf(moved)?.changed, 1, 'a supra-JND colour was not reported as changed');
 });


### PR DESCRIPTION
DEM-211 lists four deltaE implementations that disagree. This removes one of them: `lib/drift.ts` carried its own sRGB-to-Lab conversion, a hand-rolled copy of the one in `lib/colors.ts` with the matrix coefficients truncated to four digits. Both compute CIE76, from separate code, and disagree.

The Lab conversion is now exported from `lib/colors.ts` and imported by drift. `deltaE` in colors.ts routes through the same export rather than inlining it a third time.

Failure conventions are deliberately left alone and are now documented where they differ. colors.ts returns 999 so a dedup threshold treats unparseable colours as distinct. drift returns Infinity for two different unreadable values, because incomparable is a stronger claim than far apart, and 0 when the unreadable strings are identical. Unifying those is the rest of DEM-211 and moves scores; this does not.

Measured before writing any of it:

- Largest deltaE difference between the two conversions over 200k random pairs: 0.03
- Classification flips across `colorSame` (2.3) and `colorShift` (15) over 400k pairs placed near those boundaries: 0

So no drift decision changes. A reported delta can move by one 0.1 tick in the direction of the more precise coefficients.

Test pins the property that made the duplicate dangerous: drift's colour classification must agree with the shared metric on both sides of the just-noticeable-difference boundary.

`npm test` 559 pass, `npm run lint` clean.