### PR TITLE
ci(release): trusted publishing with provenance, and a publish guard that fails closed

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run the action against dembrandt.com
         id: gate

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,9 +19,9 @@ jobs:
         chunk: [0, 1, 2, 3]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-liveness-${{ matrix.chunk }}
           path: test/liveness-report.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,45 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-      - name: Publish to npm (skip if already published manually)
+      # Trusted publishing (OIDC). npm mints a short-lived credential from the
+      # `id-token: write` permission above, so there is no long-lived token in
+      # repo secrets and nothing to leak or rotate. It also attaches provenance,
+      # which lets anyone verify that this tarball was built from this commit in
+      # this workflow rather than uploaded from a laptop.
+      #
+      # Requires the package to have a trusted publisher configured on
+      # npmjs.com pointing at this repository and this workflow file. Without
+      # that, publish fails closed with an auth error, which is the correct
+      # failure: a release that cannot prove where it came from should not ship.
+      - name: Publish to npm
         run: |
-          PKG=$(node -p "require('./package.json').name + '@' + require('./package.json').version")
-          if npm view "$PKG" version --json 2>/dev/null | grep -q '"'; then
-            echo "$PKG is already on npm, skipping publish (published manually)."
-          else
-            npm publish --access public
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+
+          # Distinguish the three outcomes npm view collapses into one. Exit 0
+          # with a version means it is published; exit non-zero containing E404
+          # means it is not; anything else is the registry being unreachable,
+          # which must not be read as "already published". The previous guard
+          # grepped for a quote character, and npm prints its JSON *errors* with
+          # quotes too, so a registry hiccup silently skipped the publish while
+          # the run still reported success.
+          set +e
+          PUBLISHED=$(npm view "$NAME@$VERSION" version 2>&1)
+          CODE=$?
+          set -e
+
+          if [ $CODE -eq 0 ] && [ -n "$PUBLISHED" ]; then
+            echo "$NAME@$VERSION is already on npm, nothing to do."
+            exit 0
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          if ! printf '%s' "$PUBLISHED" | grep -q 'E404'; then
+            echo "Could not determine whether $NAME@$VERSION is published:"
+            printf '%s\n' "$PUBLISHED"
+            exit 1
+          fi
+
+          npm publish --access public --provenance
 
   sync-downstream:
     needs: publish-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [published]
 
+# One publish at a time, and never cancel one in flight. Two runs racing on the
+# same version is how a half-published state gets created: one uploads while the
+# other is still deciding whether it needs to, and both report success.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -12,9 +19,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -31,7 +38,7 @@ jobs:
       # consent.test.ts drives a real page, so the unit suite needs chromium.
       # Same cache key as smoke.yml reuses the ~100MB download.
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -85,4 +92,6 @@ jobs:
   sync-downstream:
     needs: publish-npm
     uses: ./.github/workflows/sync-skills.yml
-    secrets: inherit
+    secrets:
+      SKILLS_REPO_PAT: ${{ secrets.SKILLS_REPO_PAT }}
+      NEXT_REPO_PAT: ${{ secrets.NEXT_REPO_PAT }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 8
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -35,7 +35,7 @@ jobs:
       # consent.test.ts drives a real page, so the unit suite needs chromium.
       # Same cache key as the smoke job reuses the ~100MB download.
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -51,9 +51,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -64,7 +64,7 @@ jobs:
       # Keyed on the lockfile so a Playwright bump invalidates the cache and
       # everything else reuses the ~100MB download.
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: liveness-report
           path: test/liveness-report.json

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,7 +1,16 @@
 name: Sync downstream repos
 
 on:
+  # Secrets are declared rather than inherited. `secrets: inherit` hands a
+  # reusable workflow every secret the caller holds, including the ones it has
+  # no business seeing; naming them keeps the blast radius of this file to the
+  # two cross-repo tokens it actually uses.
   workflow_call:
+    secrets:
+      SKILLS_REPO_PAT:
+        required: true
+      NEXT_REPO_PAT:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -20,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout dembrandt-skills
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dembrandt/dembrandt-skills
           token: ${{ secrets.SKILLS_REPO_PAT }}
           path: dembrandt-skills
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -41,7 +50,7 @@ jobs:
             sed -i "s/dembrandt@[0-9][0-9.]*/dembrandt@${VERSION}/g" {} \;
 
       - name: Create PR in dembrandt-skills
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.SKILLS_REPO_PAT }}
           path: dembrandt-skills
@@ -67,13 +76,13 @@ jobs:
 
     steps:
       - name: Checkout dembrandt-next
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dembrandt/dembrandt-next
           token: ${{ secrets.NEXT_REPO_PAT }}
           path: dembrandt-next
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -92,7 +101,7 @@ jobs:
           sed -i "s/\"softwareVersion\": \"[0-9][0-9.]*\"/\"softwareVersion\": \"${VERSION}\"/" app/layout.tsx
 
       - name: Create PR in dembrandt-next
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.NEXT_REPO_PAT }}
           path: dembrandt-next

--- a/.github/workflows/tailwind-watch.yml
+++ b/.github/workflows/tailwind-watch.yml
@@ -27,9 +27,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -76,7 +76,7 @@ jobs:
       - name: Update the emitter
         id: agent
         if: (steps.check.outputs.code == '1' || steps.latest.outcome == 'failure') && env.HAS_AGENT == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1.0.200
         continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
         env:
           REPORT: ${{ steps.check.outputs.report }}
           LATEST: ${{ steps.latest.outcome }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = 'Tailwind: upstream moved, review the --tailwind export';


### PR DESCRIPTION
DEM-213, plus the workflow hardening that belongs with it. Everything here is about one property: a release should be able to prove where it came from, and should never silently not happen.

**Trusted publishing (OIDC).** The job already had `id-token: write` and a registry URL, so this drops `NODE_AUTH_TOKEN` and adds `--provenance`. npm mints a short-lived credential from the workflow identity, which removes the long-lived token from repo secrets: nothing to leak, nothing to rotate, and no dependency on a granular token in a laptop's `.npmrc`. Provenance lets an installer verify the tarball was built from this commit in this workflow.

**The publish guard was a real defect.** It was:

```bash
if npm view "$PKG" version --json 2>/dev/null | grep -q '"'; then  # skip
```

`npm view` prints its errors as JSON too, so any registry hiccup produced output containing a quote, matched the grep, skipped the publish, and let the run report success. That is the exact failure the internal checklist warns about: a GitHub release exists, npm has nothing, and downstream sync PRs open against a version that was never published.

The replacement separates the three outcomes npm collapses into one. Verified against the live registry before committing:

| case | result |
|---|---|
| `dembrandt@0.28.0` (published) | exit 0, skips |
| `dembrandt@99.99.99` (not published) | E404, publishes |
| registry unreachable | exits 1, does not skip |

**Every action pinned to a commit SHA**, with the version it resolves to in a trailing comment. Tags are mutable; the publish job holds `id-token: write`, so a moved tag on any action in that job is a path to minting an npm credential. Third-party actions (`peter-evans/create-pull-request`, `anthropics/claude-code-action`) matter most, but a uniform rule is easier to keep than a judgement call per action. Dependabot already covers the `github-actions` ecosystem monthly, so the pins do not go stale.

**`secrets: inherit` replaced with named secrets.** It handed the reusable sync workflow every secret the caller holds, including `NPM_TOKEN` and the agent credential, when it needs exactly two cross-repo PATs. Those are now declared in `sync-skills.yml` and passed explicitly.

**A concurrency group on release.** Two runs racing on the same version is how a half-published state appears: one uploads while the other is still deciding whether it needs to, and both report success. `cancel-in-progress: false`, because cancelling a publish mid-flight is worse than queueing it.

**One step is user-only and this does not work until it is done:** configure a trusted publisher for the `dembrandt` package on npmjs.com, pointing at this repository and `.github/workflows/release.yml`. Until then publish fails closed with an auth error, which is the correct failure for a release that cannot prove its origin. `NPM_TOKEN` can be revoked once a trusted publish has succeeded once.

Not done here: `design-md-watch.yml` arrives in #166 with unpinned actions and needs the same treatment after that merges. The internal release checklist still says to publish manually; that changes only once the npmjs.com side is configured and verified.