### PR TITLE
fix(motion): read durations before the animation freeze

### DIFF
--- a/lib/extractors/breakpoints.ts
+++ b/lib/extractors/breakpoints.ts
@@ -259,9 +259,12 @@ export async function extractGradients(page) {
   });
 }
 
-export async function extractMotion(page) {
-  // Phase 1: static pass — collect durations, easings, animations per semantic context
-  const staticMotion = await page.evaluate(() => {
+export const FREEZE_STYLE_ID = 'dembrandt-freeze-motion';
+
+// Static pass: durations, easings and animations per semantic context. Read
+// before the orchestrator freezes animations, so the authored values survive.
+export async function extractMotionStatic(page) {
+  return await page.evaluate(() => {
     function getContext(el) {
       const tag = el.tagName.toLowerCase();
       const role = el.getAttribute('role') || '';
@@ -379,6 +382,10 @@ export async function extractMotion(page) {
       contexts: ctxOut,
     };
   });
+}
+
+export async function extractMotion(page, staticSnapshot = null) {
+  const staticMotion = staticSnapshot ?? await extractMotionStatic(page);
 
   // Phase 2: hover interaction deltas on a sample of interactive elements
   const interactiveDeltas = [];

--- a/lib/extractors/context-config.ts
+++ b/lib/extractors/context-config.ts
@@ -21,6 +21,7 @@ export interface ScreenSize {
 }
 
 export type ColorScheme = 'light' | 'dark' | 'no-preference';
+export type ReducedMotion = 'reduce' | 'no-preference';
 
 /**
  * The subset of Playwright's BrowserContextOptions that we set. Declared
@@ -36,6 +37,7 @@ export interface ContextOptions {
   timezoneId: string;
   extraHTTPHeaders: Record<string, string>;
   colorScheme: ColorScheme;
+  reducedMotion: ReducedMotion;
   permissions?: string[];
 }
 
@@ -126,6 +128,7 @@ export function buildContextOptions(options: ExtractOptions, browserName: string
     timezoneId: options.timezoneId || DEFAULT_TIMEZONE,
     extraHTTPHeaders,
     colorScheme: 'light',
+    reducedMotion: 'no-preference',
   };
 
   if (browserName === 'chromium') {

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -8,7 +8,7 @@ import { MENU_TRIGGER_SELECTOR, CAROUSEL_NEXT_SELECTOR } from './menu-triggers.j
 import { extractTypography } from './typography.js';
 import { extractSpacing, extractBorderRadius, extractBorders, extractShadows } from './spacing.js';
 import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadgeStyles } from './components.js';
-import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients, extractMotion } from './breakpoints.js';
+import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients, extractMotion, extractMotionStatic, FREEZE_STYLE_ID } from './breakpoints.js';
 import { extractTeach } from './teach.js';
 import { extractWcagPairs } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
@@ -714,10 +714,16 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
     // report a different computed value on each run, producing phantom drift.
     // 1ms duration + iteration-count:1 + fill-mode:forwards snaps finite and
     // infinite animations to a stable end state. Opt out with keepAnimations.
+    // Authored durations and easings must be read before the freeze below
+    // rewrites every one of them to 1ms.
+    const motionStatic = await extractMotionStatic(page).catch(() => null);
+
     if (!options.keepAnimations) {
       try {
-        await page.addStyleTag({
-          content: `*, *::before, *::after {
+        await page.evaluate((id) => {
+          const style = document.createElement('style');
+          style.id = id;
+          style.textContent = `*, *::before, *::after {
             animation-duration: 1ms !important;
             animation-delay: 0ms !important;
             animation-iteration-count: 1 !important;
@@ -725,8 +731,9 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
             transition-duration: 1ms !important;
             transition-delay: 0ms !important;
             scroll-behavior: auto !important;
-          }`,
-        });
+          }`;
+          document.head.appendChild(style);
+        }, FREEZE_STYLE_ID);
         await page.waitForTimeout(200 * timeoutMultiplier);
       } catch {
         // best-effort; never block extraction on animation freezing
@@ -797,7 +804,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       // The fallback must satisfy Motion in full: the terminal renderer reads
       // motion.animations, so a short default turned an extractor failure into a
       // crash of the whole render.
-      guardExtractor('motion', extractMotion(page), { durations: [], easings: [], animations: [], contexts: {}, interactiveDeltas: [] }, extractorErrors),
+      guardExtractor('motion', extractMotion(page, motionStatic), { durations: [], easings: [], animations: [], contexts: {}, interactiveDeltas: [] }, extractorErrors),
     ]);
 
     const { logo, instances: logoInstances, favicons, manifest } = logoResult;

--- a/test/context-config.test.ts
+++ b/test/context-config.test.ts
@@ -107,6 +107,7 @@ test('buildContextOptions assembles defaults and is pure', () => {
   assert.equal(opts.userAgent, DEFAULT_USER_AGENT);
   assert.equal(opts.locale, 'en-US');
   assert.equal(opts.colorScheme, 'light');
+  assert.equal(opts.reducedMotion, 'no-preference');
   assert.equal(opts.extraHTTPHeaders['Accept-Language'], 'en-US,en;q=0.9,en;q=0.8');
   assert.deepEqual(opts.permissions, ['clipboard-read', 'clipboard-write']);
 });

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -41,7 +41,7 @@ test('a snapshot taken before the freeze keeps the authored durations', async ()
     await freeze(page);
 
     const motion = await extractMotion(page, snapshot);
-    const values = motion.durations.map((d: any) => d.value);
+    const values = motion.durations.map((d: { value: string }) => d.value);
     assert.ok(values.includes('0.2s'), `expected 0.2s, got ${values.join(', ')}`);
     assert.ok(values.includes('0.15s'), `expected 0.15s, got ${values.join(', ')}`);
     assert.equal(motion.contexts.link.durations[0], '0.2s');
@@ -57,7 +57,7 @@ test('reading a frozen page reports the freeze, not the design', async () => {
     await freeze(page);
 
     const motion = await extractMotion(page);
-    const values = motion.durations.map((d: any) => d.value);
+    const values = motion.durations.map((d: { value: string }) => d.value);
     assert.deepEqual(values, ['0.001s']);
   } finally {
     await page.close();

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser } from 'playwright';
+import { extractMotion, extractMotionStatic, FREEZE_STYLE_ID } from '../lib/extractors/breakpoints.js';
+
+// The orchestrator freezes every animation to 1ms for determinism. Motion is
+// the one extractor whose values that freeze destroys, so the static pass has
+// to be taken before it. These fixtures pin both halves of that contract.
+
+const FIXTURE = `<!doctype html><html><head><style>
+  a { color: #333; transition: color 0.2s ease-in-out; }
+  button { background: #eee; transition: background-color 0.15s ease; }
+</style></head><body>
+<a href="#">Link</a>
+<button>Press</button>
+</body></html>`;
+
+const FREEZE_CSS = `*, *::before, *::after {
+  animation-duration: 1ms !important;
+  transition-duration: 1ms !important;
+}`;
+
+let browser: Browser;
+before(async () => { browser = await chromium.launch({ headless: true }); });
+after(async () => { await browser?.close().catch(() => {}); });
+
+async function freeze(page) {
+  await page.evaluate(([id, css]) => {
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent = css;
+    document.head.appendChild(style);
+  }, [FREEZE_STYLE_ID, FREEZE_CSS]);
+}
+
+test('a snapshot taken before the freeze keeps the authored durations', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(FIXTURE);
+    const snapshot = await extractMotionStatic(page);
+    await freeze(page);
+
+    const motion = await extractMotion(page, snapshot);
+    const values = motion.durations.map((d: any) => d.value);
+    assert.ok(values.includes('0.2s'), `expected 0.2s, got ${values.join(', ')}`);
+    assert.ok(values.includes('0.15s'), `expected 0.15s, got ${values.join(', ')}`);
+    assert.equal(motion.contexts.link.durations[0], '0.2s');
+  } finally {
+    await page.close();
+  }
+});
+
+test('reading a frozen page reports the freeze, not the design', async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent(FIXTURE);
+    await freeze(page);
+
+    const motion = await extractMotion(page);
+    const values = motion.durations.map((d: any) => d.value);
+    assert.deepEqual(values, ['0.001s']);
+  } finally {
+    await page.close();
+  }
+});


### PR DESCRIPTION
Motion reported 0.001s for every context on every site. Cause: the determinism stylesheet injected in `extractBranding` sets `transition-duration: 1ms !important` globally, and extractMotion read computed styles after it.

- split the static pass into `extractMotionStatic`, taken before the freeze, and pass it into `extractMotion`
- inject the freeze style with an id so it is identifiable
- pin `reducedMotion: 'no-preference'` so a host-level reduce preference cannot reproduce the symptom

Verified on dembrandt.com: 0.15s / 0.2s / 0.3s, easing cubic-bezier(0.4, 0, 0.2, 1). 653 tests pass.

Fixes DEM-251