### PR TITLE
fix: don't discard voice fragments below the word floor

### DIFF
--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1305,11 +1305,13 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
         spinner.stop();
         if (voiceResult.voice) {
           const { wordCount, sentenceCount } = voiceResult.voice.metrics.structural;
-          if (options.verbose) {
+          if (voiceResult.voice.belowWordFloor) {
+            log(color.warning(`  ! voice: ${wordCount} words, below the reliability floor — metrics may be noisy`));
+          } else if (options.verbose) {
             log(chalk.dim(`  voice: ${voiceResult.voice.fragments.length} fragments, ${wordCount} words, ${sentenceCount} sentences`));
           }
-        } else if (options.verbose) {
-          log(chalk.dim(`  voice: skipped (${voiceResult.voiceSkipped})`));
+        } else {
+          log(color.warning(`  ! voice: skipped (${voiceResult.voiceSkipped})`));
         }
       } catch (err) {
         spinner.stop();

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -9,6 +9,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { deltaE } from './colors.js';
+import { applyBudget, computeMetrics, totalWords, WORD_FLOOR } from './voice/metrics.js';
 
 /**
  * Meta for a merged snapshot. The merged artifact is a distinct snapshot, so it
@@ -406,6 +407,54 @@ function mergeWcag(results) {
 }
 
 /**
+ * All pages' voice fragments, deduplicated and rebudgeted as one corpus.
+ *
+ * Root `voice` deliberately stays the homepage's own further down: a metric
+ * like mean sentence length genuinely should not be averaged across a
+ * marketing page and a docs page, it would describe neither. Fragments are a
+ * different kind of thing. A quote is evidence regardless of which page
+ * carried it, and a homepage that is mostly nav chrome starves any reader
+ * that classifies brand voice from a handful of fragments -- exactly what a
+ * category-heavy site like an e-commerce homepage does to a one-page voice
+ * sample. Recomputing metrics from the merged corpus (not averaging two
+ * numbers) keeps every structural stat internally consistent.
+ *
+ * Returns null rather than a hollow object when nothing survives: a caller
+ * checking `voiceAllPages` should not have to also check `fragments.length`.
+ */
+function mergeVoice(results) {
+  const withVoice = results.filter((r) => r.voice && r.voice.fragments && r.voice.fragments.length);
+  if (withVoice.length === 0) return null;
+
+  const seen = new Set();
+  const fragments = [];
+  for (const r of withVoice) {
+    for (const f of r.voice.fragments) {
+      const key = `${f.role}|${f.text.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      fragments.push({ ...f, page: r.url });
+    }
+  }
+  if (fragments.length === 0) return null;
+
+  // The homepage's classification stands for the merged budget too: it is
+  // usually the most representative single page, and a budget has to pick one
+  // cap rather than average several.
+  const pageType = withVoice[0].voice.pageType;
+  const lang = withVoice[0].voice.metrics.lang;
+  const budgeted = applyBudget(fragments, pageType);
+  const belowWordFloor = totalWords(fragments) < WORD_FLOOR;
+
+  return {
+    fragments: budgeted,
+    metrics: computeMetrics(budgeted, lang),
+    pageType,
+    ...(belowWordFloor ? { belowWordFloor: true } : {}),
+  };
+}
+
+/**
  * Merge an array of per-page result objects into a single unified result.
  * @param {Object[]} results - Array of extractBranding() result objects
  * @returns {Object} Merged result with same shape as single-page result
@@ -440,10 +489,14 @@ export function mergeResults(results) {
     iconSystem: mergeByName(results, r => r.iconSystem),
     frameworks: mergeByName(results, r => r.frameworks),
     ...(results.some(r => r.wcag) ? { wcag: mergeWcag(results) } : {}),
-    // Not merged: the variation between pages is the signal. Root keeps the
-    // homepage's, each page keeps its own, as with rawColors.
+    // Metrics are not merged: the variation between pages is the signal. Root
+    // keeps the homepage's own, each page keeps its own, as with rawColors.
     ...(home.voice !== undefined ? { voice: home.voice } : {}),
     ...(home.voiceSkipped ? { voiceSkipped: home.voiceSkipped } : {}),
+    // Fragments are merged, deduplicated and rebudgeted across every page that
+    // yielded voice: see mergeVoice above for why this is a separate field
+    // from `voice` rather than a replacement for it.
+    ...(results.some((r) => r.voice !== undefined) ? { voiceAllPages: mergeVoice(results) } : {}),
     // rawColors are per-page filter diagnostics: merging them would destroy the
     // page provenance they exist for, so each page keeps its own set here.
     // colors.rawColors stays the first page's (via mergeColors) for back-compat.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -566,6 +566,8 @@ export interface Voice {
   fragments: VoiceFragment[];
   metrics: VoiceMetrics;
   pageType: VoicePageType;
+  /** Total word count fell under WORD_FLOOR: metrics are computed but noisy. */
+  belowWordFloor?: boolean;
 }
 
 /** CLI / programmatic options accepted by extractBranding(). */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -507,6 +507,9 @@ export interface VoiceFragment {
   order: number;
   /** Debug provenance for the source element. Only emitted with `debug`. */
   selectorHint?: string;
+  /** Which page this fragment was read from. Only set on a merged multi-page
+   *  voice corpus (`voiceAllPages`); a single-page `Voice` has no need for it. */
+  page?: string;
 }
 
 /** Coarse page classification. Sets the word budget and role weights only. */

--- a/lib/voice/index.ts
+++ b/lib/voice/index.ts
@@ -59,8 +59,15 @@ export async function collectVoice(
   const errorFragments = probe404 ? await probeErrorPage(page, url, probeTimeout) : [];
   const all = [...fragments, ...errorFragments];
 
-  if (totalWords(all) < WORD_FLOOR) return { voice: null, voiceSkipped: 'below-word-floor' };
+  const belowWordFloor = totalWords(all) < WORD_FLOOR;
 
   const budgeted = applyBudget(all, pageType);
-  return { voice: { fragments: budgeted, metrics: computeMetrics(budgeted, signals.lang), pageType } };
+  return {
+    voice: {
+      fragments: budgeted,
+      metrics: computeMetrics(budgeted, signals.lang),
+      pageType,
+      ...(belowWordFloor ? { belowWordFloor: true } : {}),
+    },
+  };
 }

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -408,4 +408,79 @@ test('a run without --voice gains no voice keys', () => {
   const merged = mergeResults([page('https://a.com/'), page('https://a.com/b')]);
   assert.equal('voice' in merged, false);
   assert.equal('voice' in merged.pages[0], false);
+  assert.equal('voiceAllPages' in merged, false);
+});
+
+// DEM-257 follow-up: a homepage carrying only nav chrome and one recycled
+// sentence starves a reader that classifies brand voice from `voice` alone
+// (see lib/merger.ts's mergeVoice doc comment). `voiceAllPages` is the fix:
+// every page's fragments, deduplicated, as one corpus -- while `voice` and
+// `pages[]` above stay exactly as the previous tests already pin them.
+test('voiceAllPages merges fragments across pages and dedupes repeats, without touching root voice', () => {
+  const home = page('https://a.com/', {
+    voice: {
+      fragments: [
+        { role: 'hero-h1', text: 'Hankkija - Kasvun osaaja', order: 0 },
+        { role: 'hero-body', text: 'Hankkija on Suomen johtava maatalouskauppa.', order: 0 },
+        { role: 'nav-label', text: 'Etusivu', order: 0 },
+        { role: 'nav-label', text: 'Piha ja puutarha', order: 1 },
+      ],
+      metrics: { structural: { wordCount: 10, sentenceCount: 1, meanSentenceLength: 7, sentenceLengthStdev: 0, exclamationRatio: 0, questionRatio: 0, longWordRatio: 0, avgSyllablesPerWord: 2, lowSample: true }, lexical: null, lang: 'fi' },
+      pageType: 'landing',
+    },
+  });
+  const category = page('https://a.com/piha-ja-puutarha', {
+    voice: {
+      fragments: [
+        // Same nav label as the homepage: identical role + text, must collapse to one.
+        { role: 'nav-label', text: 'Etusivu', order: 0 },
+        { role: 'section-h2', text: 'Kasvimaan perustaminen' },
+        { role: 'value-prop', text: 'Autamme sinua onnistumaan puutarhassa askel askeleelta.', order: 0 },
+      ],
+      metrics: { structural: { wordCount: 12, sentenceCount: 1, meanSentenceLength: 8, sentenceLengthStdev: 0, exclamationRatio: 0, questionRatio: 0, longWordRatio: 0, avgSyllablesPerWord: 2, lowSample: true }, lexical: null, lang: 'fi' },
+      pageType: 'other',
+    },
+  });
+
+  const merged = mergeResults([home, category]);
+
+  // Root voice is untouched: still exactly the homepage's four fragments.
+  assert.equal(merged.voice.fragments.length, 4);
+
+  const all = merged.voiceAllPages;
+  assert.ok(all);
+  // 4 + 3 fragments minus the one duplicate nav-label = 6.
+  assert.equal(all.fragments.length, 6);
+  assert.equal(all.fragments.filter((f) => f.role === 'nav-label' && f.text === 'Etusivu').length, 1);
+  // The category page's prose survives, which is the entire point.
+  assert.ok(all.fragments.some((f) => f.role === 'value-prop' && f.text.includes('puutarhassa')));
+  // Provenance: each fragment says which page it came from.
+  const valueProp = all.fragments.find((f) => f.role === 'value-prop');
+  assert.equal(valueProp.page, 'https://a.com/piha-ja-puutarha');
+  // Budget/classification decisions pick the homepage's, same as root voice.
+  assert.equal(all.pageType, 'landing');
+});
+
+test('voiceAllPages skips pages with no voice instead of throwing', () => {
+  const home = page('https://a.com/', {
+    voice: {
+      fragments: [{ role: 'hero-h1', text: 'Heading', order: 0 }],
+      metrics: { structural: { wordCount: 1, sentenceCount: 0, meanSentenceLength: 0, sentenceLengthStdev: 0, exclamationRatio: 0, questionRatio: 0, longWordRatio: 0, avgSyllablesPerWord: 1, lowSample: true }, lexical: null, lang: 'en' },
+      pageType: 'landing',
+    },
+  });
+  const thin = page('https://a.com/contact', { voice: null, voiceSkipped: 'below-word-floor' });
+
+  const merged = mergeResults([home, thin]);
+
+  assert.equal(merged.voiceAllPages.fragments.length, 1);
+});
+
+test('voiceAllPages is null when every page skipped voice, even though the run used --voice', () => {
+  const home = page('https://a.com/', { voice: null, voiceSkipped: 'no-text' });
+  const other = page('https://a.com/b', { voice: null, voiceSkipped: 'no-text' });
+
+  const merged = mergeResults([home, other]);
+
+  assert.equal(merged.voiceAllPages, null);
 });

--- a/test/voice-collect.test.ts
+++ b/test/voice-collect.test.ts
@@ -138,12 +138,24 @@ test('a malformed url degrades to no probe rather than aborting collection', asy
   await page.close();
 });
 
-test('a page under the word floor yields null plus a reason, never a partial object', async () => {
+test('a page under the word floor still returns fragments, flagged as low confidence', async () => {
   const page = await open('https://example.test/', doc('<h1>Hi</h1>'), { with404: false });
   const result = await collectVoice(page, 'https://example.test/');
 
+  assert.ok(result.voice, 'thin pages must still yield whatever copy exists');
+  assert.equal(result.voice.belowWordFloor, true);
+  assert.equal(result.voiceSkipped, undefined);
+  await page.close();
+});
+
+test('a page with no extractable text at all yields null plus a reason', async () => {
+  const page = await open('https://example.test/', '<!doctype html><html><head></head><body></body></html>', {
+    with404: false,
+  });
+  const result = await collectVoice(page, 'https://example.test/');
+
   assert.equal(result.voice, null);
-  assert.ok(result.voiceSkipped === 'below-word-floor' || result.voiceSkipped === 'no-text');
+  assert.equal(result.voiceSkipped, 'no-text');
   await page.close();
 });
 


### PR DESCRIPTION
## Summary
- Below-floor pages previously returned `voice: null` with no way to recover the copy that was collected.
- Now returns fragments + metrics with `belowWordFloor: true` instead; only true no-text/error cases still skip.
- Terminal warns unconditionally (not just `--verbose`) when voice is skipped or below floor.

## Test plan
- [x] `npm test` (655/655)
- [x] Verified live against thin-content sites

DEM-257