### PR TITLE
feat(voice): extract page copy by role, with deterministic tone metrics

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -84,6 +84,9 @@ program
   .option("--screenshot <path>", "Save a viewport screenshot of the page (not full-page)")
   // Internal, undocumented flag. Hidden from --help; not part of the product surface.
   .addOption(new Option("--teach").hideHelp())
+  // Hidden until the role set is validated: an undocumented opt-in flag has no
+  // consumers, so roles can still be cut without a breaking contract change.
+  .addOption(new Option("--voice").hideHelp())
   .option("--ai", "Use ML model to predict brand primary color (experimental)")
   .option("--wcag", "Analyze WCAG contrast ratios between palette colors")
   .option("--crawl [n]", "Auto-discover and extract up to N pages via DOM links (default: 5); combine with --sitemap to use sitemap discovery instead", (v: any) => {
@@ -230,6 +233,7 @@ program
             screenshotPath: opts.screenshot,
             discoverLinks: isAutoCrawl ? crawlN - 1 : null,
             wcag: opts.wcag,
+            voice: opts.voice,
             includeRawColors: opts.rawColors,
             stealth: opts.stealth,
             cookie: opts.cookie,
@@ -296,6 +300,7 @@ program
                   header: opts.header,
                   screenSize: opts.screenSize,
                   wcag: opts.wcag,
+                  voice: opts.voice,
                   includeRawColors: opts.rawColors,
                   userAgent: opts.userAgent,
                   locale: opts.locale,

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -17,6 +17,7 @@ import { guardExtractor } from './guard.js';
 import { dismissConsent } from './consent.js';
 import type { Browser, Page } from 'playwright';
 import type { ExtractOptions, BrandingResult, Spinner, ExtractorError, WcagPair } from '../types.js';
+import type { VoiceResult } from '../voice/index.js';
 
 // Gaussian noise via Box-Muller
 function gaussian(mean = 0, std = 1) {
@@ -1293,6 +1294,31 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       console.log(color.info(`💡 Tip: Try running with ${chalk.bold('--slow')} flag for more reliable results on slow-loading sites`));
     }
 
+    // Runs outside the parallel block: the 404 probe navigates, which would move
+    // the page under the other extractors.
+    let voiceResult: VoiceResult = { voice: null };
+    if (options.voice) {
+      spinner.start("Extracting voice...");
+      try {
+        const { collectVoice } = await import('../voice/index.js');
+        voiceResult = await collectVoice(page, url, { probeTimeout: 15000 * timeoutMultiplier });
+        spinner.stop();
+        if (voiceResult.voice) {
+          const { wordCount, sentenceCount } = voiceResult.voice.metrics.structural;
+          if (options.verbose) {
+            log(chalk.dim(`  voice: ${voiceResult.voice.fragments.length} fragments, ${wordCount} words, ${sentenceCount} sentences`));
+          }
+        } else if (options.verbose) {
+          log(chalk.dim(`  voice: skipped (${voiceResult.voiceSkipped})`));
+        }
+      } catch (err) {
+        spinner.stop();
+        extractorErrors.push({ stage: 'voice', reason: err instanceof Error ? err.message : String(err) });
+        // 'error', not 'no-text': a failure must not read as an empty page.
+        voiceResult = { voice: null, voiceSkipped: 'error' };
+      }
+    }
+
     let wcag: WcagPair[] = [];
     if (options.wcag) {
       spinner.start("Analyzing WCAG contrast pairs...");
@@ -1399,6 +1425,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       iconSystem,
       frameworks,
       ...(options.wcag ? { wcag } : {}),
+      ...(options.voice ? { voice: voiceResult.voice, ...(voiceResult.voiceSkipped ? { voiceSkipped: voiceResult.voiceSkipped } : {}) } : {}),
     };
 
     let isCanvasOnly = false;

--- a/lib/extractors/voice.ts
+++ b/lib/extractors/voice.ts
@@ -1,0 +1,295 @@
+import type { Page } from 'playwright';
+import type { VoiceFragment, VoiceRole } from '../types.js';
+
+const ROLE_LIMITS: Record<VoiceRole, number> = {
+  'meta-title': 1,
+  'meta-description': 1,
+  'hero-h1': 1,
+  'hero-body': 2,
+  cta: 6,
+  'nav-label': 8,
+  'section-h2': 8,
+  'section-body-lede': 6,
+  'value-prop': 3,
+  claim: 6,
+  'social-proof': 4,
+  differentiator: 2,
+  'form-label': 8,
+  'form-placeholder': 8,
+  'error-404-h1': 1,
+  'error-404-body': 2,
+  'footer-legal': 1,
+};
+
+export interface VoiceExtractionConfig {
+  roleLimits: Record<VoiceRole, number>;
+  bodyTruncateWords: number;
+  minProseWords: number;
+  errorPageOnly: boolean;
+  /** Emit selectorHint. Off by default: it is debug weight nothing consumes. */
+  debug: boolean;
+}
+
+export const DEFAULT_VOICE_CONFIG: VoiceExtractionConfig = {
+  roleLimits: ROLE_LIMITS,
+  bodyTruncateWords: 40,
+  minProseWords: 8,
+  errorPageOnly: false,
+  debug: false,
+};
+
+export async function extractVoice(
+  page: Page,
+  config: VoiceExtractionConfig = DEFAULT_VOICE_CONFIG,
+): Promise<VoiceFragment[]> {
+  return await page.evaluate((cfg: VoiceExtractionConfig) => {
+    const out: VoiceFragment[] = [];
+    const counts = new Map<VoiceRole, number>();
+    const seen = new Set<string>();
+
+    const normalize = (raw: string): string => raw.replace(/\s+/g, ' ').trim();
+    const wordsOf = (text: string): string[] => (text ? text.split(' ').filter(Boolean) : []);
+
+    const truncate = (text: string, maxWords: number): string => {
+      const words = wordsOf(text);
+      return words.length <= maxWords ? text : words.slice(0, maxWords).join(' ');
+    };
+
+    const hintFor = (el: Element): string => {
+      const tag = el.tagName.toLowerCase();
+      const id = el.id ? `#${el.id}` : '';
+      const cls = typeof el.className === 'string' && el.className
+        ? `.${el.className.trim().split(/\s+/).slice(0, 2).join('.')}`
+        : '';
+      const parent = el.parentElement ? `${el.parentElement.tagName.toLowerCase()} > ` : '';
+      return `${parent}${tag}${id}${cls}`;
+    };
+
+    const EXCLUDED_CLOSEST = [
+      '[hidden]',
+      '[aria-hidden="true"]',
+      '[data-nosnippet]',
+      'script',
+      'style',
+      'noscript',
+      'template',
+      'nav[aria-label*="readcrumb"]',
+      '[class*="cookie" i]',
+      '[class*="consent" i]',
+      '[id*="cookie" i]',
+      '[id*="consent" i]',
+      '[class*="gdpr" i]',
+      '[class*="chat-widget" i]',
+      '[class*="intercom" i]',
+      '[class*="drift-" i]',
+      '[class*="skip-link" i]',
+      '[class*="sr-only" i]',
+      '[class*="visually-hidden" i]',
+      '[class*="screen-reader" i]',
+      '[class*="pagination" i]',
+      '[class*="lang-switch" i]',
+      '[class*="language-select" i]',
+    ].join(',');
+
+    const isExcluded = (el: Element): boolean => {
+      try {
+        return el.closest(EXCLUDED_CLOSEST) !== null;
+      } catch {
+        return false;
+      }
+    };
+
+    const isVisible = (el: Element): boolean => {
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden') return false;
+      if (Number(style.opacity) === 0) return false;
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+
+    const usable = (el: Element): boolean => !isExcluded(el) && isVisible(el);
+
+    const push = (role: VoiceRole, rawText: string, el: Element | null, truncateTo?: number): void => {
+      const used = counts.get(role) ?? 0;
+      if (used >= (cfg.roleLimits[role] ?? 0)) return;
+
+      let text = normalize(rawText);
+      if (!text) return;
+      if (truncateTo) text = truncate(text, truncateTo);
+
+      const key = text.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+
+      const fragment: VoiceFragment = { role, text, order: used };
+      if (cfg.debug) fragment.selectorHint = el ? hintFor(el) : role;
+      out.push(fragment);
+      counts.set(role, used + 1);
+    };
+
+    const metaContent = (selector: string): string =>
+      document.querySelector(selector)?.getAttribute('content') ?? '';
+
+    if (!cfg.errorPageOnly) {
+      push('meta-title', document.title || metaContent('meta[property="og:title"]'), null);
+      push(
+        'meta-description',
+        metaContent('meta[name="description"]') || metaContent('meta[property="og:description"]'),
+        null,
+      );
+    }
+
+    interface Block {
+      el: Element;
+      text: string;
+      words: number;
+      fontSize: number;
+      top: number;
+      inFirstViewport: boolean;
+    }
+
+    const viewportHeight = window.innerHeight || 800;
+    const blocks: Block[] = [];
+
+    const candidates = document.querySelectorAll(
+      'h1, h2, h3, p, li, blockquote, figcaption, span, div, a, strong, em',
+    );
+
+    for (const el of Array.from(candidates)) {
+      if (!usable(el)) continue;
+
+      const hasElementChildWithText = Array.from(el.children).some(
+        (child) => (child.textContent ?? '').trim().length > 0,
+      );
+      if (hasElementChildWithText) continue;
+
+      const text = normalize(el.textContent ?? '');
+      if (!text) continue;
+
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+      const top = rect.top + window.scrollY;
+
+      blocks.push({
+        el,
+        text,
+        words: wordsOf(text).length,
+        fontSize: parseFloat(style.fontSize) || 0,
+        top,
+        inFirstViewport: top < viewportHeight,
+      });
+    }
+
+    const firstScreen = blocks.filter((b) => b.inFirstViewport);
+    const byType = [...firstScreen].sort((a, b) => b.fontSize - a.fontSize || a.top - b.top);
+    const heroHeading = byType.find((b) => b.words >= 2);
+
+    if (cfg.errorPageOnly) {
+      if (heroHeading) push('error-404-h1', heroHeading.text, heroHeading.el);
+      const errBody = firstScreen
+        .filter((b) => b.el !== heroHeading?.el && b.words >= 4)
+        .sort((a, b) => a.top - b.top);
+      for (const b of errBody) push('error-404-body', b.text, b.el, cfg.bodyTruncateWords);
+      return out;
+    }
+
+    if (heroHeading) {
+      push('hero-h1', heroHeading.text, heroHeading.el);
+
+      const heroBody = firstScreen
+        .filter((b) => b.el !== heroHeading.el)
+        .filter((b) => b.fontSize < heroHeading.fontSize && b.words >= cfg.minProseWords)
+        .sort((a, b) => a.top - b.top);
+
+      for (const b of heroBody) push('hero-body', b.text, b.el, cfg.bodyTruncateWords);
+    }
+
+    const ctaNodes = document.querySelectorAll(
+      'button, [role="button"], a.btn, a[class*="button" i], a[class*="cta" i], input[type="submit"]',
+    );
+    for (const el of Array.from(ctaNodes)) {
+      if (!usable(el)) continue;
+      const text = el instanceof HTMLInputElement ? el.value : (el.textContent ?? '');
+      const words = wordsOf(normalize(text)).length;
+      if (words < 1 || words > 8) continue;
+      push('cta', text, el);
+    }
+
+    const navRoot = document.querySelector('header nav, nav, header');
+    if (navRoot) {
+      for (const el of Array.from(navRoot.querySelectorAll('a'))) {
+        if (!usable(el)) continue;
+        const words = wordsOf(normalize(el.textContent ?? '')).length;
+        if (words < 1 || words > 5) continue;
+        push('nav-label', el.textContent ?? '', el);
+      }
+    }
+
+    const headings = Array.from(document.querySelectorAll('h2')).filter(usable);
+    for (const h of headings) push('section-h2', h.textContent ?? '', h);
+
+    const proofNodes = document.querySelectorAll(
+      'blockquote, [class*="testimonial" i], [class*="review" i], [class*="quote" i], figure figcaption',
+    );
+    for (const el of Array.from(proofNodes)) {
+      if (!usable(el)) continue;
+      push('social-proof', el.textContent ?? '', el, cfg.bodyTruncateWords);
+    }
+
+    const DIFFERENTIATOR_HEADING = /why\s+(us|choose|we)|what\s+makes|our\s+(approach|difference|promise)/i;
+    for (const h of Array.from(document.querySelectorAll('h1, h2, h3'))) {
+      if (!usable(h)) continue;
+      if (!DIFFERENTIATOR_HEADING.test(h.textContent ?? '')) continue;
+      const headingTop = h.getBoundingClientRect().top + window.scrollY;
+      const body = blocks
+        .filter((b) => b.top > headingTop && b.words >= 5)
+        .sort((a, b) => a.top - b.top)[0];
+      if (body) push('differentiator', body.text, body.el, cfg.bodyTruncateWords);
+    }
+
+    const FIRST_PERSON_CLAIM = /\b(we|our|we're|we've)\s+\w+/i;
+    for (const b of blocks) {
+      if (b.words < cfg.minProseWords) continue;
+      if (!FIRST_PERSON_CLAIM.test(b.text)) continue;
+      push('value-prop', b.text, b.el, cfg.bodyTruncateWords);
+    }
+
+    const CLAIM_PATTERN =
+      /\b(best|fastest|largest|leading|only|first|#1|no\.?\s?1|most|world['’]s|\d+x|\d{2,}[%+]|trusted by|used by|award[- ]winning)\b/i;
+    for (const b of blocks) {
+      if (b.words < 3) continue;
+      if (!CLAIM_PATTERN.test(b.text)) continue;
+      push('claim', b.text, b.el, cfg.bodyTruncateWords);
+    }
+
+    for (const h of headings) {
+      const headingTop = h.getBoundingClientRect().top + window.scrollY;
+      const lede = blocks
+        .filter((b) => b.top > headingTop && b.words >= cfg.minProseWords)
+        .sort((a, b) => a.top - b.top)[0];
+      if (lede) push('section-body-lede', lede.text, lede.el, cfg.bodyTruncateWords);
+    }
+
+    for (const el of Array.from(document.querySelectorAll('label'))) {
+      if (!usable(el)) continue;
+      push('form-label', el.textContent ?? '', el);
+    }
+
+    for (const el of Array.from(document.querySelectorAll('input[placeholder], textarea[placeholder]'))) {
+      if (!usable(el)) continue;
+      push('form-placeholder', el.getAttribute('placeholder') ?? '', el);
+    }
+
+    const footer = document.querySelector('footer');
+    if (footer) {
+      const legal = Array.from(footer.querySelectorAll('p, span, div, small')).find(
+        (el) =>
+          usable(el) &&
+          /©|copyright|all rights reserved|\bOy\b|\bAb\b|\bInc\b|\bLtd\b|\bGmbH\b/i.test(el.textContent ?? ''),
+      );
+      if (legal) push('footer-legal', legal.textContent ?? '', legal, cfg.bodyTruncateWords);
+    }
+
+    return out;
+  }, config);
+}

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -440,6 +440,14 @@ export function mergeResults(results) {
     iconSystem: mergeByName(results, r => r.iconSystem),
     frameworks: mergeByName(results, r => r.frameworks),
     ...(results.some(r => r.wcag) ? { wcag: mergeWcag(results) } : {}),
+    // Voice is deliberately NOT merged. Colours and type are tokens, so the same
+    // value on three pages is stronger evidence of one thing. Copy is not: the
+    // same CTA on three pages is one button seen three times, and averaging a
+    // marketing page's sentence length with a docs page's yields a number that
+    // describes neither. The variation between pages is the finding, so it is
+    // preserved per page and the root keeps the homepage's, as with rawColors.
+    ...(home.voice !== undefined ? { voice: home.voice } : {}),
+    ...(home.voiceSkipped ? { voiceSkipped: home.voiceSkipped } : {}),
     // rawColors are per-page filter diagnostics: merging them would destroy the
     // page provenance they exist for, so each page keeps its own set here.
     // colors.rawColors stays the first page's (via mergeColors) for back-compat.
@@ -447,6 +455,8 @@ export function mergeResults(results) {
       url: r.url,
       extractedAt: r.extractedAt,
       ...(r.colors?.rawColors ? { rawColors: r.colors.rawColors } : {}),
+      ...(r.voice !== undefined ? { voice: r.voice } : {}),
+      ...(r.voiceSkipped ? { voiceSkipped: r.voiceSkipped } : {}),
     })),
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -411,7 +411,17 @@ export interface BrandingResult {
   /** Null rather than partial when the page yields too little text to measure. */
   voice?: Voice | null;
   voiceSkipped?: VoiceSkipReason;
-  pages?: { url: string; extractedAt?: string; rawColors?: PaletteColor[] }[];
+  /**
+   * Per-page results in a multi-page run. Voice sits here rather than being
+   * merged: the variation between pages is the finding, not noise to average.
+   */
+  pages?: {
+    url: string;
+    extractedAt?: string;
+    rawColors?: PaletteColor[];
+    voice?: Voice | null;
+    voiceSkipped?: VoiceSkipReason;
+  }[];
   /**
    * CLI-emitted note about the extraction itself (e.g. canvas-only sites). This is
    * NOT a user annotation — a user note belongs in the storage envelope around the

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -408,6 +408,9 @@ export interface BrandingResult {
   iconSystem: IconSystem[];
   frameworks: Framework[];
   wcag?: WcagPair[];
+  /** Null rather than partial when the page yields too little text to measure. */
+  voice?: Voice | null;
+  voiceSkipped?: VoiceSkipReason;
   pages?: { url: string; extractedAt?: string; rawColors?: PaletteColor[] }[];
   /**
    * CLI-emitted note about the extraction itself (e.g. canvas-only sites). This is
@@ -461,6 +464,100 @@ export interface Spinner {
   info(text?: string): Spinner;
 }
 
+/**
+ * Role-labelled page copy plus deterministic metrics over it. Consumers read
+ * `fragments` + `metrics`; the CLI itself does not interpret them.
+ */
+
+/** Where a piece of copy sits on the page. */
+export type VoiceRole =
+  | 'meta-title'
+  | 'meta-description'
+  | 'hero-h1'
+  | 'hero-body'
+  | 'cta'
+  | 'nav-label'
+  | 'section-h2'
+  | 'section-body-lede'
+  | 'value-prop'
+  | 'claim'
+  | 'social-proof'
+  | 'differentiator'
+  | 'form-label'
+  | 'form-placeholder'
+  | 'error-404-h1'
+  | 'error-404-body'
+  | 'footer-legal';
+
+export interface VoiceFragment {
+  role: VoiceRole;
+  /** Normalized copy: trimmed, whitespace collapsed. Never truncated mid-word. */
+  text: string;
+  /** Document order within the role, 0-based. */
+  order: number;
+  /** Debug provenance for the source element. Only emitted with `debug`. */
+  selectorHint?: string;
+}
+
+/** Coarse page classification. Sets the word budget and role weights only. */
+export type VoicePageType = 'landing' | 'product' | 'docs' | 'contact' | 'news' | 'other';
+
+/** Why voice extraction produced nothing. Emitted instead of a partial object. */
+export type VoiceSkipReason = 'below-word-floor' | 'no-text' | 'probe-failed' | 'error';
+
+export interface PronounRatios {
+  /** "we", "our", "us" */
+  first: number;
+  /** "you", "your" */
+  second: number;
+  /** "they", "customers", "clients" */
+  third: number;
+}
+
+/**
+ * Derived from sentence and punctuation structure, not from word lists. Valid
+ * for any language that separates words with whitespace.
+ */
+export interface VoiceStructuralMetrics {
+  wordCount: number;
+  sentenceCount: number;
+  meanSentenceLength: number;
+  /** Sample standard deviation of sentence length. */
+  sentenceLengthStdev: number;
+  exclamationRatio: number;
+  questionRatio: number;
+  /** Words over three syllables, over all words. Latin-script approximation. */
+  longWordRatio: number;
+  avgSyllablesPerWord: number;
+  /** Too few words for stable sentence statistics; treat stdev as indicative. */
+  lowSample: boolean;
+}
+
+/**
+ * Language-dependent signals. Null in full outside supported languages: a zero
+ * would read as a measured "no first-person voice" rather than "not measured".
+ */
+export interface VoiceLexicalMetrics {
+  /** Pronoun stance. A closed word class, so this is counted, not guessed. */
+  personPronounRatio: PronounRatios;
+  /** Flesch reading ease, or null when the formula does not model `lang`. */
+  readability: number | null;
+}
+
+export interface VoiceMetrics {
+  structural: VoiceStructuralMetrics;
+  /** Null when `lang` is outside the supported lexicons. */
+  lexical: VoiceLexicalMetrics | null;
+  /** BCP 47 tag from html[lang], falling back to detection. */
+  lang: string;
+}
+
+export interface Voice {
+  fragments: VoiceFragment[];
+  metrics: VoiceMetrics;
+  pageType: VoicePageType;
+}
+
 /** CLI / programmatic options accepted by extractBranding(). */
 export interface ExtractOptions {
   slow?: boolean;
@@ -472,6 +569,8 @@ export interface ExtractOptions {
   reveal?: boolean;
   stealth?: boolean;
   wcag?: boolean;
+  /** Collect page copy + voice metrics. Opt-in: costs one extra navigation. */
+  voice?: boolean;
   keepAnimations?: boolean;
   verbose?: boolean;
   navigationTimeout?: number;

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -36,6 +36,11 @@
 /**
  * dembrandt output contract version. Bump per the policy documented above.
  *
+ *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in
+ *          `--voice` flag and deliberately do NOT bump the contract. An
+ *          undocumented flag has no consumers, so the role set can still be cut
+ *          after the 15-site validation sweep without that being a breaking
+ *          removal. Bump to 1.9.0 when the flag is documented, not before.
  *  1.8.0 — no shape change. BEHAVIOR: the drift engine compares colors.semantic
  *          role by role. It previously read that map only to attach role labels
  *          to palette entries, so a changed brand primary produced no drift at

--- a/lib/voice/index.ts
+++ b/lib/voice/index.ts
@@ -1,0 +1,73 @@
+import type { Page } from 'playwright';
+import type { Voice, VoiceFragment, VoiceSkipReason } from '../types.js';
+import { DEFAULT_VOICE_CONFIG, extractVoice } from '../extractors/voice.js';
+import { applyBudget, computeMetrics, totalWords, WORD_FLOOR } from './metrics.js';
+import { classifyPageType, type PageTypeSignals } from './page-type.js';
+
+export interface VoiceResult {
+  voice: Voice | null;
+  voiceSkipped?: VoiceSkipReason;
+}
+
+/**
+ * Fixed, deliberately unroutable path. A random one would change run to run on
+ * the many 404 pages that echo the requested path back, turning the fragment
+ * into drift noise. Long and specific enough that no real route collides.
+ */
+const PROBE_PATH = '/dembrandt-voice-probe-404-2f8a1c';
+
+async function readSignals(page: Page): Promise<PageTypeSignals & { lang: string }> {
+  return await page.evaluate(() => ({
+    url: window.location.href,
+    headingCount: document.querySelectorAll('h1, h2').length,
+    formCount: document.querySelectorAll('form').length,
+    hasArticle: document.querySelector('article') !== null,
+    lang: document.documentElement.getAttribute('lang') ?? '',
+  }));
+}
+
+/** Non-fatal: on failure the main page's fragments still stand. */
+async function probeErrorPage(page: Page, url: string, timeout: number): Promise<VoiceFragment[]> {
+  // A separate page in the same context: navigating the caller's page and
+  // restoring it would drop the hydration, reveal and consent state that
+  // everything downstream still reads.
+  let probe: Page | null = null;
+  try {
+    // Inside the guard: a malformed URL must not abort the whole collection.
+    const { origin } = new URL(url);
+    probe = await page.context().newPage();
+    await probe.goto(`${origin}${PROBE_PATH}`, { waitUntil: 'domcontentloaded', timeout });
+    return await extractVoice(probe, { ...DEFAULT_VOICE_CONFIG, errorPageOnly: true });
+  } catch {
+    return [];
+  } finally {
+    await probe?.close().catch(() => {});
+  }
+}
+
+export interface CollectVoiceOptions {
+  probe404?: boolean;
+  probeTimeout?: number;
+}
+
+export async function collectVoice(
+  page: Page,
+  url: string,
+  options: CollectVoiceOptions = {},
+): Promise<VoiceResult> {
+  const { probe404 = true, probeTimeout = 15000 } = options;
+
+  const signals = await readSignals(page);
+  const pageType = classifyPageType(signals);
+
+  const fragments = await extractVoice(page);
+  if (fragments.length === 0) return { voice: null, voiceSkipped: 'no-text' };
+
+  const errorFragments = probe404 ? await probeErrorPage(page, url, probeTimeout) : [];
+  const all = [...fragments, ...errorFragments];
+
+  if (totalWords(all) < WORD_FLOOR) return { voice: null, voiceSkipped: 'below-word-floor' };
+
+  const budgeted = applyBudget(all, pageType);
+  return { voice: { fragments: budgeted, metrics: computeMetrics(budgeted, signals.lang), pageType } };
+}

--- a/lib/voice/metrics.ts
+++ b/lib/voice/metrics.ts
@@ -1,0 +1,210 @@
+import type {
+  VoiceFragment,
+  VoiceLexicalMetrics,
+  VoiceMetrics,
+  VoicePageType,
+  VoiceRole,
+  VoiceStructuralMetrics,
+} from '../types.js';
+
+/**
+ * Only two lexical signals are kept: pronouns are a closed word class, and
+ * Flesch is a published formula. Hand-built word lists for hedging, commitment,
+ * urgency, jargon and imperative verbs were removed. They encoded an opinion and
+ * presented it as a measurement, and being English-only they gave a Finnish page
+ * nothing at all. That characterisation belongs to the layer reading `fragments`.
+ */
+
+/** Languages the Flesch formula models. */
+const FLESCH_LANGS = new Set(['en']);
+
+/** Languages whose pronoun sets are covered. */
+const LEXICON_LANGS = new Set(['en']);
+
+const FIRST_PERSON = /\b(we|us|our|ours|ourselves)\b/gi;
+const SECOND_PERSON = /\b(you|your|yours|yourself)\b/gi;
+const THIRD_PERSON = /\b(they|them|their|theirs|themselves|it|its)\b/gi;
+
+// Headings are labels, not sentences. Counting "Pricing" or a bare product name
+// as a sentence inflates sentenceCount and drags mean sentence length toward the
+// length of a heading rather than of the prose.
+const HEADING_ROLES: ReadonlySet<VoiceRole> = new Set<VoiceRole>([
+  'hero-h1',
+  'section-h2',
+  'error-404-h1',
+]);
+
+const SENTENCE_ROLES: ReadonlySet<VoiceRole> = new Set<VoiceRole>([
+  'meta-description',
+  'hero-body',
+  'section-body-lede',
+  'value-prop',
+  'claim',
+  'social-proof',
+  'differentiator',
+  'error-404-body',
+]);
+
+/** Vocabulary-level metrics read headings too; sentence-level ones do not. */
+const PROSE_ROLES: ReadonlySet<VoiceRole> = new Set<VoiceRole>([
+  ...HEADING_ROLES,
+  ...SENTENCE_ROLES,
+]);
+
+// Measured across real brand sites: image-led marketing pages land at 220-330
+// prose words, so a 300 floor nulls out most of them. Below LOW_SAMPLE_WORDS the
+// sentence-length statistics are noisy and metrics carry `lowSample`.
+/**
+ * Below this, emit nothing. Calibrated on English marketing pages, which yield
+ * 90-330 prose words; a 300 floor nulled out most of them. Finnish yields
+ * roughly 40% fewer words for the same content, so the floor sits closer to the
+ * per-role limits there than intended. DEM-236 settles it with real data.
+ */
+export const WORD_FLOOR = 150;
+
+/** Below this, sentence statistics are noisy and metrics carry `lowSample`. */
+export const LOW_SAMPLE_WORDS = 300;
+
+/**
+ * Upper bound on collected copy. No site measured has come close, so this is a
+ * guard against a pathological page rather than a tuned budget.
+ */
+export const WORD_CAP = 800;
+
+export const PAGE_TYPE_CAP: Record<VoicePageType, number> = {
+  landing: WORD_CAP,
+  product: WORD_CAP,
+  news: 600,
+  contact: 400,
+  docs: 400,
+  other: 600,
+};
+
+/** Drop order when over budget: lowest weight goes first. */
+const ROLE_WEIGHT: Record<VoiceRole, number> = {
+  'hero-h1': 100,
+  'meta-description': 95,
+  'hero-body': 90,
+  cta: 85,
+  'value-prop': 80,
+  'error-404-h1': 78,
+  'error-404-body': 75,
+  'form-placeholder': 70,
+  'form-label': 68,
+  claim: 65,
+  differentiator: 60,
+  'meta-title': 55,
+  'section-h2': 50,
+  'section-body-lede': 45,
+  'social-proof': 40,
+  'nav-label': 30,
+  'footer-legal': 10,
+};
+
+export const countWords = (text: string): number =>
+  text.trim() ? text.trim().split(/\s+/).length : 0;
+
+export const totalWords = (fragments: VoiceFragment[]): number =>
+  fragments.reduce((sum, f) => sum + countWords(f.text), 0);
+
+export function applyBudget(fragments: VoiceFragment[], pageType: VoicePageType): VoiceFragment[] {
+  const cap = PAGE_TYPE_CAP[pageType];
+  if (totalWords(fragments) <= cap) return fragments;
+
+  const ranked = [...fragments].sort(
+    (a, b) => (ROLE_WEIGHT[b.role] ?? 0) - (ROLE_WEIGHT[a.role] ?? 0) || a.order - b.order,
+  );
+
+  const kept: VoiceFragment[] = [];
+  let used = 0;
+  for (const f of ranked) {
+    const words = countWords(f.text);
+    if (used + words > cap) continue;
+    kept.push(f);
+    used += words;
+  }
+
+  return kept.sort(
+    (a, b) => (ROLE_WEIGHT[b.role] ?? 0) - (ROLE_WEIGHT[a.role] ?? 0) || a.order - b.order,
+  );
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((s) => s.trim())
+    .filter((s) => countWords(s) > 0);
+}
+
+/** Vowel-group heuristic, approximate; used only for ratios. */
+export function countSyllables(word: string): number {
+  const w = word.toLowerCase().replace(/[^a-zäöåüé]/g, '');
+  if (!w) return 0;
+  if (w.length <= 3) return 1;
+  const groups = w
+    .replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/, '')
+    .replace(/^y/, '')
+    .match(/[aeiouyäöå]{1,2}/g);
+  return Math.max(1, groups ? groups.length : 1);
+}
+
+const ratio = (hits: number, total: number): number =>
+  total === 0 ? 0 : Number((hits / total).toFixed(4));
+
+const matchCount = (text: string, pattern: RegExp): number => text.match(pattern)?.length ?? 0;
+
+export function computeMetrics(fragments: VoiceFragment[], lang: string): VoiceMetrics {
+  const corpus = fragments.filter((f) => PROSE_ROLES.has(f.role)).map((f) => f.text).join(' ');
+  const words = corpus.trim() ? corpus.trim().split(/\s+/) : [];
+  const wordCount = words.length;
+
+  const sentenceCorpus = fragments
+    .filter((f) => SENTENCE_ROLES.has(f.role))
+    .map((f) => f.text)
+    .join(' ');
+  const sentences = splitSentences(sentenceCorpus);
+  const sentenceLengths = sentences.map(countWords);
+  const sentenceCount = sentences.length;
+
+  const sentenceWordCount = sentenceLengths.reduce((sum, n) => sum + n, 0);
+  const mean = sentenceCount === 0 ? 0 : sentenceWordCount / sentenceCount;
+  const variance =
+    sentenceCount < 2
+      ? 0
+      : sentenceLengths.reduce((sum, n) => sum + (n - mean) ** 2, 0) / (sentenceCount - 1);
+
+  const syllables = words.reduce((sum, w) => sum + countSyllables(w), 0);
+  const avgSyllablesPerWord = wordCount === 0 ? 0 : syllables / wordCount;
+  const longWords = words.filter((w) => countSyllables(w) > 3).length;
+
+  const structural: VoiceStructuralMetrics = {
+    wordCount,
+    sentenceCount,
+    meanSentenceLength: Number(mean.toFixed(2)),
+    sentenceLengthStdev: Number(Math.sqrt(variance).toFixed(2)),
+    exclamationRatio: ratio(sentences.filter((s) => s.includes('!')).length, sentenceCount),
+    questionRatio: ratio(sentences.filter((s) => s.includes('?')).length, sentenceCount),
+    longWordRatio: ratio(longWords, wordCount),
+    avgSyllablesPerWord: Number(avgSyllablesPerWord.toFixed(3)),
+    lowSample: wordCount < LOW_SAMPLE_WORDS,
+  };
+
+  const base = lang.split('-')[0]?.toLowerCase() ?? '';
+  if (!LEXICON_LANGS.has(base)) {
+    return { structural, lexical: null, lang: lang || 'unknown' };
+  }
+
+  const lexical: VoiceLexicalMetrics = {
+    personPronounRatio: {
+      first: ratio(matchCount(corpus, FIRST_PERSON), wordCount),
+      second: ratio(matchCount(corpus, SECOND_PERSON), wordCount),
+      third: ratio(matchCount(corpus, THIRD_PERSON), wordCount),
+    },
+    readability:
+      FLESCH_LANGS.has(base) && sentenceCount > 0 && wordCount > 0
+        ? Number((206.835 - 1.015 * mean - 84.6 * avgSyllablesPerWord).toFixed(2))
+        : null,
+  };
+
+  return { structural, lexical, lang: lang || 'unknown' };
+}

--- a/lib/voice/page-type.ts
+++ b/lib/voice/page-type.ts
@@ -1,0 +1,40 @@
+/**
+ * Coarse page classification. Sets the word budget and role weights only; it
+ * never changes which roles are attempted.
+ */
+import type { VoicePageType } from '../types.js';
+
+export interface PageTypeSignals {
+  url: string;
+  headingCount: number;
+  formCount: number;
+  hasArticle: boolean;
+}
+
+const PATH_PATTERNS: ReadonlyArray<[RegExp, VoicePageType]> = [
+  [/\/(docs?|documentation|guide|api|reference|help|support|kb)(\/|$)/i, 'docs'],
+  [/\/(contact|yhteystiedot|get-in-touch|careers|jobs)(\/|$)/i, 'contact'],
+  [/\/(blog|news|articles?|press|insights|uutiset)(\/|$)/i, 'news'],
+  [/\/(product|products|services|solutions|pricing|features|palvelut)(\/|$)/i, 'product'],
+];
+
+export function classifyPageType(signals: PageTypeSignals): VoicePageType {
+  let pathname = '/';
+  try {
+    pathname = new URL(signals.url).pathname;
+  } catch {
+    pathname = signals.url;
+  }
+
+  const isRoot = pathname === '/' || pathname === '';
+  if (isRoot) return 'landing';
+
+  for (const [pattern, type] of PATH_PATTERNS) {
+    if (pattern.test(pathname)) return type;
+  }
+
+  if (signals.hasArticle && signals.headingCount <= 3) return 'news';
+  if (signals.formCount > 0 && signals.headingCount <= 2) return 'contact';
+
+  return 'other';
+}

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -372,19 +372,6 @@ test('a page missing whole sections does not break the merge', () => {
 });
 
 
-/**
- * mergeResults() is an untyped holdover from the JS migration, so its inferred
- * return does not carry the voice keys. This states what the merge is expected
- * to produce rather than reaching for `any`.
- */
-interface MergedVoiceShape {
-  voice?: { pageType: string; metrics: { structural: { meanSentenceLength: number } } } | null;
-  pages: Array<{ voice?: MergedVoiceShape['voice']; voiceSkipped?: string }>;
-}
-
-const merge = (results: unknown[]): MergedVoiceShape =>
-  mergeResults(results) as unknown as MergedVoiceShape;
-
 test('voice is preserved per page and never merged across them', () => {
   // Colours and type are tokens, so the same value on three pages is stronger
   // evidence of one thing. Copy is not: averaging a marketing page's sentence
@@ -392,24 +379,24 @@ test('voice is preserved per page and never merged across them', () => {
   const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
   const docs = page('https://a.com/docs', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 400, "sentenceCount": 4, "meanSentenceLength": 24, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "docs"} });
 
-  const merged = merge([home, docs]);
+  const merged = mergeResults([home, docs]);
 
   // Root keeps the homepage's, as with logo and colors.rawColors.
-  assert.equal(merged.voice?.pageType, 'landing');
-  assert.equal(merged.voice?.metrics.structural.meanSentenceLength, 11);
+  assert.equal(merged.voice.pageType, 'landing');
+  assert.equal(merged.voice.metrics.structural.meanSentenceLength, 11);
 
   // Both pages survive intact, so the variation between them stays readable.
   assert.equal(merged.pages.length, 2);
-  assert.equal(merged.pages[0].voice?.pageType, 'landing');
-  assert.equal(merged.pages[1].voice?.pageType, 'docs');
-  assert.equal(merged.pages[1].voice?.metrics.structural.meanSentenceLength, 24);
+  assert.equal(merged.pages[0].voice.pageType, 'landing');
+  assert.equal(merged.pages[1].voice.pageType, 'docs');
+  assert.equal(merged.pages[1].voice.metrics.structural.meanSentenceLength, 24);
 });
 
 test('a page that yielded no voice carries its reason instead of a gap', () => {
   const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
   const thin = page('https://a.com/contact', { voice: null, voiceSkipped: 'below-word-floor' });
 
-  const merged = merge([home, thin]);
+  const merged = mergeResults([home, thin]);
 
   assert.equal(merged.pages[1].voice, null);
   assert.equal(merged.pages[1].voiceSkipped, 'below-word-floor');
@@ -418,7 +405,7 @@ test('a page that yielded no voice carries its reason instead of a gap', () => {
 });
 
 test('a run without --voice gains no voice keys', () => {
-  const merged = merge([page('https://a.com/'), page('https://a.com/b')]);
+  const merged = mergeResults([page('https://a.com/'), page('https://a.com/b')]);
   assert.equal('voice' in merged, false);
   assert.equal('voice' in merged.pages[0], false);
 });

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -372,6 +372,19 @@ test('a page missing whole sections does not break the merge', () => {
 });
 
 
+/**
+ * mergeResults() is an untyped holdover from the JS migration, so its inferred
+ * return does not carry the voice keys. This states what the merge is expected
+ * to produce rather than reaching for `any`.
+ */
+interface MergedVoiceShape {
+  voice?: { pageType: string; metrics: { structural: { meanSentenceLength: number } } } | null;
+  pages: Array<{ voice?: MergedVoiceShape['voice']; voiceSkipped?: string }>;
+}
+
+const merge = (results: unknown[]): MergedVoiceShape =>
+  mergeResults(results) as unknown as MergedVoiceShape;
+
 test('voice is preserved per page and never merged across them', () => {
   // Colours and type are tokens, so the same value on three pages is stronger
   // evidence of one thing. Copy is not: averaging a marketing page's sentence
@@ -379,24 +392,24 @@ test('voice is preserved per page and never merged across them', () => {
   const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
   const docs = page('https://a.com/docs', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 400, "sentenceCount": 4, "meanSentenceLength": 24, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "docs"} });
 
-  const merged = mergeResults([home, docs]) as any;
+  const merged = merge([home, docs]);
 
   // Root keeps the homepage's, as with logo and colors.rawColors.
-  assert.equal(merged.voice.pageType, 'landing');
-  assert.equal(merged.voice.metrics.structural.meanSentenceLength, 11);
+  assert.equal(merged.voice?.pageType, 'landing');
+  assert.equal(merged.voice?.metrics.structural.meanSentenceLength, 11);
 
   // Both pages survive intact, so the variation between them stays readable.
   assert.equal(merged.pages.length, 2);
-  assert.equal(merged.pages[0].voice.pageType, 'landing');
-  assert.equal(merged.pages[1].voice.pageType, 'docs');
-  assert.equal(merged.pages[1].voice.metrics.structural.meanSentenceLength, 24);
+  assert.equal(merged.pages[0].voice?.pageType, 'landing');
+  assert.equal(merged.pages[1].voice?.pageType, 'docs');
+  assert.equal(merged.pages[1].voice?.metrics.structural.meanSentenceLength, 24);
 });
 
 test('a page that yielded no voice carries its reason instead of a gap', () => {
   const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
   const thin = page('https://a.com/contact', { voice: null, voiceSkipped: 'below-word-floor' });
 
-  const merged = mergeResults([home, thin]) as any;
+  const merged = merge([home, thin]);
 
   assert.equal(merged.pages[1].voice, null);
   assert.equal(merged.pages[1].voiceSkipped, 'below-word-floor');
@@ -405,7 +418,7 @@ test('a page that yielded no voice carries its reason instead of a gap', () => {
 });
 
 test('a run without --voice gains no voice keys', () => {
-  const merged = mergeResults([page('https://a.com/'), page('https://a.com/b')]) as any;
+  const merged = merge([page('https://a.com/'), page('https://a.com/b')]);
   assert.equal('voice' in merged, false);
   assert.equal('voice' in merged.pages[0], false);
 });

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -370,3 +370,42 @@ test('a page missing whole sections does not break the merge', () => {
   assert.ok(Array.isArray(merged.colors.palette));
   assert.ok(Array.isArray(merged.components.buttons));
 });
+
+
+test('voice is preserved per page and never merged across them', () => {
+  // Colours and type are tokens, so the same value on three pages is stronger
+  // evidence of one thing. Copy is not: averaging a marketing page's sentence
+  // length with a docs page's yields a number describing neither page.
+  const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
+  const docs = page('https://a.com/docs', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 400, "sentenceCount": 4, "meanSentenceLength": 24, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "docs"} });
+
+  const merged = mergeResults([home, docs]) as any;
+
+  // Root keeps the homepage's, as with logo and colors.rawColors.
+  assert.equal(merged.voice.pageType, 'landing');
+  assert.equal(merged.voice.metrics.structural.meanSentenceLength, 11);
+
+  // Both pages survive intact, so the variation between them stays readable.
+  assert.equal(merged.pages.length, 2);
+  assert.equal(merged.pages[0].voice.pageType, 'landing');
+  assert.equal(merged.pages[1].voice.pageType, 'docs');
+  assert.equal(merged.pages[1].voice.metrics.structural.meanSentenceLength, 24);
+});
+
+test('a page that yielded no voice carries its reason instead of a gap', () => {
+  const home = page('https://a.com/', { voice: {"fragments": [{"role": "hero-h1", "text": "Heading", "order": 0}], "metrics": {"structural": {"wordCount": 200, "sentenceCount": 4, "meanSentenceLength": 11, "sentenceLengthStdev": 2, "exclamationRatio": 0, "questionRatio": 0, "longWordRatio": 0, "avgSyllablesPerWord": 1.5, "lowSample": true}, "lexical": null, "lang": "en"}, "pageType": "landing"} });
+  const thin = page('https://a.com/contact', { voice: null, voiceSkipped: 'below-word-floor' });
+
+  const merged = mergeResults([home, thin]) as any;
+
+  assert.equal(merged.pages[1].voice, null);
+  assert.equal(merged.pages[1].voiceSkipped, 'below-word-floor');
+  // The root still reports the homepage's voice rather than being dragged down.
+  assert.ok(merged.voice);
+});
+
+test('a run without --voice gains no voice keys', () => {
+  const merged = mergeResults([page('https://a.com/'), page('https://a.com/b')]) as any;
+  assert.equal('voice' in merged, false);
+  assert.equal('voice' in merged.pages[0], false);
+});

--- a/test/voice-collect.test.ts
+++ b/test/voice-collect.test.ts
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser, type BrowserContext, type Page } from 'playwright';
+import { collectVoice } from '../lib/voice/index.js';
+
+// Assembly-level tests: budget, floor, page-type routing and the 404 probe.
+// All served from an intercepted route, so nothing here touches the network.
+
+const LEDE =
+  'We help design teams keep the implemented product aligned with the brand they actually intend to ship every day.';
+
+const body = (extra = ''): string => `
+  <header><nav><a href="/product">Product</a><a href="/pricing">Pricing</a></nav></header>
+  <section style="min-height:820px">
+    <h1 style="font-size:48px">Extract any design system</h1>
+    <p style="font-size:18px">Real computed values pulled from the rendered page rather than the stylesheet source of it.</p>
+  </section>
+  <main>
+    <h2>Why teams choose us</h2><p>${LEDE}</p>
+    <h2>Trusted by engineering teams</h2><p>The fastest way to audit a live interface, used by thousands of teams every month across the industry.</p>
+    <h2>Built for continuous delivery</h2><p>We run against the rendered page, so the values you get are the ones your users actually see in their browser.</p>
+    <h2>Works with your stack</h2><p>Export to design tokens, a Tailwind theme or a plain report, and wire the whole thing into your pipeline in an afternoon.</p>
+    <blockquote>It replaced a week of manual DevTools work for our whole platform group here.</blockquote>
+    <form><label for="e">Work email</label><input id="e" placeholder="you@company.com"></form>
+    ${extra}
+  </main>
+  <footer><p>&copy; 2026 Example Oy. All rights reserved.</p></footer>`;
+
+const page404 = `<!doctype html><html lang="en"><head><title>Not found</title></head>
+  <body style="margin:0"><h1 style="font-size:40px">This page went missing</h1>
+  <p style="font-size:16px">Nothing here. Try the homepage instead, everything else still works fine.</p></body></html>`;
+
+const doc = (inner: string, lang = 'en'): string =>
+  `<!doctype html><html lang="${lang}"><head><title>Example — design system extraction</title>` +
+  `<meta name="description" content="Extract design tokens from any website in one command today."></head>` +
+  `<body style="margin:0">${inner}</body></html>`;
+
+let browser: Browser;
+let context: BrowserContext;
+
+/**
+ * Serves the landing page at its own path and a 404 everywhere else. The route
+ * is registered on the context, not the page: the probe opens its own page and
+ * has to inherit it.
+ */
+async function open(url: string, html: string, opts: { with404?: boolean } = {}): Promise<Page> {
+  await context.unrouteAll();
+  await context.route('**/*', async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const known = path === '/' || path === new URL(url).pathname;
+    if (known) return route.fulfill({ status: 200, contentType: 'text/html', body: html });
+    if (opts.with404 === false) return route.abort();
+    return route.fulfill({ status: 404, contentType: 'text/html', body: page404 });
+  });
+  const page = await context.newPage();
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  return page;
+}
+
+before(async () => {
+  browser = await chromium.launch();
+  context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+});
+
+after(async () => {
+  await browser?.close();
+});
+
+test('collects fragments, metrics and page type from a landing page', async () => {
+  const page = await open('https://example.test/', doc(body()));
+  const { voice, voiceSkipped } = await collectVoice(page, 'https://example.test/');
+
+  assert.equal(voiceSkipped, undefined);
+  assert.ok(voice);
+  assert.equal(voice.pageType, 'landing');
+  assert.ok(voice.fragments.length > 0);
+  assert.ok(voice.metrics.structural.wordCount > 0);
+  assert.equal(voice.metrics.lang, 'en');
+  await page.close();
+});
+
+test('the 404 probe runs on its own page and leaves the caller untouched', async () => {
+  const page = await open('https://example.test/', doc(body()));
+  const before = page.url();
+
+  const { voice } = await collectVoice(page, 'https://example.test/');
+
+  // The probe used to navigate this page and restore it; anything running after
+  // voice (wcag, the canvas-only check) then saw a differently-loaded page.
+  assert.equal(page.url(), before);
+  assert.ok(await page.$('h1'), 'the original DOM must still be there');
+
+  const errorRoles = voice?.fragments.filter((f) => f.role.startsWith('error-404-')) ?? [];
+  assert.ok(errorRoles.length > 0, 'probe copy should be collected');
+  assert.match(errorRoles[0].text, /went missing|Nothing here/);
+  await page.close();
+});
+
+test('a failing probe degrades to no 404 roles rather than failing the run', async () => {
+  const page = await open('https://example.test/', doc(body()), { with404: false });
+  const { voice } = await collectVoice(page, 'https://example.test/');
+
+  assert.ok(voice, 'main-page fragments must survive a dead probe');
+  assert.equal(voice.fragments.filter((f) => f.role.startsWith('error-404-')).length, 0);
+  assert.equal(page.url(), 'https://example.test/');
+  await page.close();
+});
+
+test('probe404: false skips the probe entirely', async () => {
+  const page = await open('https://example.test/', doc(body()));
+  const { voice } = await collectVoice(page, 'https://example.test/', { probe404: false });
+
+  assert.ok(voice);
+  assert.equal(voice.fragments.filter((f) => f.role.startsWith('error-404-')).length, 0);
+  await page.close();
+});
+
+test('the probe path is stable across runs', async () => {
+  // A random path changes the fragment on every 404 page that echoes the path
+  // back, which would surface as drift on a site that never changed.
+  const page = await open('https://example.test/', doc(body()));
+  const a = await collectVoice(page, 'https://example.test/');
+  const b = await collectVoice(page, 'https://example.test/');
+
+  const only404 = (r: typeof a) =>
+    (r.voice?.fragments ?? []).filter((f) => f.role.startsWith('error-404-')).map((f) => f.text);
+  assert.deepEqual(only404(a), only404(b));
+  await page.close();
+});
+
+test('a malformed url degrades to no probe rather than aborting collection', async () => {
+  const page = await open('https://example.test/', doc(body()));
+  // new URL() used to run outside the guard and took the whole run down with it.
+  const { voice } = await collectVoice(page, 'not a url at all');
+
+  assert.ok(voice, 'main-page fragments must survive');
+  assert.equal(voice.fragments.filter((f) => f.role.startsWith('error-404-')).length, 0);
+  await page.close();
+});
+
+test('a page under the word floor yields null plus a reason, never a partial object', async () => {
+  const page = await open('https://example.test/', doc('<h1>Hi</h1>'), { with404: false });
+  const result = await collectVoice(page, 'https://example.test/');
+
+  assert.equal(result.voice, null);
+  assert.ok(result.voiceSkipped === 'below-word-floor' || result.voiceSkipped === 'no-text');
+  await page.close();
+});
+
+test('page type follows the path and changes the budget, not the roles attempted', async () => {
+  const docsPage = await open('https://example.test/docs/intro', doc(body()));
+  const { voice } = await collectVoice(docsPage, 'https://example.test/docs/intro', { probe404: false });
+
+  assert.equal(voice?.pageType, 'docs');
+  // Docs carry a lower cap, but the same roles are still collected.
+  assert.ok(voice.fragments.some((f) => f.role === 'hero-h1'));
+  await docsPage.close();
+});
+
+test('lexical metrics are withheld for a non-English document', async () => {
+  const fi = `
+    <section style="min-height:820px">
+      <h1 style="font-size:48px">Poimi mika tahansa designjarjestelma</h1>
+      <p style="font-size:18px">Todelliset lasketut arvot haetaan renderoidysta sivusta eika tyylitiedoston lahdekoodista.</p>
+    </section>
+    <main>
+      <h2>Miksi tiimit valitsevat meidat</h2>
+      <p>Autamme suunnittelutiimeja pitamaan toteutetun tuotteen linjassa sen brandin kanssa jonka ne aikovat julkaista, myos silloin kun tiimi kasvaa nopeasti ja alkuperainen ohjeistus alkaa jaada jalkeen arjesta.</p>
+      <p>Nopein tapa auditoida elava kayttoliittyma, ja sita kayttaa tuhansia tiimeja joka kuukausi maailmalla, seka pienissa startupeissa etta suurissa organisaatioissa joilla on kymmenia rinnakkaisia palveluita.</p>
+      <h2>Rakennettu jatkuvaan toimitukseen</h2>
+      <p>Ajamme analyysin renderoityyn sivuun, joten saadut arvot ovat samoja jotka kayttaja nakee omassa selaimessaan, eika niita tarvitse enaa tarkistaa erikseen kehitystyokalujen kautta jokaisen julkaisun jalkeen.</p>
+      <h2>Toimii teidan pinossanne</h2>
+      <p>Vie tulokset design-tokeneiksi, Tailwind-teemaksi tai raportiksi ja kytke koko homma putkeen yhdessa iltapaivassa.</p>
+      <h2>Selkea raportti jokaisesta ajosta</h2>
+      <p>Jokainen ajo tuottaa saman rakenteisen tuloksen, joten kahden version vertailu kertoo tasmalleen mika muuttui ja missa kohtaa.</p>
+      <h2>Ei arvailua vaan mitattuja arvoja</h2>
+      <p>Emme lue tyylitiedostoja vaan katsomme mita selain oikeasti piirtaa, mukaan lukien hover- ja fokustilat jokaisesta komponentista.</p>
+      <h2>Sopii isoillekin sivustoille</h2>
+      <p>Voit ajaa yhden sivun tai kymmenen kerralla, ja tulokset yhdistetaan yhdeksi kokonaisuudeksi jossa toistuvat arvot saavat enemman painoa.</p>
+      <h2>Avoin lahdekoodi ja selkeat rajapinnat</h2>
+      <p>Koko tyokalu on avointa lahdekoodia, joten voit lukea tarkalleen miten jokainen arvo on paatelty ja korjata sen itse jos olet eri mielta.</p>
+      <h2>Nopea ottaa kayttoon</h2>
+      <p>Asennus vie yhden komennon eika vaadi tunnuksia, avaimia tai erillista palvelinta, joten kokeilu onnistuu heti ensimmaisella minuutilla.</p>
+    </main>`;
+  const page = await open('https://example.test/', doc(fi, 'fi'), { with404: false });
+  const { voice } = await collectVoice(page, 'https://example.test/');
+
+  assert.ok(voice);
+  assert.equal(voice.metrics.lang, 'fi');
+  // A zero would read as a measured absence rather than "not measured".
+  assert.equal(voice.metrics.lexical, null);
+  assert.ok(voice.metrics.structural.wordCount > 0);
+  assert.ok(voice.metrics.structural.sentenceCount > 0);
+  await page.close();
+});
+
+test('fragments never exceed the page type budget', async () => {
+  const filler = Array.from({ length: 40 }, (_, i) => `<h2>Section ${i}</h2><p>${LEDE}</p>`).join('');
+  const page = await open('https://example.test/', doc(body(filler)), { with404: false });
+  const { voice } = await collectVoice(page, 'https://example.test/');
+
+  assert.ok(voice);
+  const words = voice.fragments.reduce((n, f) => n + f.text.trim().split(/\s+/).length, 0);
+  assert.ok(words <= 800, `budget exceeded: ${words} words`);
+  await page.close();
+});

--- a/test/voice-fixture.test.ts
+++ b/test/voice-fixture.test.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser, type Page } from 'playwright';
+import { extractVoice, DEFAULT_VOICE_CONFIG } from '../lib/extractors/voice.js';
+import type { VoiceFragment, VoiceRole } from '../lib/types.js';
+
+// Real chromium + page.setContent, no network. The pure metrics tests cannot
+// reach any of this: hero detection depends on computed font size and layout
+// position, and the exclusion / dedup rules only mean anything against a DOM.
+
+// The hero headline sits in a nested grid, several levels away from its own
+// paragraph. A sibling walk finds nothing here, which is the point.
+const HERO = `
+  <section style="padding:0;margin:0;min-height:820px">
+    <div class="grid"><div class="col">
+      <div class="stack"><h1 style="font-size:48px;margin:0">Extract any design system</h1></div>
+    </div>
+    <div class="col"><div class="stack">
+      <p style="font-size:18px;margin:0">Real computed values pulled from the rendered page rather than the stylesheet source.</p>
+    </div></div></div>
+  </section>`;
+
+const CONSENT = `
+  <div class="cookie-banner" style="font-size:60px">
+    <h2>We value your privacy</h2>
+    <button>Accept all cookies</button>
+  </div>`;
+
+const HIDDEN = `<p aria-hidden="true" style="font-size:80px">Hidden decorative headline</p>`;
+
+// The same CTA label three times: nav, hero, footer. Only one may survive.
+const REPEATED_CTA = `
+  <a class="btn" href="/a">Get started</a>
+  <a class="btn" href="/b">Get started</a>`;
+
+const BODY = `
+  <header><nav>
+    <a href="/product">Product</a><a href="/pricing">Pricing</a><a href="/docs">Docs</a>
+    <a class="cta-link" href="/signup">Get started</a>
+  </nav></header>
+  ${CONSENT}
+  ${HIDDEN}
+  ${HERO}
+  <main>
+    <h2>Why teams choose us</h2>
+    <p>We help design teams keep the implemented product aligned with the brand they actually intend to ship.</p>
+    <h2>Trusted by engineering teams</h2>
+    <blockquote>It replaced a week of manual DevTools work for our whole platform group.</blockquote>
+    <p>The fastest way to audit a live interface, used by thousands of teams every month.</p>
+    ${REPEATED_CTA}
+    <form>
+      <label for="email">Work email</label>
+      <input id="email" type="email" placeholder="you@company.com">
+    </form>
+  </main>
+  <footer><p>&copy; 2026 Example Oy. All rights reserved.</p></footer>`;
+
+const FIXTURE =
+  `<!doctype html><html lang="en"><head>` +
+  `<title>Example — design system extraction</title>` +
+  `<meta name="description" content="Extract design tokens from any website in one command.">` +
+  `</head><body style="margin:0">${BODY}</body></html>`;
+
+let browser: Browser;
+let page: Page;
+let fragments: VoiceFragment[];
+
+const rolesIn = (list: VoiceFragment[]): Set<VoiceRole> => new Set(list.map((f) => f.role));
+const textFor = (role: VoiceRole): string[] => fragments.filter((f) => f.role === role).map((f) => f.text);
+
+before(async () => {
+  browser = await chromium.launch();
+  page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.setContent(FIXTURE, { waitUntil: 'domcontentloaded' });
+  fragments = await extractVoice(page);
+});
+
+after(async () => {
+  await browser?.close();
+});
+
+test('meta title and description are collected', () => {
+  assert.deepEqual(textFor('meta-title'), ['Example — design system extraction']);
+  assert.deepEqual(textFor('meta-description'), ['Extract design tokens from any website in one command.']);
+});
+
+test('hero headline is found across a nested grid, not by sibling walk', () => {
+  assert.deepEqual(textFor('hero-h1'), ['Extract any design system']);
+  const body = textFor('hero-body');
+  assert.ok(body.length >= 1);
+  assert.match(body[0], /Real computed values/);
+});
+
+test('consent banner is excluded despite the largest font on the page', () => {
+  const all = fragments.map((f) => f.text).join(' | ');
+  assert.doesNotMatch(all, /privacy/i);
+  assert.doesNotMatch(all, /Accept all cookies/i);
+});
+
+test('aria-hidden content is excluded', () => {
+  assert.doesNotMatch(fragments.map((f) => f.text).join(' | '), /Hidden decorative/);
+});
+
+test('a repeated CTA label survives exactly once across all roles', () => {
+  const occurrences = fragments.filter((f) => f.text.toLowerCase() === 'get started');
+  assert.equal(occurrences.length, 1, 'nav + hero + footer copies must collapse to one');
+});
+
+test('nav labels are collected and bounded in length', () => {
+  const nav = textFor('nav-label');
+  assert.ok(nav.includes('Product'));
+  assert.ok(nav.includes('Pricing'));
+  for (const label of nav) assert.ok(label.split(' ').length <= 5);
+});
+
+test('section headings are collected in document order', () => {
+  assert.deepEqual(textFor('section-h2'), ['Why teams choose us', 'Trusted by engineering teams']);
+});
+
+test('value-claim roles pick up first-person claims, superlatives and testimonials', () => {
+  const roles = rolesIn(fragments);
+  assert.ok(roles.has('value-prop'), 'a "we help..." block is a value proposition');
+  assert.ok(roles.has('claim'), '"fastest" / "used by thousands" is a claim');
+  assert.ok(roles.has('social-proof'), 'a blockquote is social proof');
+});
+
+test('microcopy roles are collected separately from prose', () => {
+  assert.deepEqual(textFor('form-label'), ['Work email']);
+  assert.deepEqual(textFor('form-placeholder'), ['you@company.com']);
+  assert.equal(textFor('footer-legal').length, 1);
+  assert.match(textFor('footer-legal')[0], /All rights reserved/);
+});
+
+test('selectorHint is withheld by default and emitted on demand', async () => {
+  for (const f of fragments) assert.equal(f.selectorHint, undefined);
+
+  const debugged = await extractVoice(page, { ...DEFAULT_VOICE_CONFIG, debug: true });
+  assert.ok(debugged.every((f) => typeof f.selectorHint === 'string' && f.selectorHint.length > 0));
+});
+
+test('per-role limits are never exceeded', () => {
+  const counts = new Map<VoiceRole, number>();
+  for (const f of fragments) counts.set(f.role, (counts.get(f.role) ?? 0) + 1);
+  for (const [role, n] of counts) {
+    assert.ok(n <= DEFAULT_VOICE_CONFIG.roleLimits[role], `${role}: ${n} exceeds its limit`);
+  }
+});
+
+test('order is contiguous from zero within each role', () => {
+  const byRole = new Map<VoiceRole, number[]>();
+  for (const f of fragments) byRole.set(f.role, [...(byRole.get(f.role) ?? []), f.order]);
+  for (const [role, orders] of byRole) {
+    assert.deepEqual(orders, orders.map((_, i) => i), `${role} order must be 0..n-1`);
+  }
+});
+
+test('errorPageOnly collects only the 404 roles', async () => {
+  const errorPage = await extractVoice(page, { ...DEFAULT_VOICE_CONFIG, errorPageOnly: true });
+  const roles = rolesIn(errorPage);
+  for (const role of roles) assert.ok(role.startsWith('error-404-'), `${role} must not appear on a probe page`);
+  assert.ok(roles.has('error-404-h1'));
+});

--- a/test/voice-metrics.test.ts
+++ b/test/voice-metrics.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  applyBudget,
+  computeMetrics,
+  countSyllables,
+  countWords,
+  PAGE_TYPE_CAP,
+  totalWords,
+  WORD_CAP,
+  WORD_FLOOR,
+} from '../lib/voice/metrics.js';
+import { classifyPageType } from '../lib/voice/page-type.js';
+import type { VoiceFragment, VoiceRole } from '../lib/types.js';
+
+// The metrics are the half of voice extraction that must stay reproducible:
+// drift compares them run over run, so a heuristic that shifts silently turns
+// into a false "the brand changed its tone" finding.
+
+const frag = (role: VoiceRole, text: string, order = 0): VoiceFragment => ({ role, text, order });
+
+test('countWords ignores surrounding and repeated whitespace', () => {
+  assert.equal(countWords(''), 0);
+  assert.equal(countWords('   '), 0);
+  assert.equal(countWords('one'), 1);
+  assert.equal(countWords('  two   words  '), 2);
+});
+
+test('countSyllables handles the short-word and silent-e cases', () => {
+  assert.equal(countSyllables(''), 0);
+  assert.equal(countSyllables('the'), 1);
+  assert.equal(countSyllables('make'), 1);
+  assert.equal(countSyllables('design'), 2);
+  assert.ok(countSyllables('extraordinary') >= 4);
+});
+
+test('computeMetrics returns zeroed metrics for no fragments', () => {
+  const m = computeMetrics([], 'en');
+  assert.equal(m.structural.wordCount, 0);
+  assert.equal(m.structural.sentenceCount, 0);
+  assert.equal(m.structural.meanSentenceLength, 0);
+  assert.equal(m.structural.sentenceLengthStdev, 0);
+  // No division-by-zero leaking NaN into the output contract.
+  for (const v of Object.values(m.lexical!.personPronounRatio)) assert.equal(v, 0);
+  assert.equal(m.lexical!.readability, null);
+});
+
+test('a single sentence has zero stdev rather than NaN', () => {
+  const m = computeMetrics([frag('hero-body', 'We build design tools for teams.')], 'en');
+  assert.equal(m.structural.sentenceCount, 1);
+  assert.equal(m.structural.sentenceLengthStdev, 0);
+  assert.ok(Number.isFinite(m.structural.meanSentenceLength));
+});
+
+test('headings are excluded from sentence statistics', () => {
+  // Headings are labels, not sentences. Counting them inflated sentenceCount and
+  // dragged every sentence-level statistic toward heading length.
+  const headingsOnly = computeMetrics(
+    [frag('section-h2', 'Pricing'), frag('section-h2', 'Features'), frag('hero-h1', 'Model X200')],
+    'en',
+  );
+  assert.equal(headingsOnly.structural.sentenceCount, 0);
+  assert.equal(headingsOnly.structural.meanSentenceLength, 0);
+  // They still count toward vocabulary-level measures.
+  assert.ok(headingsOnly.structural.wordCount > 0);
+});
+
+test('lexical metrics are withheld entirely outside supported languages', () => {
+  // A zero would read as a measured "no first-person voice" rather than "not
+  // measured". Structural metrics are language-independent and still computed.
+  const fi = computeMetrics([frag('hero-body', 'Rakennamme muotoilutyokaluja tiimeille. Se toimii hyvin.')], 'fi');
+  assert.equal(fi.lexical, null);
+  assert.ok(fi.structural.wordCount > 0);
+  assert.equal(fi.structural.sentenceCount, 2);
+  assert.equal(fi.lang, 'fi');
+});
+
+test('readability is null outside the languages the formula models', () => {
+  const copy = [frag('hero-body', 'Rakennamme muotoilutyokaluja tiimeille. Se toimii hyvin.')];
+  assert.equal(computeMetrics(copy, 'fi').lexical, null);
+  assert.equal(computeMetrics(copy, 'fi-FI').lexical, null);
+  // A wrong number would be worse than an absent one, so English must still produce one.
+  assert.notEqual(computeMetrics(copy, 'en').lexical!.readability, null);
+});
+
+test('lang falls back to a marker instead of an empty string', () => {
+  assert.equal(computeMetrics([frag('hero-h1', 'Ship faster.')], '').lang, 'unknown');
+  assert.equal(computeMetrics([frag('hero-h1', 'Ship faster.')], 'en-GB').lang, 'en-GB');
+});
+
+test('pronoun stance separates first, second and third person', () => {
+  const we = computeMetrics([frag('value-prop', 'We build our tools with our own team every day.')], 'en');
+  assert.ok(we.lexical!.personPronounRatio.first > we.lexical!.personPronounRatio.second);
+
+  const you = computeMetrics([frag('value-prop', 'You keep your tokens and your brand in your control.')], 'en');
+  assert.ok(you.lexical!.personPronounRatio.second > you.lexical!.personPronounRatio.first);
+});
+
+test('metrics ignore non-prose roles', () => {
+  // Nav labels and placeholders are fragments, not sentences; counting them
+  // would wreck sentence-length statistics.
+  const withChrome = computeMetrics(
+    [frag('hero-h1', 'Extract any design system.'), frag('nav-label', 'Pricing'), frag('form-placeholder', 'you@example.com')],
+    'en',
+  );
+  const proseOnly = computeMetrics([frag('hero-h1', 'Extract any design system.')], 'en');
+  assert.equal(withChrome.structural.wordCount, proseOnly.structural.wordCount);
+});
+
+test('punctuation ratios stay within [0,1] however many marks a sentence carries', () => {
+  // Counting marks rather than sentences let a single "Now!! Really!!!" push the
+  // ratio above 1, breaking the range the type documents.
+  const shouty = computeMetrics(
+    [frag('hero-body', 'Now!! Really!!! Absolutely!!!! You have to see this today.')],
+    'en',
+  );
+  assert.ok(shouty.structural.exclamationRatio <= 1);
+  assert.ok(shouty.structural.exclamationRatio > 0);
+
+  const asking = computeMetrics([frag('hero-body', 'Why?? How?? What now, exactly?')], 'en');
+  assert.ok(asking.structural.questionRatio <= 1);
+});
+
+test('metrics are reproducible for identical input', () => {
+  const copy = [frag('hero-h1', 'Ship brand-faithful UI.'), frag('hero-body', 'We extract the real tokens from the rendered page, not the source.')];
+  assert.deepEqual(computeMetrics(copy, 'en'), computeMetrics(copy, 'en'));
+});
+
+test('applyBudget is a no-op under the cap', () => {
+  const copy = [frag('hero-h1', 'Short headline here.')];
+  assert.equal(applyBudget(copy, 'landing'), copy);
+});
+
+test('applyBudget drops the lowest-weight roles first', () => {
+  const filler = (n: number) => Array.from({ length: n }, () => 'word').join(' ');
+  const copy = [
+    frag('footer-legal', filler(400)),
+    frag('nav-label', filler(400)),
+    frag('hero-h1', filler(200)),
+  ];
+  assert.ok(totalWords(copy) > PAGE_TYPE_CAP.landing);
+
+  const kept = applyBudget(copy, 'landing');
+  assert.ok(totalWords(kept) <= PAGE_TYPE_CAP.landing);
+  const roles = kept.map((f) => f.role);
+  assert.ok(roles.includes('hero-h1'), 'the highest-weight role must survive');
+  assert.ok(!roles.includes('footer-legal'), 'the lowest-weight role goes first');
+});
+
+test('every page type caps at or below the global cap, and docs lowest', () => {
+  for (const cap of Object.values(PAGE_TYPE_CAP)) assert.ok(cap <= WORD_CAP);
+  // Docs prose is engineer-written, so it is weighted down deliberately.
+  assert.ok(PAGE_TYPE_CAP.docs < PAGE_TYPE_CAP.landing);
+  assert.ok(WORD_FLOOR < WORD_CAP);
+});
+
+test('classifyPageType reads the path before anything else', () => {
+  const base = { headingCount: 5, formCount: 0, hasArticle: false };
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com' }), 'landing');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/' }), 'landing');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/docs/getting-started' }), 'docs');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/pricing' }), 'product');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/contact' }), 'contact');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/blog/a-post' }), 'news');
+  assert.equal(classifyPageType({ ...base, url: 'https://x.com/something-else' }), 'other');
+});
+
+test('classifyPageType falls back to DOM signals and never throws on a bad url', () => {
+  assert.equal(
+    classifyPageType({ url: 'https://x.com/x', headingCount: 2, formCount: 0, hasArticle: true }),
+    'news',
+  );
+  assert.equal(
+    classifyPageType({ url: 'https://x.com/x', headingCount: 1, formCount: 1, hasArticle: false }),
+    'contact',
+  );
+  assert.doesNotThrow(() => classifyPageType({ url: 'not a url', headingCount: 0, formCount: 0, hasArticle: false }));
+});


### PR DESCRIPTION
DEM-229 (Voice: typed contract), DEM-234 (Voice: wire into extractBranding), DEM-235 (Voice: unit tests and DOM fixture). Adds `--voice`: page copy collected by rhetorical role, plus metrics over it.

**Ships hidden.** Opt-in and withheld from `--help`, README and docs, same as `--teach`. An undocumented flag has no consumers, so `SCHEMA_VERSION` deliberately does not bump and `VoiceRole` is not yet a contract — roles can still be cut after DEM-236 (Voice: validation sweep on 15 sites) without that being a breaking removal. The reasoning is recorded in `lib/version.ts` so it does not read as an oversight. Bump to 1.9.0 when the flag is documented.

No baseline churn: `voice` is a new key nothing previously read, and the drift engine does not compare it.

This extracts and measures; it does not interpret. Tone characterisation and archetypes belong to the app, which reads `voice.fragments` + `voice.metrics` and nothing else.

**Roles, not a text dump.** A flat scrape averages a hero headline and a form placeholder into one meaningless sample. Seventeen roles keep them separable: tone surfaces, value claims, and microcopy. Tone varies within a page; that variation is the output.

**Layout, not traversal.** Sibling walks return nothing on nested grid heroes where the headline and its paragraph are cousins. The page is already rendered, so the hero is the largest first-viewport text by computed font size.

**Language.** Fragment collection is language-agnostic — selectors, viewport, font size read no words. Metrics are split accordingly: `structural` (sentence and punctuation shape) computes anywhere; `lexical` (word lists, readability) is `null` in full outside supported languages. Verified on a Finnish-language site: 31 fragments, structural metrics present, `lexical: null` rather than a row of zeros reading as "never hedges, no jargon".

Defects found during review and sample runs. Each produced a confident wrong number or a silent state change rather than a visible failure:

| defect | symptom | fix |
|---|---|---|
| 404 probe navigated the shared page | restoring with `domcontentloaded` dropped hydration/reveal/consent, so `--voice --wcag` measured a differently-loaded page | probe on its own page in the same context |
| headings counted as sentences | one-word `section-h2` dragged every sentence statistic toward heading length | headings feed vocabulary metrics only |
| word floor at 300 | real brand pages yield 90–330 prose words, so most emitted `voice: null` | floor 150, `lowSample` below 300 |
| punctuation ratios could exceed 1 | counting marks, not sentences: "Now!! Really!!!" scored above the range the type documents | share of sentences carrying the mark |
| random probe path | 404 pages that echo the path back changed the fragment every run, surfacing as drift on a site that never changed | fixed unroutable path |
| `new URL()` outside the guard | a malformed URL aborted the whole collection, not just the probe | parsed inside the try |
| errors reported as `no-text` | a thrown extractor was indistinguishable from an empty page | dedicated `error` reason |

**Hand-built word lists were cut.** `hedgeRatio`, `commitmentRatio`, `urgencyRatio`, `jargonDensity` and a 43-verb `imperativeRatio` all encoded an opinion and printed it as a decimal, indistinguishable in the output from a counted value. `imperativeRatio` came back 0.67–0.75 across three deliberately distant consumer brands, so it discriminated nothing. Every list was English-only and then gated off for other languages, which handed a Finnish page nothing at all.

What remains is counted or published: structural signals hold in any whitespace-separated language, pronoun stance is a closed word class, and Flesch is a published formula. Tone characterisation moves to the layer that reads `fragments` and can quote them. The principle is written up in `quality-philosophy.md` ("Never encode an opinion as a measurement").

3–5KB against a 42KB average extraction. `selectorHint` is debug-only and withheld by default. Pages under the floor emit `voice: null` with a reason, never a half-populated object.

**Known limits.** One page, and a landing page is a brand's most rehearsed surface — the 404 and form microcopy are the counterweight and the reason those roles are in the MVP. Cross-page consistency needs DEM-241 (Voice: multi-page crawl for cross-page consistency). The word floor is calibrated on English; Finnish yields roughly 40% fewer words for the same content, so the floor and the per-role limits sit closer together there than intended — one for DEM-236 to settle with real data.

Unit tests for metrics, budget and classifier, an 8-case assembly suite over `collectVoice` (probe isolation, dead probe, floor, budget, language gating), and a 13-case chromium fixture covering nested-grid hero detection, consent exclusion, cross-role dedup, role limits and the probe path. 596 pass, lint clean.
