### PR TITLE
fix(sync): a skipped cloud sync fails the run instead of passing quietly

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -110,4 +110,8 @@ A pipeline can branch on the exit code; "design drifted" and "extraction broke" 
 
 With `--json-only`, a failure also prints a machine-readable `{ "error": { "code", "message" } }` to stdout.
 
-`3` exists so a pipeline can tell "this run was not recorded" apart from "the extractor is broken". Passing `--key` states an intent, and a run that could not meet it has not done what was asked, even though its output is valid: the payload was over the size limit, the key was rejected, or the API was unreachable. Reporting success there means drift tracking stops recording and nothing ever says so. Drift (`1`) takes precedence when both apply, since drift is the more actionable signal and the sync failure is printed regardless.
+`3` exists so a pipeline can tell "this run was not recorded" apart from "the extractor is broken". Passing `--key` states an intent, and a run that could not meet it has not done what was asked, even though its output is valid: the payload was over the size limit, the key was rejected, or the API was unreachable. Reporting success there means drift tracking stops recording and nothing ever says so.
+
+**Rate limiting is not a sync failure.** Exceeding the account quota (20/hour, 200/day, 500/week) still warns and exits `0`, because hitting a quota is the system working as designed rather than a fault to fix, and a snapshot job should not turn a deploy pipeline red for it. A rejected key, an oversized payload or an unreachable API are the opposite: they need someone to act, and nobody acts on what nobody sees.
+
+Drift (`1`) takes precedence when both apply, since drift is the more actionable signal and the sync failure is printed regardless.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -105,6 +105,9 @@ A pipeline can branch on the exit code; "design drifted" and "extraction broke" 
 | `0` | Success, or stable (no drift) under `--compare` |
 | `1` | Drift detected (`--compare`) |
 | `2` | Extraction failure (`EXTRACTION_FAILED`, `BROWSER_UNAVAILABLE`) |
+| `3` | Cloud sync failed under `--key`; the extraction itself succeeded |
 | `67` | Navigation/connection timeout (`NAVIGATION_TIMEOUT`), retryable, try `--slow` |
 
 With `--json-only`, a failure also prints a machine-readable `{ "error": { "code", "message" } }` to stdout.
+
+`3` exists so a pipeline can tell "this run was not recorded" apart from "the extractor is broken". Passing `--key` states an intent, and a run that could not meet it has not done what was asked, even though its output is valid: the payload was over the size limit, the key was rejected, or the API was unreachable. Reporting success there means drift tracking stops recording and nothing ever says so. Drift (`1`) takes precedence when both apply, since drift is the more actionable signal and the sync failure is printed regardless.

--- a/index.ts
+++ b/index.ts
@@ -602,12 +602,17 @@ program
 
       // Sync to cloud if --key / DEMBRANDT_KEY is set.
       //
-      // A skipped sync used to print a warning and exit 0. In CI that warning
+      // A failed sync used to print a warning and exit 0. In CI that warning
       // scrolls past in a log nobody reads, the run reports success, and drift
-      // tracking silently never starts — the failure mode is invisible exactly
-      // where it matters. Passing --key states an intent, so failing to meet it
-      // is a failure of the run, reported on its own exit code (the extraction
-      // itself succeeded, so RUNTIME would be the wrong signal).
+      // tracking silently never starts — invisible exactly where it matters.
+      // Passing --key states an intent, so failing to meet it is a failure of
+      // the run, on its own exit code (the extraction succeeded, so RUNTIME
+      // would be the wrong signal).
+      //
+      // Rate limiting is excluded on purpose. Hitting a quota is the system
+      // working as designed, not a fault to fix, and the published recipes
+      // promise it never fails a pipeline. A bad key, an oversized payload or
+      // an unreachable API are the opposite: nobody fixes what nobody sees.
       if (apiKey) {
         const syncFailure = (reason: string, remedy: string): void => {
           console.error(color.error(`✖ Cloud sync failed: ${reason}`));
@@ -639,6 +644,12 @@ program
             });
             if (syncRes.ok) {
               savedNotices.push(chalk.dim(`☁  Synced to your account (--key)`));
+            } else if (syncRes.status === 429) {
+              // Hitting the rate limit is the system working, not a fault, and
+              // the recipes have always promised it does not fail a pipeline.
+              const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
+              console.error(color.warning(`! Cloud sync skipped: ${err.error ?? "rate limit reached"}`));
+              console.error(chalk.dim(`  This run was not recorded. Limits reset hourly.`));
             } else {
               const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
               syncFailure(

--- a/index.ts
+++ b/index.ts
@@ -389,6 +389,8 @@ program
 
       // Collect "saved to" notices and print them after the results below
       const savedNotices = [];
+      // Set when --key was given but the snapshot did not reach the cloud.
+      let syncFailed = false;
 
       // Save JSON output if --save-output or --dtcg is specified
       if (opts.saveOutput || opts.dtcg) {
@@ -598,14 +600,33 @@ program
         }
       }
 
-      // Sync to cloud if --key / DEMBRANDT_KEY is set
+      // Sync to cloud if --key / DEMBRANDT_KEY is set.
+      //
+      // A skipped sync used to print a warning and exit 0. In CI that warning
+      // scrolls past in a log nobody reads, the run reports success, and drift
+      // tracking silently never starts — the failure mode is invisible exactly
+      // where it matters. Passing --key states an intent, so failing to meet it
+      // is a failure of the run, reported on its own exit code (the extraction
+      // itself succeeded, so RUNTIME would be the wrong signal).
       if (apiKey) {
+        const syncFailure = (reason: string, remedy: string): void => {
+          console.error(color.error(`✖ Cloud sync failed: ${reason}`));
+          console.error(chalk.dim(`  ${remedy}`));
+          console.error(chalk.dim(`  The extraction itself succeeded. Drift tracking did NOT record this run.`));
+          syncFailed = true;
+        };
+
         try {
           const payload = JSON.stringify(result);
           const byteSize = Buffer.byteLength(payload, "utf8");
-          const MAX_BYTES = 150_000;
+          const MAX_BYTES = 300_000;
           if (byteSize > MAX_BYTES) {
-            console.error(color.warning(`! Extraction too large to sync (${byteSize} bytes > ${MAX_BYTES}). Skipping cloud upload.`));
+            syncFailure(
+              `extraction is ${Math.round(byteSize / 1024)} KB, over the ${Math.round(MAX_BYTES / 1024)} KB limit`,
+              result.pages?.length
+                ? `Extract fewer pages (--crawl ${Math.max(1, Math.floor((result.pages.length * MAX_BYTES) / byteSize))} or lower), or drop --raw-colors.`
+                : `Drop --raw-colors, or open an issue if a single page really is this large.`,
+            );
           } else {
             const apiBase = process.env.DEMBRANDT_API_URL ?? "https://www.dembrandt.com";
             const syncRes = await fetch(`${apiBase}/api/extractions`, {
@@ -620,11 +641,16 @@ program
               savedNotices.push(chalk.dim(`☁  Synced to your account (--key)`));
             } else {
               const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
-              console.error(color.warning(`! Cloud sync failed: ${err.error ?? syncRes.statusText}`));
+              syncFailure(
+                `${err.error ?? syncRes.statusText} (HTTP ${syncRes.status})`,
+                syncRes.status === 401
+                  ? `Check the API key at dembrandt.com/app/api-keys.`
+                  : `Retry, or check dembrandt.com/app for service status.`,
+              );
             }
           }
         } catch (syncErr) {
-          console.error(color.warning(`! Cloud sync error: ${syncErr.message}`));
+          syncFailure(syncErr.message, `Check network access to the API host and retry.`);
         }
       }
 
@@ -675,6 +701,10 @@ program
           console.log(chalk.dim("💡 --key <token> snapshots each run to your account and catches design drift over time: ") + chalk.dim(terminalLink("https://www.dembrandt.com/recipes/cloud-drift-ci", "dembrandt.com/recipes/cloud-drift-ci")));
         }
       }
+
+      // Drift (1) outranks this: a detected drift is the more actionable signal,
+      // and the sync failure is already printed above either way.
+      if (syncFailed && process.exitCode === undefined) process.exitCode = EXIT.SYNC_FAILED;
     } catch (err) {
       const { code, exit } = classifyError(err);
       spinner.fail("Failed");

--- a/lib/exit-codes.ts
+++ b/lib/exit-codes.ts
@@ -2,7 +2,8 @@
  * CI exit-code contract. A pipeline branches on these to tell apart "design
  * drifted" (review the diff) from "extraction broke" (retry / investigate):
  *   0  success / stable      1  drift detected (--compare)
- *   2  extraction failure    67 navigation/connection timeout (retryable, try --slow)
+ *   2  extraction failure    3  cloud sync failed (--key; extraction itself is fine)
+ *   67 navigation/connection timeout (retryable, try --slow)
  *
  * Kept in its own module (not index.ts, which runs the CLI on import) so the
  * classifier is importable and unit-testable without spawning a subprocess.
@@ -10,7 +11,7 @@
  * changing one is a breaking change to the gate.
  */
 
-export const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 } as const;
+export const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, TIMEOUT: 67 } as const;
 
 /** Stable failure code surfaced to CI alongside the numeric exit. */
 export type ErrorCode = "NAVIGATION_TIMEOUT" | "EXTRACTION_FAILED";

--- a/test/exit-codes.test.ts
+++ b/test/exit-codes.test.ts
@@ -10,7 +10,7 @@ import { EXIT, classifyError } from '../lib/exit-codes.js';
  */
 
 test('EXIT codes hold their documented values', () => {
-  assert.deepEqual(EXIT, { OK: 0, DRIFT: 1, RUNTIME: 2, TIMEOUT: 67 });
+  assert.deepEqual(EXIT, { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, TIMEOUT: 67 });
 });
 
 test('drift exit is distinct from every failure exit', () => {
@@ -19,6 +19,15 @@ test('drift exit is distinct from every failure exit', () => {
   assert.notEqual(EXIT.DRIFT, EXIT.RUNTIME);
   assert.notEqual(EXIT.DRIFT, EXIT.TIMEOUT);
   assert.notEqual(EXIT.DRIFT, EXIT.OK);
+  assert.notEqual(EXIT.DRIFT, EXIT.SYNC_FAILED);
+});
+
+test('a failed sync is distinguishable from a failed extraction', () => {
+  // The extraction succeeded and its output is valid; only the upload did not
+  // happen. Reporting RUNTIME would send a pipeline chasing a broken extractor.
+  assert.notEqual(EXIT.SYNC_FAILED, EXIT.RUNTIME);
+  assert.notEqual(EXIT.SYNC_FAILED, EXIT.TIMEOUT);
+  assert.notEqual(EXIT.SYNC_FAILED, EXIT.OK);
 });
 
 const TIMEOUT_CASES: Array<[string, string]> = [


### PR DESCRIPTION
DEM-174 (Cloud sync drops multi-page runs: 150 KB payload cap), client side. Pairs with dembrandt-next#120, which raises the server cap, but fixes the half that matters more.

The cap was never the real defect. This was:

```ts
if (byteSize > MAX_BYTES) {
  console.error(color.warning(`! Extraction too large to sync ...`));
}
```

A warning, then the run exits 0. In CI that line scrolls past in a log nobody reads, the job goes green, and drift tracking silently never starts. Nothing downstream reports a gap either, because from the App's side those snapshots were never sent rather than sent and rejected. The same held for a rejected key and an unreachable API: every sync failure looked like success.

Passing `--key` states an intent. A run that could not meet it has not done what was asked, even though its output is valid.

**`EXIT.SYNC_FAILED` (3), not `RUNTIME` (2).** The extraction succeeded and its JSON is good; only the upload failed. Reusing `2` would send a pipeline chasing a broken extractor. Drift (`1`) still takes precedence, since drift is the more actionable signal and the sync failure prints either way. The existing contract test caught the change immediately and now pins the new value too — the exit-code table in `docs/ci.md` gains the row and the reasoning.

**Rate limiting is exempt.** The published `cloud-drift-ci` recipe promises that going over quota skips the upload and still exits 0, never failing a pipeline. That promise is right on its own terms too: hitting a quota is the system working as designed, not a fault anyone can act on. A rejected key, an oversized payload or an unreachable API are the opposite. Finding that line in the recipe is what split this from a single blunt "sync failed" into the distinction that actually matters.

**Messages name the remedy, not just the symptom.** Over the limit derives a page count from the measured payload (`--crawl 3 or lower`) rather than saying "too large". A 401 points at the key page. Every path ends on the same line: *the extraction itself succeeded, drift tracking did NOT record this run* — the fact that was previously missing.

The client limit moves to 300 KB alongside the API. Worth noting what measurement showed while sizing it: `--crawl 5` is **43 KB**, barely more than a single page, because the merge dedupes and `pages[]` carries little. Multi-page runs do not systematically blow the cap; `--raw-colors` with a crawl does, and so do unusually heavy sites. The original diagnosis in the ticket was too broad.

560 tests pass, lint clean.



Two follow-ups in `dembrandt-next`, neither blocking this: the `cloud-drift-ci` recipe's note that a skipped upload always exits 0 now needs the rate-limit qualifier, and `.github/workflows/drift.yml` ends its snapshot command with `|| true`, which swallows every exit code — so our own dogfood pipeline would not surface this signal, or the old silent one either.
