### PR TITLE
fix(sync): let the API own the payload limit

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -627,43 +627,41 @@ program
         };
 
         try {
-          const payload = JSON.stringify(result);
-          const byteSize = Buffer.byteLength(payload, "utf8");
-          const MAX_BYTES = 300_000;
-          if (byteSize > MAX_BYTES) {
-            syncFailure(
-              `extraction is ${Math.round(byteSize / 1024)} KB, over the ${Math.round(MAX_BYTES / 1024)} KB limit`,
-              result.pages?.length
-                ? `Extract fewer pages (--crawl ${Math.max(1, Math.floor((result.pages.length * MAX_BYTES) / byteSize))} or lower), or drop --raw-colors.`
-                : `Drop --raw-colors, or open an issue if a single page really is this large.`,
-            );
+          // No size check here. The cap belongs to the API, which already
+          // enforces it and reports the exact limit; duplicating the number in
+          // the CLI meant two sources of truth in two repos that could drift
+          // apart silently, and raising the cap would have needed a CLI release.
+          const apiBase = process.env.DEMBRANDT_API_URL ?? "https://www.dembrandt.com";
+          const syncRes = await fetch(`${apiBase}/api/extractions`, {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(result),
+          });
+
+          if (syncRes.ok) {
+            savedNotices.push(chalk.dim(`☁  Synced to your account (--key)`));
+          } else if (syncRes.status === 429) {
+            // Hitting the rate limit is the system working, not a fault, and
+            // the recipes have always promised it does not fail a pipeline.
+            const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
+            console.error(color.warning(`! Cloud sync skipped: ${err.error ?? "rate limit reached"}`));
+            console.error(chalk.dim(`  This run was not recorded. Limits reset hourly.`));
           } else {
-            const apiBase = process.env.DEMBRANDT_API_URL ?? "https://www.dembrandt.com";
-            const syncRes = await fetch(`${apiBase}/api/extractions`, {
-              method: "POST",
-              headers: {
-                "Authorization": `Bearer ${apiKey}`,
-                "Content-Type": "application/json",
-              },
-              body: payload,
-            });
-            if (syncRes.ok) {
-              savedNotices.push(chalk.dim(`☁  Synced to your account (--key)`));
-            } else if (syncRes.status === 429) {
-              // Hitting the rate limit is the system working, not a fault, and
-              // the recipes have always promised it does not fail a pipeline.
-              const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
-              console.error(color.warning(`! Cloud sync skipped: ${err.error ?? "rate limit reached"}`));
-              console.error(chalk.dim(`  This run was not recorded. Limits reset hourly.`));
-            } else {
-              const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
-              syncFailure(
-                `${err.error ?? syncRes.statusText} (HTTP ${syncRes.status})`,
-                syncRes.status === 401
+            const err = await syncRes.json().catch(() => ({ error: syncRes.statusText }));
+            const pageCount = result.pages?.length ?? 0;
+            syncFailure(
+              `${err.error ?? syncRes.statusText} (HTTP ${syncRes.status})`,
+              syncRes.status === 413
+                ? pageCount > 1
+                  ? `Extract fewer pages (--crawl ${Math.max(1, Math.floor(pageCount / 2))} or lower), or drop --raw-colors.`
+                  : `Drop --raw-colors, or open an issue if a single page really is this large.`
+                : syncRes.status === 401
                   ? `Check the API key at dembrandt.com/app/api-keys.`
                   : `Retry, or check dembrandt.com/app for service status.`,
-              );
-            }
+            );
           }
         } catch (syncErr) {
           syncFailure(syncErr.message, `Check network access to the API host and retry.`);


### PR DESCRIPTION
Follow-up to #169 (fix(sync): a skipped cloud sync fails the run instead of passing quietly), from reviewing main against the repo's own standards.

`lib/version.ts` opens with "Single source of truth" and exists because a value should have one owner. The sync path was doing the opposite: `MAX_BYTES = 300_000` in the CLI and `MAX_EXTRACTION_BYTES = 300_000` in the API, two constants in two repos, nothing watching whether they still agree.

Both drift directions have a real cost. Raise the server cap and the CLI keeps refusing at the old number, so the change does nothing until a CLI release ships. Lower it and the CLI happily sends a payload the server rejects — and since #169 that is a red build, for a reason the CLI could have stated before the request left.

So it stops guessing. It sends, and reads the answer. A 413 still produces the same page-count advice, derived from the run itself rather than from a number the CLI has no business knowing. Raising the cap is now a server-side change alone.

Needs dembrandt-next#121 (fix(api): answer 413 for an oversized extraction, not a generic 400) to land first, otherwise an oversized payload comes back as 400 and gets the generic "retry" remedy instead of the page-count one. Not a failure, just a less useful message.

606 tests pass, lint clean.