### PR TITLE
feat(mcp): job_id handoff, multi-page crawl, container-safe launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
+### Added
+- MCP extraction tools take `pages`, `paths` and `sitemap`, crawling and merging several pages over the same path as the CLI. `sitemap` alone takes up to 20 pages; `pages` caps it. A page that fails to load is dropped and the merge carries the rest (#172)
+- MCP extraction tools take `noSandbox` (also `DEMBRANDT_NO_SANDBOX`) for Docker and CI containers, plus `header` and `userAgent`. A launch failure names `noSandbox` as the remedy (#172)
+- `compute_drift`, `get_findings`, `export_dtcg`, `generate_design_md` and `render_report` accept the `job_id` of a completed extraction in place of an inline one. They previously took the whole extraction as a tool argument, so an agent had to resend a result it had just received, which is prohibitive at real extraction sizes. An inline extraction still wins when both are given (#172)
+
 ### Fixed
+- MCP: two concurrent extractions restored each other's console handlers, so the second job's output could land in the JSON-RPC stream. Console is silenced once per process instead (#172)
+- MCP: `meta.dembrandtVersion` and the DTCG `toolVersion` were null on every extraction, because the server never passed the tool version to the extractor (#172)
+- MCP: the job cleanup interval kept the event loop alive, so the process outlived its transport by minutes (#172)
+- `BrandingResult._discoveredLinks` is typed `string[]`. `discoverLinks` has always returned href strings, which the crawl path feeds straight to `new URL()` (#172)
 - Drift compares `colors.semantic` role by role. The engine read that map only to attach role labels to palette entries, so a changed brand primary produced no drift at all: a rebrand that promotes a colour the page already used leaves the palette set identical and reported stable (DEM-208). Changes now appear as `semantic.<role>`, and `docs/FLAGS.md` no longer describes `--ai` primary drift the engine could not see
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,7 +95,18 @@ Or add to your project's `.mcp.json`:
 }
 ```
 
-Available tools include `get_design_tokens`, `get_color_palette`, `get_typography`, `get_component_styles`, `get_surfaces`, `get_spacing`, and `get_brand_identity`, plus pure analysis tools (`compute_drift`, `get_findings`, `export_dtcg`, `generate_design_md`, `render_report`) and job-control tools. Extraction tools accept `mobile`, `cookie` (for authenticated pages), and `wcag` options.
+Available tools include `get_design_tokens`, `get_color_palette`, `get_typography`, `get_component_styles`, `get_surfaces`, `get_spacing`, and `get_brand_identity`, plus pure analysis tools (`compute_drift`, `get_findings`, `export_dtcg`, `generate_design_md`, `render_report`) and job-control tools.
+
+Extraction tools accept `slow`, `mobile`, `darkMode`, `wcag`, `cookie` and `header` (for authenticated pages), `userAgent`, and `noSandbox` (Docker and most CI containers). Set `pages` above 1 to crawl and merge several pages, which produces a markedly stronger token set than one page; `paths` names them explicitly and `sitemap` discovers them from sitemap.xml.
+
+Extraction returns a `job_id`. Poll it with `get_job_status`, then hand that same id to the pure tools instead of passing the extraction back as an argument:
+
+```
+get_design_tokens(url: "example.com", pages: 5)  ->  job_id
+get_job_status(job_id)                           ->  tokens
+get_findings(job_id)                             ->  contrast and consistency issues
+export_dtcg(job_id)                              ->  W3C design tokens
+```
 
 Pair with **[dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** to give your agent UX intelligence on top of extracted tokens: hierarchy, accessibility, interaction states, and a full 6-stage design pipeline orchestrator.
 

--- a/lib/mcp/jobs.ts
+++ b/lib/mcp/jobs.ts
@@ -1,0 +1,181 @@
+/**
+ * The MCP job queue. Extraction takes tens of seconds, far longer than a client
+ * will wait on a tool call, so tools enqueue and return a job_id.
+ */
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface JobResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface Job<T> {
+  status: JobStatus;
+  url: string;
+  createdAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  /** The slice the requesting tool asked for. */
+  result?: unknown;
+  /** The whole extraction, so later tools can read it back by job_id. */
+  full?: T;
+  error?: string;
+}
+
+export interface JobSummary {
+  job_id: string;
+  status: JobStatus;
+  url: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+export interface JobQueueOptions<T> {
+  run: (url: string, options: unknown) => Promise<JobResult<T>>;
+  maxConcurrent?: number;
+  /** How long a finished job stays readable. */
+  ttlMs?: number;
+  now?: () => number;
+}
+
+/** Completed jobs stay readable for an hour so later tools can cite their id. */
+export const DEFAULT_JOB_TTL_MS = 3_600_000;
+
+export class JobQueue<T = unknown> {
+  #jobs = new Map<string, Job<T> & { opts: unknown; pick: (data: T) => unknown }>();
+  #queue: string[] = [];
+  #running = new Set<string>();
+  #run: JobQueueOptions<T>['run'];
+  #maxConcurrent: number;
+  #ttlMs: number;
+  #now: () => number;
+  /** Resolves once nothing is queued or running. Test seam; also useful for shutdown. */
+  #idle: Promise<void> = Promise.resolve();
+  #settleIdle: () => void = () => {};
+
+  constructor({ run, maxConcurrent = 2, ttlMs = DEFAULT_JOB_TTL_MS, now = Date.now }: JobQueueOptions<T>) {
+    this.#run = run;
+    this.#maxConcurrent = maxConcurrent;
+    this.#ttlMs = ttlMs;
+    this.#now = now;
+  }
+
+  enqueue(url: string, opts: unknown, pick: (data: T) => unknown): string {
+    const id = `job_${this.#now()}_${Math.random().toString(36).slice(2, 8)}`;
+    this.#jobs.set(id, { status: 'queued', url, opts, pick, createdAt: this.#now() });
+    this.#queue.push(id);
+    if (this.#running.size === 0 && this.#queue.length === 1) {
+      this.#idle = new Promise((resolve) => { this.#settleIdle = resolve; });
+    }
+    void this.#drain();
+    return id;
+  }
+
+  get(id: string): Job<T> | null {
+    return this.#jobs.get(id) ?? null;
+  }
+
+  list(): JobSummary[] {
+    return Array.from(this.#jobs, ([id, job]) => ({
+      job_id: id,
+      status: job.status,
+      url: job.url,
+      createdAt: job.createdAt,
+      completedAt: job.completedAt,
+    }));
+  }
+
+  /** Only a job that has not started can be cancelled; a running browser is left alone. */
+  cancel(id: string): boolean {
+    const job = this.#jobs.get(id);
+    if (!job || job.status !== 'queued') return false;
+    job.status = 'cancelled';
+    job.completedAt = this.#now();
+    const idx = this.#queue.indexOf(id);
+    if (idx !== -1) this.#queue.splice(idx, 1);
+    if (this.#queue.length === 0 && this.#running.size === 0) this.#settleIdle();
+    return true;
+  }
+
+  /** Resolves when every queued and running job has settled. */
+  idle(): Promise<void> {
+    if (this.#queue.length === 0 && this.#running.size === 0) return Promise.resolve();
+    return this.#idle;
+  }
+
+  async #drain(): Promise<void> {
+    while (this.#queue.length > 0 && this.#running.size < this.#maxConcurrent) {
+      const id = this.#queue.shift() as string;
+      const job = this.#jobs.get(id);
+      if (!job || job.status === 'cancelled') continue;
+
+      job.status = 'running';
+      job.startedAt = this.#now();
+      this.#running.add(id);
+
+      this.#run(job.url, job.opts)
+        .then((result) => {
+          if (job.status === 'cancelled') return;
+          if (result.ok) {
+            job.status = 'completed';
+            job.full = result.data;
+            job.result = job.pick(result.data as T);
+          } else {
+            job.status = 'failed';
+            job.error = result.error;
+          }
+        })
+        .catch((err: unknown) => {
+          if (job.status !== 'cancelled') {
+            job.status = 'failed';
+            job.error = err instanceof Error ? err.message : String(err);
+          }
+        })
+        .finally(() => {
+          job.completedAt = this.#now();
+          this.#running.delete(id);
+          if (this.#queue.length === 0 && this.#running.size === 0) this.#settleIdle();
+          void this.#drain();
+        });
+    }
+  }
+
+  /** Drop finished jobs past the TTL so a long-lived server does not grow without bound. */
+  cleanup(): void {
+    const cutoff = this.#now() - this.#ttlMs;
+    for (const [id, job] of this.#jobs) {
+      if (
+        ['completed', 'failed', 'cancelled'].includes(job.status) &&
+        job.completedAt !== undefined &&
+        job.completedAt < cutoff
+      ) {
+        this.#jobs.delete(id);
+      }
+    }
+  }
+}
+
+export type Resolved<T> =
+  | { ok: true; value: T; error?: undefined }
+  | { ok: false; value?: undefined; error: string };
+
+/**
+ * Pure tools accept either an inline extraction or the job_id of a completed
+ * one. The job path exists because an inline extraction has to travel back
+ * through the model as a tool argument, which is prohibitively large.
+ */
+export function resolveExtraction<T>(
+  inline: T | undefined,
+  jobId: string | undefined,
+  label: string,
+  queue: Pick<JobQueue<T>, 'get'>,
+): Resolved<T> {
+  if (inline && Object.keys(inline as object).length > 0) return { ok: true, value: inline };
+  if (!jobId) return { ok: false, error: `Pass either ${label} or job_id.` };
+  const job = queue.get(jobId);
+  if (!job) return { ok: false, error: `No job found with id: ${jobId}` };
+  if (job.status !== 'completed') return { ok: false, error: `Job ${jobId} is ${job.status}, not completed.` };
+  return { ok: true, value: job.full as T };
+}

--- a/lib/mcp/options.ts
+++ b/lib/mcp/options.ts
@@ -1,0 +1,111 @@
+import { parseSitemap } from '../discovery.js';
+import type { BrandingResult } from '../types.js';
+
+/**
+ * The slice of an extraction the crawl logic reads. Every field beyond the URL
+ * is optional so a test can state only what it exercises.
+ */
+export interface Extraction extends Partial<BrandingResult> {
+  url: string;
+}
+
+/** The navigation, auth and crawl surface every MCP extraction tool accepts. */
+export interface ExtractionRequest {
+  slow?: boolean;
+  darkMode?: boolean;
+  mobile?: boolean;
+  wcag?: boolean;
+  cookie?: string;
+  header?: string;
+  userAgent?: string;
+  noSandbox?: boolean;
+  pages?: number;
+  paths?: string[];
+  sitemap?: boolean;
+}
+
+/** Extra pages a bare `sitemap: true` takes when no budget is given, matching the CLI. */
+export const SITEMAP_DEFAULT_PAGES = 20;
+
+export function launchArgs(noSandbox?: boolean, env: NodeJS.ProcessEnv = process.env): string[] {
+  const args = ['--disable-blink-features=AutomationControlled'];
+  if (noSandbox || env.DEMBRANDT_NO_SANDBOX) {
+    args.push('--no-sandbox', '--disable-setuid-sandbox');
+  }
+  return args;
+}
+
+/**
+ * Translate one MCP request into extractBranding() options. Shared by the first
+ * page and every crawled page so a merged run cannot drift from the first hit.
+ */
+export function extractOptions(req: ExtractionRequest, version: string) {
+  return {
+    navigationTimeout: 90000,
+    slow: req.slow || false,
+    darkMode: req.darkMode || false,
+    mobile: req.mobile || false,
+    wcag: req.wcag || false,
+    _version: version,
+    ...(req.cookie ? { cookie: req.cookie } : {}),
+    ...(req.header ? { header: req.header } : {}),
+    ...(req.userAgent ? { userAgent: req.userAgent } : {}),
+  };
+}
+
+/** How many pages beyond the first the request asks for. 0 means a single page. */
+export function pageBudget(req: ExtractionRequest): number {
+  if (req.paths?.length) return req.paths.length;
+  const requested = req.pages ?? 1;
+  if (requested > 1) return requested - 1;
+  return req.sitemap ? SITEMAP_DEFAULT_PAGES : 0;
+}
+
+export function isMultiPage(req: ExtractionRequest): boolean {
+  return pageBudget(req) > 0;
+}
+
+/**
+ * How many links the first extraction should discover. Null unless the request
+ * needs DOM discovery: explicit paths and sitemap crawls resolve their own URLs.
+ */
+export function discoveryBudget(req: ExtractionRequest): number | null {
+  if (req.paths?.length || req.sitemap) return null;
+  const budget = pageBudget(req);
+  return budget > 0 ? budget : null;
+}
+
+/** Resolve caller-supplied paths against the page actually landed on. */
+export function resolvePaths(baseUrl: string, paths: string[]): string[] {
+  const base = new URL(baseUrl);
+  return paths.map((path) =>
+    path.startsWith('http') ? path : `${base.protocol}//${base.host}${path.startsWith('/') ? path : '/' + path}`,
+  );
+}
+
+/**
+ * The extra page URLs to merge into the first result: explicit paths, sitemap
+ * entries, or the links discovered while extracting the first page.
+ *
+ * `requestedUrl` is the URL the caller asked for. It differs from the result URL
+ * whenever the site redirected, and a sitemap can live under either.
+ */
+export async function additionalPages(
+  first: Extraction,
+  requestedUrl: string,
+  req: ExtractionRequest,
+  fetchSitemap: (url: string, max: number) => Promise<string[]> = parseSitemap,
+): Promise<string[]> {
+  if (req.paths?.length) return resolvePaths(first.url, req.paths);
+
+  const max = pageBudget(req);
+  if (max < 1) return [];
+
+  if (req.sitemap) {
+    const fromResult = await fetchSitemap(first.url, max);
+    if (fromResult.length > 0) return fromResult;
+    return first.url !== requestedUrl ? await fetchSitemap(requestedUrl, max) : [];
+  }
+
+  return (first._discoveredLinks ?? []).slice(0, max);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -430,7 +430,7 @@ export interface BrandingResult {
   note?: string;
   isCanvasOnly?: boolean;
   /** Internal/transient fields used during crawl + merge. Never persist; see stripTransient(). */
-  _discoveredLinks?: DiscoveredLink[];
+  _discoveredLinks?: string[];
   _extractedUrls?: string[];
   _pageResults?: BrandingResult[];
 }

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -19,8 +19,10 @@ import { computeFindings } from "./lib/findings.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
 import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generateDesignMd } from "./lib/formatters/markdown.js";
-import { parseSitemap } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
+import { additionalPages, discoveryBudget, extractOptions, isMultiPage, launchArgs } from "./lib/mcp/options.js";
+import type { Extraction, ExtractionRequest } from "./lib/mcp/options.js";
+import { JobQueue, resolveExtraction } from "./lib/mcp/jobs.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -63,53 +65,11 @@ const nullSpinner = {
   info(_msg) { return this; },
 };
 
-function launchArgs(noSandbox: boolean) {
-  const args = ["--disable-blink-features=AutomationControlled"];
-  if (noSandbox || process.env.DEMBRANDT_NO_SANDBOX) {
-    args.push("--no-sandbox", "--disable-setuid-sandbox");
-  }
-  return args;
-}
-
-function extractOptions(options: any) {
-  return {
-    navigationTimeout: 90000,
-    slow: options.slow || false,
-    darkMode: options.darkMode || false,
-    mobile: options.mobile || false,
-    wcag: options.wcag || false,
-    _version: version,
-    ...(options.cookie ? { cookie: options.cookie } : {}),
-    ...(options.header ? { header: options.header } : {}),
-    ...(options.userAgent ? { userAgent: options.userAgent } : {}),
-  };
-}
-
-/** Resolve the extra page URLs to merge into the first result. */
-async function additionalPages(first: any, requestedUrl: string, options: any) {
-  const paths: string[] = options.paths ?? [];
-  if (paths.length > 0) {
-    const base = new URL(first.url);
-    return paths.map((path) =>
-      path.startsWith("http") ? path : `${base.protocol}//${base.host}${path.startsWith("/") ? path : "/" + path}`,
-    );
-  }
-  // A sitemap crawl with no explicit budget follows the CLI and takes up to 20.
-  const max = (options.pages ?? 1) > 1 ? (options.pages as number) - 1 : options.sitemap ? 20 : 0;
-  if (max < 1) return [];
-  if (options.sitemap) {
-    const fromResult = await parseSitemap(first.url, max);
-    if (fromResult.length > 0) return fromResult;
-    return first.url !== requestedUrl ? await parseSitemap(requestedUrl, max) : [];
-  }
-  return first._discoveredLinks ?? [];
-}
-
 /**
  * Run extraction with error handling suitable for MCP responses.
  * Returns { ok, data?, error? } so tool handlers never throw.
  */
-async function runExtraction(url: string, options: any = {}) {
+async function runExtraction(url: string, options: ExtractionRequest = {}) {
   if (!/^https?:\/\//i.test(url)) url = "https://" + url;
   let browser;
   let chromium;
@@ -132,15 +92,13 @@ async function runExtraction(url: string, options: any = {}) {
     };
   }
 
-  const multiPage = (options.paths?.length ?? 0) > 0 || (options.pages ?? 1) > 1 || !!options.sitemap;
-
   try {
-    const first = await extractBranding(url, nullSpinner, browser, {
-      ...extractOptions(options),
-      discoverLinks: multiPage && !options.sitemap && !(options.paths?.length) ? (options.pages ?? 1) - 1 : null,
+    const first: Extraction = await extractBranding(url, nullSpinner, browser, {
+      ...extractOptions(options, version),
+      discoverLinks: discoveryBudget(options),
     });
 
-    if (!multiPage) {
+    if (!isMultiPage(options)) {
       delete first._discoveredLinks;
       return { ok: true, data: first };
     }
@@ -152,7 +110,7 @@ async function runExtraction(url: string, options: any = {}) {
     for (const pageUrl of extraUrls) {
       await new Promise((r) => setTimeout(r, 1500 + Math.random() * 1500));
       try {
-        const pageResult = await extractBranding(pageUrl, nullSpinner, browser, extractOptions(options));
+        const pageResult: Extraction = await extractBranding(pageUrl, nullSpinner, browser, extractOptions(options, version));
         delete pageResult._discoveredLinks;
         results.push(pageResult);
       } catch {
@@ -186,109 +144,7 @@ function errorResult(message) {
   return { content: [{ type: "text", text: message }], isError: true };
 }
 
-// ── Job Queue ──────────────────────────────────────────────────────────
-
-class JobQueue {
-  #jobs = new Map();
-  #queue = [];
-  #running = new Set();
-  #maxConcurrent = 2;
-
-  enqueue(url, opts, pick) {
-    const id = `job_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    this.#jobs.set(id, {
-      status: "queued",
-      url,
-      opts,
-      pick,
-      createdAt: Date.now(),
-      startedAt: undefined,
-      completedAt: undefined,
-      result: undefined,
-      full: undefined,
-      error: undefined,
-    });
-    this.#queue.push(id);
-    void this.#drain();
-    return id;
-  }
-
-  get(id) {
-    return this.#jobs.get(id) ?? null;
-  }
-
-  list() {
-    return Array.from(this.#jobs, ([id, job]) => ({
-      job_id: id,
-      status: job.status,
-      url: job.url,
-      createdAt: job.createdAt,
-      completedAt: job.completedAt,
-    }));
-  }
-
-  cancel(id) {
-    const job = this.#jobs.get(id);
-    if (!job || job.status !== "queued") return false;
-    job.status = "cancelled";
-    job.completedAt = Date.now();
-    const idx = this.#queue.indexOf(id);
-    if (idx !== -1) this.#queue.splice(idx, 1);
-    return true;
-  }
-
-  async #drain() {
-    while (this.#queue.length > 0 && this.#running.size < this.#maxConcurrent) {
-      const id = this.#queue.shift();
-      const job = this.#jobs.get(id);
-      if (!job || job.status === "cancelled") continue;
-
-      job.status = "running";
-      job.startedAt = Date.now();
-      this.#running.add(id);
-
-      runExtraction(job.url, job.opts)
-        .then((result) => {
-          if (job.status === "cancelled") return;
-          if (result.ok) {
-            job.status = "completed";
-            job.full = result.data;
-            job.result = job.pick(result.data);
-          } else {
-            job.status = "failed";
-            job.error = result.error;
-          }
-        })
-        .catch((err) => {
-          if (job.status !== "cancelled") {
-            job.status = "failed";
-            job.error = err.message || String(err);
-          }
-        })
-        .finally(() => {
-          job.completedAt = Date.now();
-          this.#running.delete(id);
-          void this.#drain();
-        });
-    }
-  }
-
-  // Remove completed/failed/cancelled jobs older than 1 hour
-  cleanup() {
-    const cutoff = Date.now() - 3_600_000;
-    for (const [id, job] of this.#jobs) {
-      if (
-        ["completed", "failed", "cancelled"].includes(job.status) &&
-        job.completedAt !== undefined &&
-        job.completedAt < cutoff
-      ) {
-        this.#jobs.delete(id);
-      }
-    }
-  }
-}
-
-const jobQueue = new JobQueue();
+const jobQueue = new JobQueue<Extraction>({ run: runExtraction });
 const cleanupTimer = setInterval(() => jobQueue.cleanup(), 600_000);
 cleanupTimer.unref();
 
@@ -339,14 +195,14 @@ async function main() {
 
   const url = z.string().describe("Website URL (e.g. example.com)");
   const slow = z.boolean().optional().default(false).describe("3x timeouts for heavy SPAs");
-  const sync = z.boolean().optional().default(false).describe("Wait for result directly instead of returning a job_id (blocks 15-40s)");
+  const sync = z.boolean().optional().default(false).describe("Wait for the result directly instead of returning a job_id. Blocks 15-40s for one page, and proportionally longer for a multi-page crawl.");
   const mobile = z.boolean().optional().default(false).describe("Extract from a mobile viewport instead of desktop");
   const cookie = z.string().optional().describe('Cookie string for authenticated pages, e.g. "session=abc; token=xyz"');
   const header = z.string().optional().describe('Extra HTTP header, e.g. "Authorization: Bearer eyJ..."');
   const userAgent = z.string().optional().describe("Custom user agent string");
   const noSandbox = z.boolean().optional().default(false).describe("Disable the browser sandbox, required inside Docker and most CI containers");
   const pages = z.number().int().min(1).max(20).optional().default(1).describe("Extract up to N pages and merge them into one token set. Pages are discovered from DOM links, or from sitemap.xml when sitemap is true. Merged tokens are markedly stronger than a single page.");
-  const paths = z.array(z.string()).optional().describe('Explicit extra paths on the same domain to extract and merge, e.g. ["/pricing", "/docs"]. Overrides page discovery.');
+  const paths = z.array(z.string()).max(20).optional().describe('Explicit extra paths on the same domain to extract and merge, e.g. ["/pricing", "/docs"]. Overrides page discovery.');
   const sitemap = z.boolean().optional().default(false).describe("Discover the extra pages from sitemap.xml instead of DOM links. Alone it takes up to 20 pages; set pages to cap it");
 
   // Every extraction tool takes the same navigation, auth and crawl surface.
@@ -427,20 +283,6 @@ async function main() {
 
   // ── Drift & report tools (synchronous, no browser) ─────────────────────
 
-  /**
-   * Pure tools accept either an inline extraction or the job_id of a completed
-   * one. The job path exists because an inline extraction has to travel back
-   * through the model as a tool argument, which is prohibitively large.
-   */
-  function resolveExtraction(inline: any, jobId: string | undefined, label: string) {
-    if (inline && Object.keys(inline).length > 0) return { ok: true as const, value: inline };
-    if (!jobId) return { ok: false as const, error: `Pass either ${label} or job_id.` };
-    const job = jobQueue.get(jobId);
-    if (!job) return { ok: false as const, error: `No job found with id: ${jobId}` };
-    if (job.status !== "completed") return { ok: false as const, error: `Job ${jobId} is ${job.status}, not completed.` };
-    return { ok: true as const, value: job.full };
-  }
-
   // zod 4: z.record needs explicit key + value types; z.record(z.any()) treats
   // the lone arg as the KEY and leaves value undefined, which crashes tools/list.
   const extract = z
@@ -463,9 +305,9 @@ async function main() {
       failThreshold: z.number().optional().describe("Score above this yields a 'drift' verdict (default 10)"),
     },
     ({ baseline, candidate, baselineJobId, candidateJobId, failThreshold }: any) => {
-      const a = resolveExtraction(baseline, baselineJobId, "baseline");
+      const a = resolveExtraction(baseline, baselineJobId, "baseline", jobQueue);
       if (!a.ok) return errorResult(a.error);
-      const b = resolveExtraction(candidate, candidateJobId, "candidate");
+      const b = resolveExtraction(candidate, candidateJobId, "candidate", jobQueue);
       if (!b.ok) return errorResult(b.error);
       const report = computeDrift(a.value, b.value, failThreshold != null ? { failThreshold } : {});
       return jsonResult(report);
@@ -481,7 +323,7 @@ async function main() {
       drift: z.any().optional().describe("A drift report from compute_drift, to render the diff banner"),
     },
     ({ result, job_id, drift }: any) => {
-      const source = resolveExtraction(result, job_id, "result");
+      const source = resolveExtraction(result, job_id, "result", jobQueue);
       if (!source.ok) return errorResult(source.error);
       const html = generateHtmlReport(source.value, { drift: drift ?? undefined });
       return { content: [{ type: "text", text: html }] };
@@ -493,7 +335,7 @@ async function main() {
     "Lint a dembrandt extraction for design-system quality issues: WCAG contrast failures, inconsistency (near-duplicate colors, off-scale spacing values, radius sprawl), and duplication. Returns findings with severity (error/warn), category, and a human-readable message, plus summary counts. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Complements compute_drift: drift asks 'did it change', findings asks 'is it good'.",
     { result: extract, job_id: sourceJob },
     ({ result, job_id }: any) => {
-      const source = resolveExtraction(result, job_id, "result");
+      const source = resolveExtraction(result, job_id, "result", jobQueue);
       return source.ok ? jsonResult(computeFindings(source.value)) : errorResult(source.error);
     },
   );
@@ -503,7 +345,7 @@ async function main() {
     "Convert a dembrandt extraction to W3C Design Tokens (DTCG) format: color, typography, spacing, radius, border, and shadow tokens with $type/$value structure and dembrandt provenance under $extensions. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Use it to hand tokens to Style Dictionary, Figma token plugins, or any DTCG-compatible pipeline.",
     { result: extract, job_id: sourceJob },
     ({ result, job_id }: any) => {
-      const source = resolveExtraction(result, job_id, "result");
+      const source = resolveExtraction(result, job_id, "result", jobQueue);
       return source.ok ? jsonResult(toDtcgTokens(source.value)) : errorResult(source.error);
     },
   );
@@ -513,7 +355,7 @@ async function main() {
     "Render a DESIGN.md brand guide (markdown) from a dembrandt extraction: colors, typography, spacing, surfaces, and components as a human-readable design reference. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Write the output to DESIGN.md in a project so agents and developers build UI against the extracted brand.",
     { result: extract, job_id: sourceJob },
     ({ result, job_id }: any) => {
-      const source = resolveExtraction(result, job_id, "result");
+      const source = resolveExtraction(result, job_id, "result", jobQueue);
       if (!source.ok) return errorResult(source.error);
       return { content: [{ type: "text", text: generateDesignMd(source.value) }] };
     },

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -19,6 +19,8 @@ import { computeFindings } from "./lib/findings.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
 import { toDtcgTokens } from "./lib/formatters/dtcg.js";
 import { generateDesignMd } from "./lib/formatters/markdown.js";
+import { parseSitemap } from "./lib/discovery.js";
+import { mergeResults } from "./lib/merger.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -61,6 +63,47 @@ const nullSpinner = {
   info(_msg) { return this; },
 };
 
+function launchArgs(noSandbox: boolean) {
+  const args = ["--disable-blink-features=AutomationControlled"];
+  if (noSandbox || process.env.DEMBRANDT_NO_SANDBOX) {
+    args.push("--no-sandbox", "--disable-setuid-sandbox");
+  }
+  return args;
+}
+
+function extractOptions(options: any) {
+  return {
+    navigationTimeout: 90000,
+    slow: options.slow || false,
+    darkMode: options.darkMode || false,
+    mobile: options.mobile || false,
+    wcag: options.wcag || false,
+    _version: version,
+    ...(options.cookie ? { cookie: options.cookie } : {}),
+    ...(options.header ? { header: options.header } : {}),
+    ...(options.userAgent ? { userAgent: options.userAgent } : {}),
+  };
+}
+
+/** Resolve the extra page URLs to merge into the first result. */
+async function additionalPages(first: any, requestedUrl: string, options: any) {
+  const paths: string[] = options.paths ?? [];
+  if (paths.length > 0) {
+    const base = new URL(first.url);
+    return paths.map((path) =>
+      path.startsWith("http") ? path : `${base.protocol}//${base.host}${path.startsWith("/") ? path : "/" + path}`,
+    );
+  }
+  const max = (options.pages ?? 1) - 1;
+  if (max < 1) return [];
+  if (options.sitemap) {
+    const fromResult = await parseSitemap(first.url, max);
+    if (fromResult.length > 0) return fromResult;
+    return first.url !== requestedUrl ? await parseSitemap(requestedUrl, max) : [];
+  }
+  return first._discoveredLinks ?? [];
+}
+
 /**
  * Run extraction with error handling suitable for MCP responses.
  * Returns { ok, data?, error? } so tool handlers never throw.
@@ -77,36 +120,46 @@ async function runExtraction(url: string, options: any = {}) {
   }
   const pwVersion = createRequire(import.meta.url)("playwright-core/package.json").version;
   try {
-    browser = await chromium.launch({
-      headless: true,
-      args: ["--disable-blink-features=AutomationControlled"],
-    });
+    browser = await chromium.launch({ headless: true, args: launchArgs(options.noSandbox) });
   } catch (err) {
+    const sandboxHint = options.noSandbox
+      ? ""
+      : "\n\nIn a container or CI sandbox, retry with noSandbox: true.";
     return {
       ok: false,
-      error: `Browser launch failed. Install the matching browser: npx playwright@${pwVersion} install chromium\n\n${err.message}`,
+      error: `Browser launch failed. Install the matching browser: npx playwright@${pwVersion} install chromium${sandboxHint}\n\n${err.message}`,
     };
   }
 
-  // Suppress console output — extractors.js writes directly to stdout
-  // which would corrupt the JSON-RPC stream
-  const _log = console.log;
-  const _warn = console.warn;
-  const _error = console.error;
-  console.log = () => {};
-  console.warn = () => {};
-  console.error = () => {};
+  const multiPage = (options.paths?.length ?? 0) > 0 || (options.pages ?? 1) > 1;
 
   try {
-    const data = await extractBranding(url, nullSpinner, browser, {
-      navigationTimeout: 90000,
-      slow: options.slow || false,
-      darkMode: options.darkMode || false,
-      mobile: options.mobile || false,
-      wcag: options.wcag || false,
-      ...(options.cookie ? { cookie: options.cookie } : {}),
+    const first = await extractBranding(url, nullSpinner, browser, {
+      ...extractOptions(options),
+      discoverLinks: multiPage && !options.sitemap && !(options.paths?.length) ? (options.pages ?? 1) - 1 : null,
     });
-    return { ok: true, data };
+
+    if (!multiPage) {
+      delete first._discoveredLinks;
+      return { ok: true, data: first };
+    }
+
+    const extraUrls = await additionalPages(first, url, options);
+    delete first._discoveredLinks;
+
+    const results = [first];
+    for (const pageUrl of extraUrls) {
+      await new Promise((r) => setTimeout(r, 1500 + Math.random() * 1500));
+      try {
+        const pageResult = await extractBranding(pageUrl, nullSpinner, browser, extractOptions(options));
+        delete pageResult._discoveredLinks;
+        results.push(pageResult);
+      } catch {
+        // A page that fails to load is dropped; the merge still carries the rest.
+      }
+    }
+
+    return { ok: true, data: results.length > 1 ? mergeResults(results) : first };
   } catch (err) {
     const msg = err.message || String(err);
     if (msg.includes("timeout") || msg.includes("Timeout")) {
@@ -120,9 +173,6 @@ async function runExtraction(url: string, options: any = {}) {
     }
     return { ok: false, error: `Extraction failed for ${url}: ${msg}` };
   } finally {
-    console.log = _log;
-    console.warn = _warn;
-    console.error = _error;
     await browser.close().catch(() => {});
   }
 }
@@ -154,6 +204,7 @@ class JobQueue {
       startedAt: undefined,
       completedAt: undefined,
       result: undefined,
+      full: undefined,
       error: undefined,
     });
     this.#queue.push(id);
@@ -200,6 +251,7 @@ class JobQueue {
           if (job.status === "cancelled") return;
           if (result.ok) {
             job.status = "completed";
+            job.full = result.data;
             job.result = job.pick(result.data);
           } else {
             job.status = "failed";
@@ -236,7 +288,8 @@ class JobQueue {
 }
 
 const jobQueue = new JobQueue();
-setInterval(() => jobQueue.cleanup(), 600_000);
+const cleanupTimer = setInterval(() => jobQueue.cleanup(), 600_000);
+cleanupTimer.unref();
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -272,6 +325,13 @@ async function main() {
     process.exit(1);
   }
 
+  // stdout is the JSON-RPC stream. Anything a dependency prints would corrupt
+  // it, so silence console for the process once. Per-call save/restore is not
+  // an option: two concurrent extractions would restore each other's handlers.
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+
   const server = new McpServer({ name: "dembrandt", version });
 
   // ── Shared params ──────────────────────────────────────────────────────
@@ -281,14 +341,24 @@ async function main() {
   const sync = z.boolean().optional().default(false).describe("Wait for result directly instead of returning a job_id (blocks 15-40s)");
   const mobile = z.boolean().optional().default(false).describe("Extract from a mobile viewport instead of desktop");
   const cookie = z.string().optional().describe('Cookie string for authenticated pages, e.g. "session=abc; token=xyz"');
+  const header = z.string().optional().describe('Extra HTTP header, e.g. "Authorization: Bearer eyJ..."');
+  const userAgent = z.string().optional().describe("Custom user agent string");
+  const noSandbox = z.boolean().optional().default(false).describe("Disable the browser sandbox, required inside Docker and most CI containers");
+  const pages = z.number().int().min(1).max(20).optional().default(1).describe("Extract up to N pages and merge them into one token set. Pages are discovered from DOM links, or from sitemap.xml when sitemap is true. Merged tokens are markedly stronger than a single page.");
+  const paths = z.array(z.string()).optional().describe('Explicit extra paths on the same domain to extract and merge, e.g. ["/pricing", "/docs"]. Overrides page discovery.');
+  const sitemap = z.boolean().optional().default(false).describe("Discover the extra pages from sitemap.xml instead of DOM links; needs pages > 1");
+
+  // Every extraction tool takes the same navigation, auth and crawl surface.
+  const crawlParams = { pages, paths, sitemap };
+  const browserParams = { slow, mobile, cookie, header, userAgent, noSandbox };
 
   // ── Extraction tools ───────────────────────────────────────────────────
 
   (server.tool as any)(
     "get_design_tokens",
-    "Extract the full design system from a live website. Launches a real browser, navigates to the site, and returns production-ready design tokens: color palette (hex, RGB, LCH, OKLCH) with semantic roles and CSS custom properties, typography scale (families, fallbacks, sizes, weights, line heights, letter spacing by context), spacing system with grid detection, border radii, border patterns, box shadows for elevation, component styles (buttons with hover/focus states, inputs, links, badges), responsive breakpoints, logo and favicons, site name, detected CSS frameworks, and icon systems. Returns a job_id by default — use get_job_status to poll for the result.",
+    "Extract the full design system from a live website. Launches a real browser, navigates to the site, and returns production-ready design tokens: color palette (hex, RGB, LCH, OKLCH) with semantic roles and CSS custom properties, typography scale (families, fallbacks, sizes, weights, line heights, letter spacing by context), spacing system with grid detection, border radii, border patterns, box shadows for elevation, component styles (buttons with hover/focus states, inputs, links, badges), responsive breakpoints, logo and favicons, site name, detected CSS frameworks, and icon systems. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
     {
-      url, slow, sync, mobile, cookie,
+      url, sync, ...browserParams, ...crawlParams,
       darkMode: z.boolean().optional().default(false).describe("Extract with dark mode emulation (prefers-color-scheme: dark)"),
       wcag: z.boolean().optional().default(false).describe("Include WCAG contrast analysis between palette colors"),
     },
@@ -297,9 +367,9 @@ async function main() {
 
   (server.tool as any)(
     "get_color_palette",
-    "Extract brand colors from a live website. Returns semantic colors (primary, secondary, accent, plus background and text promoted from the page surface and body text), full palette ranked by usage frequency and confidence (high/medium/low), CSS custom properties with their design-system names, and hover/focus state colors discovered by simulating real user interactions. Each color in hex, RGB, LCH, and OKLCH. Returns a job_id by default — use get_job_status to poll for the result.",
+    "Extract brand colors from a live website. Returns semantic colors (primary, secondary, accent, plus background and text promoted from the page surface and body text), full palette ranked by usage frequency and confidence (high/medium/low), CSS custom properties with their design-system names, and hover/focus state colors discovered by simulating real user interactions. Each color in hex, RGB, LCH, and OKLCH. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
     {
-      url, slow, sync, mobile, cookie,
+      url, sync, ...browserParams, ...crawlParams,
       darkMode: z.boolean().optional().default(false).describe("Also extract dark mode palette"),
       wcag: z.boolean().optional().default(false).describe("Include WCAG contrast analysis between palette colors"),
     },
@@ -308,22 +378,22 @@ async function main() {
 
   (server.tool as any)(
     "get_typography",
-    "Extract typography from a live website. Returns every font family with its fallback stack, the complete type scale grouped by context (heading, body, text, button, link, caption) with pixel and rem sizes, weights, line heights, letter spacing, and text transforms. The body context marks the dominant reading-text font; text marks other body-eligible copy. Also reports font sources: Google Fonts URLs, Adobe Fonts usage, and variable font detection. Returns a job_id by default — use get_job_status to poll for the result.",
-    { url, slow, sync, mobile, cookie },
+    "Extract typography from a live website. Returns every font family with its fallback stack, the complete type scale grouped by context (heading, body, text, button, link, caption) with pixel and rem sizes, weights, line heights, letter spacing, and text transforms. The body context marks the dominant reading-text font; text marks other body-eligible copy. Also reports font sources: Google Fonts URLs, Adobe Fonts usage, and variable font detection. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
+    { url, sync, ...browserParams, ...crawlParams },
     toolHandler((d) => ({ url: d.url, typography: d.typography })),
   );
 
   (server.tool as any)(
     "get_component_styles",
-    "Extract UI component styles from a live website. Returns button variants with default, hover, active, and focus states (background, text color, padding, border radius, border, shadow, outline, opacity), input field styles (border, focus ring, padding, placeholder), link styles (color, text decoration, hover changes), and badge/tag styles. Returns a job_id by default — use get_job_status to poll for the result.",
-    { url, slow, sync, mobile, cookie },
+    "Extract UI component styles from a live website. Returns button variants with default, hover, active, and focus states (background, text color, padding, border radius, border, shadow, outline, opacity), input field styles (border, focus ring, padding, placeholder), link styles (color, text decoration, hover changes), and badge/tag styles. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
+    { url, sync, ...browserParams, ...crawlParams },
     toolHandler((d) => ({ url: d.url, components: d.components })),
   );
 
   (server.tool as any)(
     "get_surfaces",
-    "Extract surface treatment tokens from a live website: border radii with element context (which radii are used on buttons vs cards vs inputs vs modals), border patterns (width + style + color combinations), and box shadow elevation levels. Returns a job_id by default — use get_job_status to poll for the result.",
-    { url, slow, sync, mobile, cookie },
+    "Extract surface treatment tokens from a live website: border radii with element context (which radii are used on buttons vs cards vs inputs vs modals), border patterns (width + style + color combinations), and box shadow elevation levels. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
+    { url, sync, ...browserParams, ...crawlParams },
     toolHandler((d) => ({
       url: d.url,
       borderRadius: d.borderRadius,
@@ -334,15 +404,15 @@ async function main() {
 
   (server.tool as any)(
     "get_spacing",
-    "Extract the spacing system from a live website: common margin and padding values sorted by frequency, pixel and rem values, and grid system detection (4px, 8px, or custom scale). Returns a job_id by default — use get_job_status to poll for the result.",
-    { url, slow, sync, mobile, cookie },
+    "Extract the spacing system from a live website: common margin and padding values sorted by frequency, pixel and rem values, and grid system detection (4px, 8px, or custom scale). Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
+    { url, sync, ...browserParams, ...crawlParams },
     toolHandler((d) => ({ url: d.url, spacing: d.spacing })),
   );
 
   (server.tool as any)(
     "get_brand_identity",
-    "Extract brand identity from a live website: site name, logo (source, dimensions, safe zone), all favicon variants (icon, apple-touch-icon, og:image, twitter:image with sizes and URLs), detected CSS frameworks (Tailwind, Bootstrap, MUI, etc.), icon systems (Font Awesome, Material Icons, SVG), and responsive breakpoints. Returns a job_id by default — use get_job_status to poll for the result.",
-    { url, slow, sync, mobile, cookie },
+    "Extract brand identity from a live website: site name, logo (source, dimensions, safe zone), all favicon variants (icon, apple-touch-icon, og:image, twitter:image with sizes and URLs), detected CSS frameworks (Tailwind, Bootstrap, MUI, etc.), icon systems (Font Awesome, Material Icons, SVG), and responsive breakpoints. Set pages > 1 to crawl and merge several pages, which yields a markedly stronger token set than a single page. Returns a job_id by default: poll it with get_job_status, and pass the same job_id to compute_drift, get_findings, export_dtcg, generate_design_md or render_report instead of resending the extraction.",
+    { url, sync, ...browserParams, ...crawlParams },
     toolHandler((d) => ({
       url: d.url,
       siteName: d.siteName,
@@ -356,56 +426,96 @@ async function main() {
 
   // ── Drift & report tools (synchronous, no browser) ─────────────────────
 
+  /**
+   * Pure tools accept either an inline extraction or the job_id of a completed
+   * one. The job path exists because an inline extraction has to travel back
+   * through the model as a tool argument, which is prohibitively large.
+   */
+  function resolveExtraction(inline: any, jobId: string | undefined, label: string) {
+    if (inline) return { ok: true as const, value: inline };
+    if (!jobId) return { ok: false as const, error: `Pass either ${label} or job_id.` };
+    const job = jobQueue.get(jobId);
+    if (!job) return { ok: false as const, error: `No job found with id: ${jobId}` };
+    if (job.status !== "completed") return { ok: false as const, error: `Job ${jobId} is ${job.status}, not completed.` };
+    return { ok: true as const, value: job.full };
+  }
+
   // zod 4: z.record needs explicit key + value types; z.record(z.any()) treats
   // the lone arg as the KEY and leaves value undefined, which crashes tools/list.
-  const extract = z.record(z.string(), z.any()).describe("A dembrandt extraction object, as returned by get_design_tokens");
+  const extract = z
+    .record(z.string(), z.any())
+    .optional()
+    .describe("A dembrandt extraction object. Omit it and pass job_id instead to read a completed extraction straight out of the job queue, which avoids sending the whole extraction back through the model.");
+  const sourceJob = z
+    .string()
+    .optional()
+    .describe("job_id of a completed extraction to read instead of passing result inline");
 
   (server.tool as any)(
     "compute_drift",
-    "Compare two dembrandt extractions and return a design-drift report: a 0-100 score (0 = identical), a stable/drift verdict, per-category scores, and the list of changed/added/removed tokens (colors, typography, spacing, radius, shadows). Pure and synchronous — no browser. Use it to check whether generated or updated UI has drifted from a brand baseline.",
+    "Compare two dembrandt extractions and return a design-drift report: a 0-100 score (0 = identical), a stable/drift verdict, per-category scores, and the list of changed/added/removed tokens (colors, typography, spacing, radius, shadows). Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Use it to check whether generated or updated UI has drifted from a brand baseline.",
     {
       baseline: extract,
       candidate: extract,
+      baselineJobId: sourceJob,
+      candidateJobId: sourceJob,
       failThreshold: z.number().optional().describe("Score above this yields a 'drift' verdict (default 10)"),
     },
-    ({ baseline, candidate, failThreshold }: any) => {
-      const report = computeDrift(baseline, candidate, failThreshold != null ? { failThreshold } : {});
+    ({ baseline, candidate, baselineJobId, candidateJobId, failThreshold }: any) => {
+      const a = resolveExtraction(baseline, baselineJobId, "baseline");
+      if (!a.ok) return errorResult(a.error);
+      const b = resolveExtraction(candidate, candidateJobId, "candidate");
+      if (!b.ok) return errorResult(b.error);
+      const report = computeDrift(a.value, b.value, failThreshold != null ? { failThreshold } : {});
       return jsonResult(report);
     },
   );
 
   (server.tool as any)(
     "render_report",
-    "Render a self-contained HTML report (inline CSS, no external resources) from a dembrandt extraction, optionally including a drift diff. Returns the HTML as text — write it to a .html file to open offline or attach as a CI artifact.",
+    "Render a self-contained HTML report (inline CSS, no external resources) from a dembrandt extraction, optionally including a drift diff. Takes either an inline extraction or the job_id of a completed one. Returns the HTML as text: write it to a .html file to open offline or attach as a CI artifact.",
     {
       result: extract,
+      job_id: sourceJob,
       drift: z.any().optional().describe("A drift report from compute_drift, to render the diff banner"),
     },
-    ({ result, drift }: any) => {
-      const html = generateHtmlReport(result, { drift: drift ?? undefined });
+    ({ result, job_id, drift }: any) => {
+      const source = resolveExtraction(result, job_id, "result");
+      if (!source.ok) return errorResult(source.error);
+      const html = generateHtmlReport(source.value, { drift: drift ?? undefined });
       return { content: [{ type: "text", text: html }] };
     },
   );
 
   (server.tool as any)(
     "get_findings",
-    "Lint a dembrandt extraction for design-system quality issues: WCAG contrast failures, inconsistency (near-duplicate colors, off-scale spacing values, radius sprawl), and duplication. Returns findings with severity (error/warn), category, and a human-readable message, plus summary counts. Pure and synchronous — no browser. Complements compute_drift: drift asks 'did it change', findings asks 'is it good'.",
-    { result: extract },
-    ({ result }: any) => jsonResult(computeFindings(result)),
+    "Lint a dembrandt extraction for design-system quality issues: WCAG contrast failures, inconsistency (near-duplicate colors, off-scale spacing values, radius sprawl), and duplication. Returns findings with severity (error/warn), category, and a human-readable message, plus summary counts. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Complements compute_drift: drift asks 'did it change', findings asks 'is it good'.",
+    { result: extract, job_id: sourceJob },
+    ({ result, job_id }: any) => {
+      const source = resolveExtraction(result, job_id, "result");
+      return source.ok ? jsonResult(computeFindings(source.value)) : errorResult(source.error);
+    },
   );
 
   (server.tool as any)(
     "export_dtcg",
-    "Convert a dembrandt extraction to W3C Design Tokens (DTCG) format: color, typography, spacing, radius, border, and shadow tokens with $type/$value structure and dembrandt provenance under $extensions. Pure and synchronous — no browser. Use it to hand tokens to Style Dictionary, Figma token plugins, or any DTCG-compatible pipeline.",
-    { result: extract },
-    ({ result }: any) => jsonResult(toDtcgTokens(result)),
+    "Convert a dembrandt extraction to W3C Design Tokens (DTCG) format: color, typography, spacing, radius, border, and shadow tokens with $type/$value structure and dembrandt provenance under $extensions. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Use it to hand tokens to Style Dictionary, Figma token plugins, or any DTCG-compatible pipeline.",
+    { result: extract, job_id: sourceJob },
+    ({ result, job_id }: any) => {
+      const source = resolveExtraction(result, job_id, "result");
+      return source.ok ? jsonResult(toDtcgTokens(source.value)) : errorResult(source.error);
+    },
   );
 
   (server.tool as any)(
     "generate_design_md",
-    "Render a DESIGN.md brand guide (markdown) from a dembrandt extraction: colors, typography, spacing, surfaces, and components as a human-readable design reference. Pure and synchronous — no browser. Write the output to DESIGN.md in a project so agents and developers build UI against the extracted brand.",
-    { result: extract },
-    ({ result }: any) => ({ content: [{ type: "text", text: generateDesignMd(result) }] }),
+    "Render a DESIGN.md brand guide (markdown) from a dembrandt extraction: colors, typography, spacing, surfaces, and components as a human-readable design reference. Pure and synchronous, no browser. Takes either an inline extraction or the job_id of a completed one. Write the output to DESIGN.md in a project so agents and developers build UI against the extracted brand.",
+    { result: extract, job_id: sourceJob },
+    ({ result, job_id }: any) => {
+      const source = resolveExtraction(result, job_id, "result");
+      if (!source.ok) return errorResult(source.error);
+      return { content: [{ type: "text", text: generateDesignMd(source.value) }] };
+    },
   );
 
   // ── Job management tools ───────────────────────────────────────────────
@@ -443,6 +553,9 @@ async function main() {
   // ── Start ──────────────────────────────────────────────────────────────
 
   const transport = new StdioServerTransport();
+  transport.onclose = () => process.exit(0);
+  process.on("SIGINT", () => process.exit(0));
+  process.on("SIGTERM", () => process.exit(0));
   await server.connect(transport);
 }
 

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -94,7 +94,8 @@ async function additionalPages(first: any, requestedUrl: string, options: any) {
       path.startsWith("http") ? path : `${base.protocol}//${base.host}${path.startsWith("/") ? path : "/" + path}`,
     );
   }
-  const max = (options.pages ?? 1) - 1;
+  // A sitemap crawl with no explicit budget follows the CLI and takes up to 20.
+  const max = (options.pages ?? 1) > 1 ? (options.pages as number) - 1 : options.sitemap ? 20 : 0;
   if (max < 1) return [];
   if (options.sitemap) {
     const fromResult = await parseSitemap(first.url, max);
@@ -131,7 +132,7 @@ async function runExtraction(url: string, options: any = {}) {
     };
   }
 
-  const multiPage = (options.paths?.length ?? 0) > 0 || (options.pages ?? 1) > 1;
+  const multiPage = (options.paths?.length ?? 0) > 0 || (options.pages ?? 1) > 1 || !!options.sitemap;
 
   try {
     const first = await extractBranding(url, nullSpinner, browser, {
@@ -346,7 +347,7 @@ async function main() {
   const noSandbox = z.boolean().optional().default(false).describe("Disable the browser sandbox, required inside Docker and most CI containers");
   const pages = z.number().int().min(1).max(20).optional().default(1).describe("Extract up to N pages and merge them into one token set. Pages are discovered from DOM links, or from sitemap.xml when sitemap is true. Merged tokens are markedly stronger than a single page.");
   const paths = z.array(z.string()).optional().describe('Explicit extra paths on the same domain to extract and merge, e.g. ["/pricing", "/docs"]. Overrides page discovery.');
-  const sitemap = z.boolean().optional().default(false).describe("Discover the extra pages from sitemap.xml instead of DOM links; needs pages > 1");
+  const sitemap = z.boolean().optional().default(false).describe("Discover the extra pages from sitemap.xml instead of DOM links. Alone it takes up to 20 pages; set pages to cap it");
 
   // Every extraction tool takes the same navigation, auth and crawl surface.
   const crawlParams = { pages, paths, sitemap };
@@ -432,7 +433,7 @@ async function main() {
    * through the model as a tool argument, which is prohibitively large.
    */
   function resolveExtraction(inline: any, jobId: string | undefined, label: string) {
-    if (inline) return { ok: true as const, value: inline };
+    if (inline && Object.keys(inline).length > 0) return { ok: true as const, value: inline };
     if (!jobId) return { ok: false as const, error: `Pass either ${label} or job_id.` };
     const job = jobQueue.get(jobId);
     if (!job) return { ok: false as const, error: `No job found with id: ${jobId}` };

--- a/test/mcp-jobs.test.ts
+++ b/test/mcp-jobs.test.ts
@@ -1,0 +1,214 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_JOB_TTL_MS, JobQueue, resolveExtraction } from '../lib/mcp/jobs.js';
+import type { JobResult } from '../lib/mcp/jobs.js';
+
+type Extract = { url: string; colors?: unknown };
+
+const identity = (d: Extract) => d;
+const ok = (data: Extract): JobResult<Extract> => ({ ok: true, data });
+
+/** A runner whose completion the test controls. */
+function deferredRunner() {
+  const started: string[] = [];
+  const settle = new Map<string, (r: JobResult<Extract>) => void>();
+  const run = (url: string) => {
+    started.push(url);
+    return new Promise<JobResult<Extract>>((resolve) => settle.set(url, resolve));
+  };
+  return { run, started, finish: (url: string, r: JobResult<Extract>) => settle.get(url)!(r) };
+}
+
+// ── lifecycle ──────────────────────────────────────────────────────────
+
+test('a job runs and keeps both the sliced result and the whole extraction', async () => {
+  const queue = new JobQueue<Extract>({ run: async () => ok({ url: 'https://x/', colors: { primary: '#000' } }) });
+  const id = queue.enqueue('https://x/', {}, (d) => ({ colors: d.colors }));
+  await queue.idle();
+
+  const job = queue.get(id)!;
+  assert.equal(job.status, 'completed');
+  assert.deepEqual(job.result, { colors: { primary: '#000' } });
+  assert.deepEqual(job.full, { url: 'https://x/', colors: { primary: '#000' } });
+});
+
+test('a failed extraction is reported as failed, not thrown', async () => {
+  const queue = new JobQueue<Extract>({ run: async () => ({ ok: false, error: 'boom' }) });
+  const id = queue.enqueue('https://x/', {}, identity);
+  await queue.idle();
+
+  assert.equal(queue.get(id)!.status, 'failed');
+  assert.equal(queue.get(id)!.error, 'boom');
+});
+
+test('a runner that rejects fails the job instead of crashing the server', async () => {
+  const queue = new JobQueue<Extract>({ run: async () => { throw new Error('launch failed'); } });
+  const id = queue.enqueue('https://x/', {}, identity);
+  await queue.idle();
+
+  assert.equal(queue.get(id)!.status, 'failed');
+  assert.equal(queue.get(id)!.error, 'launch failed');
+});
+
+test('a non-Error rejection still yields a readable message', async () => {
+  const queue = new JobQueue<Extract>({ run: async () => { throw 'plain string'; } });
+  const id = queue.enqueue('https://x/', {}, identity);
+  await queue.idle();
+
+  assert.equal(queue.get(id)!.error, 'plain string');
+});
+
+test('an unknown id reads back as null rather than throwing', () => {
+  const queue = new JobQueue<Extract>({ run: async () => ok({ url: 'https://x/' }) });
+  assert.equal(queue.get('nope'), null);
+});
+
+test('a job carries its own pick, so a second tool cannot reshape the first result', async () => {
+  const queue = new JobQueue<Extract>({ run: async (url) => ok({ url: String(url) }) });
+  const a = queue.enqueue('https://a/', {}, () => 'shape-a');
+  const b = queue.enqueue('https://b/', {}, () => 'shape-b');
+  await queue.idle();
+
+  assert.equal(queue.get(a)!.result, 'shape-a');
+  assert.equal(queue.get(b)!.result, 'shape-b');
+});
+
+// ── concurrency ────────────────────────────────────────────────────────
+
+test('no more than maxConcurrent extractions run at once', async () => {
+  const { run, started, finish } = deferredRunner();
+  const queue = new JobQueue<Extract>({ run, maxConcurrent: 2 });
+  queue.enqueue('https://a/', {}, identity);
+  queue.enqueue('https://b/', {}, identity);
+  const third = queue.enqueue('https://c/', {}, identity);
+
+  assert.deepEqual(started, ['https://a/', 'https://b/']);
+  assert.equal(queue.get(third)!.status, 'queued');
+
+  finish('https://a/', ok({ url: 'https://a/' }));
+  await new Promise((r) => setImmediate(r));
+  assert.ok(started.includes('https://c/'), 'the queued job starts as soon as a slot frees');
+
+  finish('https://b/', ok({ url: 'https://b/' }));
+  finish('https://c/', ok({ url: 'https://c/' }));
+  await queue.idle();
+});
+
+// ── cancellation ───────────────────────────────────────────────────────
+
+test('a queued job can be cancelled and never starts', async () => {
+  const { run, started, finish } = deferredRunner();
+  const queue = new JobQueue<Extract>({ run, maxConcurrent: 1 });
+  queue.enqueue('https://a/', {}, identity);
+  const queued = queue.enqueue('https://b/', {}, identity);
+
+  assert.equal(queue.cancel(queued), true);
+  assert.equal(queue.get(queued)!.status, 'cancelled');
+
+  finish('https://a/', ok({ url: 'https://a/' }));
+  await queue.idle();
+  assert.deepEqual(started, ['https://a/'], 'a cancelled job is never handed to the runner');
+});
+
+test('a running job cannot be cancelled, since the browser is already open', async () => {
+  const { run, finish } = deferredRunner();
+  const queue = new JobQueue<Extract>({ run });
+  const id = queue.enqueue('https://a/', {}, identity);
+
+  assert.equal(queue.cancel(id), false);
+  assert.equal(queue.get(id)!.status, 'running');
+
+  finish('https://a/', ok({ url: 'https://a/' }));
+  await queue.idle();
+});
+
+test('cancelling an unknown id reports false', () => {
+  const queue = new JobQueue<Extract>({ run: async () => ok({ url: 'https://x/' }) });
+  assert.equal(queue.cancel('nope'), false);
+});
+
+// ── listing and cleanup ────────────────────────────────────────────────
+
+test('list reports every job without leaking the payload', async () => {
+  const queue = new JobQueue<Extract>({ run: async () => ok({ url: 'https://x/', colors: { big: true } }) });
+  queue.enqueue('https://x/', {}, identity);
+  await queue.idle();
+
+  const [row] = queue.list();
+  assert.deepEqual(Object.keys(row).sort(), ['completedAt', 'createdAt', 'job_id', 'status', 'url']);
+  assert.equal(row.status, 'completed');
+});
+
+test('cleanup drops finished jobs past the TTL and keeps fresh ones', async () => {
+  let clock = 1_000_000;
+  const queue = new JobQueue<Extract>({ run: async () => ok({ url: 'https://x/' }), now: () => clock });
+  const old = queue.enqueue('https://old/', {}, identity);
+  await queue.idle();
+
+  clock += DEFAULT_JOB_TTL_MS + 1;
+  const fresh = queue.enqueue('https://fresh/', {}, identity);
+  await queue.idle();
+
+  queue.cleanup();
+  assert.equal(queue.get(old), null);
+  assert.ok(queue.get(fresh));
+});
+
+test('cleanup never drops a job that is still running', async () => {
+  let clock = 1_000_000;
+  const { run, finish } = deferredRunner();
+  const queue = new JobQueue<Extract>({ run, now: () => clock });
+  const id = queue.enqueue('https://a/', {}, identity);
+
+  clock += DEFAULT_JOB_TTL_MS * 10;
+  queue.cleanup();
+  assert.equal(queue.get(id)!.status, 'running');
+
+  finish('https://a/', ok({ url: 'https://a/' }));
+  await queue.idle();
+});
+
+// ── resolveExtraction ──────────────────────────────────────────────────
+
+const queueWith = (job: unknown) => ({ get: () => job } as never);
+
+test('an inline extraction is used as given', () => {
+  const inline = { url: 'https://x/' };
+  assert.deepEqual(resolveExtraction(inline, undefined, 'result', queueWith(null)), { ok: true, value: inline });
+});
+
+test('an inline extraction wins over a job_id, so an explicit argument is never ignored', () => {
+  const inline = { url: 'https://inline/' };
+  const resolved = resolveExtraction(inline, 'job_1', 'result', queueWith({ status: 'completed', full: { url: 'https://job/' } }));
+  assert.deepEqual(resolved.value, inline);
+});
+
+test('an empty object is not an extraction', () => {
+  const resolved = resolveExtraction({}, undefined, 'result', queueWith(null));
+  assert.equal(resolved.ok, false);
+  assert.match(resolved.error!, /Pass either result or job_id/);
+});
+
+test('a completed job resolves to the whole extraction, not the sliced result', () => {
+  const full = { url: 'https://x/', colors: {} };
+  const resolved = resolveExtraction(undefined, 'job_1', 'result', queueWith({ status: 'completed', full, result: { colors: {} } }));
+  assert.deepEqual(resolved.value, full);
+});
+
+test('an unknown job_id names the id it could not find', () => {
+  const resolved = resolveExtraction(undefined, 'job_missing', 'result', queueWith(null));
+  assert.equal(resolved.ok, false);
+  assert.match(resolved.error!, /No job found with id: job_missing/);
+});
+
+test('an unfinished job reports its status instead of resolving to undefined', () => {
+  for (const status of ['queued', 'running', 'failed', 'cancelled']) {
+    const resolved = resolveExtraction(undefined, 'job_1', 'result', queueWith({ status }));
+    assert.equal(resolved.ok, false, status);
+    assert.match(resolved.error!, new RegExp(`is ${status}, not completed`));
+  }
+});
+
+test('the label names the argument the caller left out', () => {
+  assert.match(resolveExtraction(undefined, undefined, 'baseline', queueWith(null)).error!, /Pass either baseline or job_id/);
+});

--- a/test/mcp-options.test.ts
+++ b/test/mcp-options.test.ts
@@ -1,0 +1,186 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SITEMAP_DEFAULT_PAGES,
+  additionalPages,
+  discoveryBudget,
+  extractOptions,
+  isMultiPage,
+  launchArgs,
+  pageBudget,
+  resolvePaths,
+} from '../lib/mcp/options.js';
+import type { Extraction, ExtractionRequest } from '../lib/mcp/options.js';
+
+const home = (overrides: Partial<Extraction> = {}): Extraction =>
+  ({ url: 'https://example.com/', ...overrides }) as Extraction;
+
+// ── launchArgs ─────────────────────────────────────────────────────────
+
+test('launchArgs always disables the automation banner', () => {
+  assert.deepEqual(launchArgs(false, {}), ['--disable-blink-features=AutomationControlled']);
+});
+
+test('launchArgs drops the sandbox on request', () => {
+  assert.deepEqual(launchArgs(true, {}), [
+    '--disable-blink-features=AutomationControlled',
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+  ]);
+});
+
+test('launchArgs honours DEMBRANDT_NO_SANDBOX, so a container can be fixed without touching every call', () => {
+  assert.ok(launchArgs(undefined, { DEMBRANDT_NO_SANDBOX: '1' }).includes('--no-sandbox'));
+});
+
+test('an empty DEMBRANDT_NO_SANDBOX does not disable the sandbox', () => {
+  assert.ok(!launchArgs(undefined, { DEMBRANDT_NO_SANDBOX: '' }).includes('--no-sandbox'));
+});
+
+// ── extractOptions ─────────────────────────────────────────────────────
+
+test('extractOptions stamps the tool version, which the DTCG provenance block reads back', () => {
+  assert.equal(extractOptions({}, '9.9.9')._version, '9.9.9');
+});
+
+test('extractOptions normalises absent booleans instead of forwarding undefined', () => {
+  const opts = extractOptions({}, '1.0.0');
+  assert.deepEqual(
+    { slow: opts.slow, darkMode: opts.darkMode, mobile: opts.mobile, wcag: opts.wcag },
+    { slow: false, darkMode: false, mobile: false, wcag: false },
+  );
+});
+
+test('extractOptions omits auth fields entirely when unset, so no empty header is sent', () => {
+  const opts = extractOptions({}, '1.0.0');
+  assert.ok(!('cookie' in opts));
+  assert.ok(!('header' in opts));
+  assert.ok(!('userAgent' in opts));
+});
+
+test('extractOptions forwards auth fields when set', () => {
+  const opts = extractOptions({ cookie: 'a=b', header: 'Authorization: Bearer x', userAgent: 'ua' }, '1.0.0');
+  assert.equal(opts.cookie, 'a=b');
+  assert.equal(opts.header, 'Authorization: Bearer x');
+  assert.equal(opts.userAgent, 'ua');
+});
+
+test('every crawled page reuses the first page options, so a merge cannot mix viewports', () => {
+  const req: ExtractionRequest = { mobile: true, darkMode: true, slow: true, cookie: 'a=b' };
+  assert.deepEqual(extractOptions(req, '1.0.0'), extractOptions(req, '1.0.0'));
+});
+
+// ── budgets ────────────────────────────────────────────────────────────
+
+test('a bare request is single-page', () => {
+  assert.equal(pageBudget({}), 0);
+  assert.equal(isMultiPage({}), false);
+  assert.equal(discoveryBudget({}), null);
+});
+
+test('pages counts the total, so the budget is one less', () => {
+  assert.equal(pageBudget({ pages: 3 }), 2);
+  assert.equal(discoveryBudget({ pages: 3 }), 2);
+});
+
+test('pages: 1 is explicitly single-page', () => {
+  assert.equal(pageBudget({ pages: 1 }), 0);
+  assert.equal(isMultiPage({ pages: 1 }), false);
+});
+
+test('sitemap alone crawls without an explicit budget rather than silently doing nothing', () => {
+  assert.equal(pageBudget({ sitemap: true }), SITEMAP_DEFAULT_PAGES);
+  assert.equal(isMultiPage({ sitemap: true }), true);
+});
+
+test('pages caps a sitemap crawl', () => {
+  assert.equal(pageBudget({ sitemap: true, pages: 3 }), 2);
+});
+
+test('sitemap and explicit paths need no DOM discovery pass', () => {
+  assert.equal(discoveryBudget({ sitemap: true }), null);
+  assert.equal(discoveryBudget({ paths: ['/pricing'] }), null);
+});
+
+test('explicit paths set the budget themselves and ignore pages', () => {
+  assert.equal(pageBudget({ paths: ['/a', '/b'], pages: 5 }), 2);
+});
+
+// ── resolvePaths ───────────────────────────────────────────────────────
+
+test('resolvePaths accepts paths with and without a leading slash', () => {
+  assert.deepEqual(resolvePaths('https://example.com/', ['/pricing', 'docs']), [
+    'https://example.com/pricing',
+    'https://example.com/docs',
+  ]);
+});
+
+test('resolvePaths passes absolute URLs through untouched', () => {
+  assert.deepEqual(resolvePaths('https://example.com/', ['https://other.test/x']), ['https://other.test/x']);
+});
+
+test('resolvePaths resolves against the landed URL, so a redirected host is honoured', () => {
+  assert.deepEqual(resolvePaths('https://www.example.com/home', ['/pricing']), ['https://www.example.com/pricing']);
+});
+
+test('resolvePaths keeps the port of a local origin', () => {
+  assert.deepEqual(resolvePaths('http://localhost:3000/', ['/about']), ['http://localhost:3000/about']);
+});
+
+// ── additionalPages ────────────────────────────────────────────────────
+
+const noSitemap = async () => [];
+
+test('a single-page request asks for no extra pages', async () => {
+  assert.deepEqual(await additionalPages(home(), 'https://example.com/', {}, noSitemap), []);
+});
+
+test('explicit paths win over discovered links', async () => {
+  const first = home({ _discoveredLinks: ['https://example.com/blog'] });
+  assert.deepEqual(
+    await additionalPages(first, 'https://example.com/', { paths: ['/pricing'] }, noSitemap),
+    ['https://example.com/pricing'],
+  );
+});
+
+test('discovered links are capped at the requested budget', async () => {
+  const first = home({ _discoveredLinks: ['https://example.com/a', 'https://example.com/b', 'https://example.com/c'] });
+  assert.deepEqual(await additionalPages(first, 'https://example.com/', { pages: 3 }, noSitemap), [
+    'https://example.com/a',
+    'https://example.com/b',
+  ]);
+});
+
+test('a page that discovered nothing yields an empty crawl rather than throwing', async () => {
+  assert.deepEqual(await additionalPages(home(), 'https://example.com/', { pages: 4 }, noSitemap), []);
+});
+
+test('a sitemap crawl reads the landed URL first', async () => {
+  const seen: Array<[string, number]> = [];
+  const fetchSitemap = async (url: string, max: number) => {
+    seen.push([url, max]);
+    return ['https://example.com/a'];
+  };
+  const pages = await additionalPages(home(), 'https://example.com/', { sitemap: true, pages: 4 }, fetchSitemap);
+  assert.deepEqual(pages, ['https://example.com/a']);
+  assert.deepEqual(seen, [['https://example.com/', 3]]);
+});
+
+test('a redirected site falls back to the requested URL when the landed one has no sitemap', async () => {
+  const seen: string[] = [];
+  const fetchSitemap = async (url: string) => {
+    seen.push(url);
+    return url === 'https://example.com' ? ['https://example.com/a'] : [];
+  };
+  const first = home({ url: 'https://www.example.com/' });
+  const pages = await additionalPages(first, 'https://example.com', { sitemap: true }, fetchSitemap);
+  assert.deepEqual(pages, ['https://example.com/a']);
+  assert.deepEqual(seen, ['https://www.example.com/', 'https://example.com']);
+});
+
+test('the sitemap fallback is not re-fetched when both URLs are the same', async () => {
+  let calls = 0;
+  const fetchSitemap = async () => { calls += 1; return []; };
+  assert.deepEqual(await additionalPages(home(), 'https://example.com/', { sitemap: true }, fetchSitemap), []);
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
The MCP server exposed five of the CLI's flags and made its own pure tools unreachable in practice.

## job_id handoff
`compute_drift`, `get_findings`, `export_dtcg`, `generate_design_md` and `render_report` took the whole extraction as a tool argument, so the model had to resend a result it had just received. They now accept the `job_id` of a completed extraction instead. The queue keeps the full result alongside the sliced one, so a job started by `get_color_palette` still feeds them. An inline extraction still wins when both are given.

## Multi-page
`pages`, `paths` and `sitemap` on every extraction tool, over the same `discoverLinks` + `mergeResults` path as the CLI. `sitemap` alone takes up to 20 pages, as `--sitemap` does; `pages` caps it. A page that fails to load is dropped and the merge carries the rest.

## Launch and auth
`noSandbox` (also `DEMBRANDT_NO_SANDBOX`), `header`, `userAgent`. A launch failure now names `noSandbox` as the container remedy.

## Fixes
- console was saved and restored per call, so with `maxConcurrent = 2` the first job to finish restored the handlers under the second, whose output would land in the JSON-RPC stream. Silenced once per process instead.
- `_version` never reached `extractBranding`, leaving `meta.dembrandtVersion` and the DTCG `toolVersion` null on every MCP extraction.
- the cleanup interval kept the event loop alive, so the process outlived its transport by minutes.
- `BrandingResult._discoveredLinks` was typed `DiscoveredLink[]`; `discoverLinks` has always returned the href strings that `index.ts` feeds straight to `new URL()`.

## Structure
The server file kept its logic inside `main()`, where no test could reach it. The queue and the crawl planning now live in `lib/mcp/`: `JobQueue` takes its runner and clock by injection, and the budget, path resolution and option mapping are pure functions. `mcp-server.ts` is left with transport wiring and tool declarations.

## Verification
47 new unit tests (653 total), eslint clean. End to end against dembrandt.com through a real stdio client: `pages: 3` merged `/`, `/about` and `/getting-started`; `sitemap: true` merged from sitemap.xml; `paths: ["/pricing"]` merged that page; findings, DTCG and drift all ran from job_id alone; `meta.dembrandtVersion` and DTCG `toolVersion` both read `0.28.0`; the process exits 0 on stdin close.