### PR TITLE
Stop dropping footer logos flagged as brand walls

### DIFF
--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -112,10 +112,13 @@ export async function extractLogo(page, url) {
     function inLogoWall(el) {
       const r0 = el.getBoundingClientRect();
       if (r0.width < 24 || r0.height < 8) return false;
-      // The primary logo lives in the header / nav; brand walls are content sections
-      // ("trusted by", integrations, press). Never treat a header/nav mark as a wall
-      // member — that protected e.g. a header logo sitting beside a couple of UI marks.
-      if (el.closest('header, nav, [role="banner"]')) return false;
+      // The primary logo lives in the header/nav or the footer; brand walls are content
+      // sections ("trusted by", integrations, press) in between. Never treat a header/nav
+      // or footer mark as a wall member — that protected e.g. a header logo sitting beside
+      // a couple of UI marks. A footer logo needs the same protection: footers commonly
+      // group it with social/app-store icons, which is exactly the >=3-sizable-marks shape
+      // this function otherwise flags as a wall.
+      if (el.closest('header, nav, [role="banner"], footer, [role="contentinfo"], [class*="footer" i], [id*="footer" i]')) return false;
       // Some sites build the top bar from plain divs (no <header>). A mark in the top strip
       // is chrome, not a content wall, so protect it by position too.
       if (r0.top + window.scrollY < 180) return false;


### PR DESCRIPTION
A footer logo sitting next to a row of social or app-store icons was getting classified as a customer/partner logo wall and dropped instead of proposed. inLogoWall() already said in its own comment that header and footer marks get the same protection, but the selector only checked header/nav. Fixed by extending the exemption to footer, [role=contentinfo], and class/id patterns matching "footer", the same zone-detection pattern pickZone already uses elsewhere in this file.

Verified against a marketing site with a scripted header logo and a raster wordmark in the footer sitting next to a cluster of social icons. Before the fix only the header mark surfaced in logoInstances; after the fix both do. All existing tests still pass. No new test added, since inLogoWall lives inline in the page.evaluate rather than in the pure, unit-tested heuristics file; happy to extract it there if that's preferred.

Not sure whether the same wall heuristic needs a similar look at sidebar or hero zones. Flag it if another false negative like this one turns up.