### PR TITLE
chore: cut the commentary back to what the code needs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -394,7 +394,6 @@ program
 
       // Collect "saved to" notices and print them after the results below
       const savedNotices = [];
-      // Set when --key was given but the snapshot did not reach the cloud.
       let syncFailed = false;
 
       // Save JSON output if --save-output or --dtcg is specified
@@ -605,19 +604,8 @@ program
         }
       }
 
-      // Sync to cloud if --key / DEMBRANDT_KEY is set.
-      //
-      // A failed sync used to print a warning and exit 0. In CI that warning
-      // scrolls past in a log nobody reads, the run reports success, and drift
-      // tracking silently never starts — invisible exactly where it matters.
-      // Passing --key states an intent, so failing to meet it is a failure of
-      // the run, on its own exit code (the extraction succeeded, so RUNTIME
-      // would be the wrong signal).
-      //
-      // Rate limiting is excluded on purpose. Hitting a quota is the system
-      // working as designed, not a fault to fix, and the published recipes
-      // promise it never fails a pipeline. A bad key, an oversized payload or
-      // an unreachable API are the opposite: nobody fixes what nobody sees.
+      // Sync to cloud if --key / DEMBRANDT_KEY is set. A failed sync exits
+      // SYNC_FAILED; a rate limit does not, and only warns.
       if (apiKey) {
         const syncFailure = (reason: string, remedy: string): void => {
           console.error(color.error(`✖ Cloud sync failed: ${reason}`));
@@ -716,8 +704,7 @@ program
         }
       }
 
-      // Drift (1) outranks this: a detected drift is the more actionable signal,
-      // and the sync failure is already printed above either way.
+      // Drift (1) outranks this.
       if (syncFailed && process.exitCode === undefined) process.exitCode = EXIT.SYNC_FAILED;
     } catch (err) {
       const { code, exit } = classifyError(err);

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -440,12 +440,8 @@ export function mergeResults(results) {
     iconSystem: mergeByName(results, r => r.iconSystem),
     frameworks: mergeByName(results, r => r.frameworks),
     ...(results.some(r => r.wcag) ? { wcag: mergeWcag(results) } : {}),
-    // Voice is deliberately NOT merged. Colours and type are tokens, so the same
-    // value on three pages is stronger evidence of one thing. Copy is not: the
-    // same CTA on three pages is one button seen three times, and averaging a
-    // marketing page's sentence length with a docs page's yields a number that
-    // describes neither. The variation between pages is the finding, so it is
-    // preserved per page and the root keeps the homepage's, as with rawColors.
+    // Not merged: the variation between pages is the signal. Root keeps the
+    // homepage's, each page keeps its own, as with rawColors.
     ...(home.voice !== undefined ? { voice: home.voice } : {}),
     ...(home.voiceSkipped ? { voiceSkipped: home.voiceSkipped } : {}),
     // rawColors are per-page filter diagnostics: merging them would destroy the

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -544,8 +544,8 @@ export interface VoiceStructuralMetrics {
 }
 
 /**
- * Language-dependent signals. Null in full outside supported languages: a zero
- * would read as a measured "no first-person voice" rather than "not measured".
+ * Language-dependent signals. Null in full outside supported languages, since a
+ * zero would read as measured rather than absent.
  */
 export interface VoiceLexicalMetrics {
   /** Pronoun stance. A closed word class, so this is counted, not guessed. */

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -36,11 +36,9 @@
 /**
  * dembrandt output contract version. Bump per the policy documented above.
  *
- *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in
- *          `--voice` flag and deliberately do NOT bump the contract. An
- *          undocumented flag has no consumers, so the role set can still be cut
- *          after the 15-site validation sweep without that being a breaking
- *          removal. Bump to 1.9.0 when the flag is documented, not before.
+ *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in flag
+ *          and deliberately do not bump the contract. Bump to 1.9.0 when the
+ *          flag is documented, not before.
  *  1.8.0 — no shape change. BEHAVIOR: the drift engine compares colors.semantic
  *          role by role. It previously read that map only to attach role labels
  *          to palette entries, so a changed brand primary produced no drift at

--- a/lib/voice/index.ts
+++ b/lib/voice/index.ts
@@ -9,11 +9,7 @@ export interface VoiceResult {
   voiceSkipped?: VoiceSkipReason;
 }
 
-/**
- * Fixed, deliberately unroutable path. A random one would change run to run on
- * the many 404 pages that echo the requested path back, turning the fragment
- * into drift noise. Long and specific enough that no real route collides.
- */
+/** Fixed and unroutable: a random path would churn on 404s that echo it back. */
 const PROBE_PATH = '/dembrandt-voice-probe-404-2f8a1c';
 
 async function readSignals(page: Page): Promise<PageTypeSignals & { lang: string }> {
@@ -28,12 +24,9 @@ async function readSignals(page: Page): Promise<PageTypeSignals & { lang: string
 
 /** Non-fatal: on failure the main page's fragments still stand. */
 async function probeErrorPage(page: Page, url: string, timeout: number): Promise<VoiceFragment[]> {
-  // A separate page in the same context: navigating the caller's page and
-  // restoring it would drop the hydration, reveal and consent state that
-  // everything downstream still reads.
+  // A separate page: navigating the caller's would drop its hydration state.
   let probe: Page | null = null;
   try {
-    // Inside the guard: a malformed URL must not abort the whole collection.
     const { origin } = new URL(url);
     probe = await page.context().newPage();
     await probe.goto(`${origin}${PROBE_PATH}`, { waitUntil: 'domcontentloaded', timeout });

--- a/lib/voice/metrics.ts
+++ b/lib/voice/metrics.ts
@@ -8,11 +8,9 @@ import type {
 } from '../types.js';
 
 /**
- * Only two lexical signals are kept: pronouns are a closed word class, and
- * Flesch is a published formula. Hand-built word lists for hedging, commitment,
- * urgency, jargon and imperative verbs were removed. They encoded an opinion and
- * presented it as a measurement, and being English-only they gave a Finnish page
- * nothing at all. That characterisation belongs to the layer reading `fragments`.
+ * Only signals that are counted from a closed word class or computed by a
+ * published formula. Anything resting on a curated word list is interpretation,
+ * and belongs to the layer that reads `fragments`.
  */
 
 /** Languages the Flesch formula models. */
@@ -25,9 +23,7 @@ const FIRST_PERSON = /\b(we|us|our|ours|ourselves)\b/gi;
 const SECOND_PERSON = /\b(you|your|yours|yourself)\b/gi;
 const THIRD_PERSON = /\b(they|them|their|theirs|themselves|it|its)\b/gi;
 
-// Headings are labels, not sentences. Counting "Pricing" or a bare product name
-// as a sentence inflates sentenceCount and drags mean sentence length toward the
-// length of a heading rather than of the prose.
+// Headings are labels, not sentences, and skew every sentence statistic.
 const HEADING_ROLES: ReadonlySet<VoiceRole> = new Set<VoiceRole>([
   'hero-h1',
   'section-h2',
@@ -51,24 +47,13 @@ const PROSE_ROLES: ReadonlySet<VoiceRole> = new Set<VoiceRole>([
   ...SENTENCE_ROLES,
 ]);
 
-// Measured across real brand sites: image-led marketing pages land at 220-330
-// prose words, so a 300 floor nulls out most of them. Below LOW_SAMPLE_WORDS the
-// sentence-length statistics are noisy and metrics carry `lowSample`.
-/**
- * Below this, emit nothing. Calibrated on English marketing pages, which yield
- * 90-330 prose words; a 300 floor nulled out most of them. Finnish yields
- * roughly 40% fewer words for the same content, so the floor sits closer to the
- * per-role limits there than intended. DEM-236 settles it with real data.
- */
+/** Below this, emit nothing. Calibrated on English pages; Finnish yields ~40% fewer words. */
 export const WORD_FLOOR = 150;
 
 /** Below this, sentence statistics are noisy and metrics carry `lowSample`. */
 export const LOW_SAMPLE_WORDS = 300;
 
-/**
- * Upper bound on collected copy. No site measured has come close, so this is a
- * guard against a pathological page rather than a tuned budget.
- */
+/** Guard against a pathological page rather than a tuned budget. */
 export const WORD_CAP = 800;
 
 export const PAGE_TYPE_CAP: Record<VoicePageType, number> = {


### PR DESCRIPTION
38 lines of comment removed across the voice extractor, the merger and the sync path.

The removed ones explained history ("used to print a warning and exit 0"), justified rejected alternatives, or recorded what a measurement showed. That is commit-message and ticket material. In the source of a public repo it ages the moment the code moves, and it reads as an internal conversation rather than as help for whoever is reading the function.

What stayed states a constraint that is not visible from the code: that headings skew sentence statistics, that the 404 probe needs its own page, that voice is deliberately not merged across pages. Those change what a reader would otherwise get wrong.

606 tests pass, lint clean, no behaviour touched.