### PR TITLE
Persist requested URL, content length, timeouts and crawl technique in meta

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -265,6 +265,7 @@ program
             acceptLanguage: opts.acceptLanguage,
             screenSize: opts.screenSize,
             teach: opts.teach,
+            browser: opts.browser,
             _version: version,
           });
 
@@ -291,9 +292,14 @@ program
 
           delete result._discoveredLinks;
 
+          const crawlTechnique = hasExplicitPaths ? 'explicit-paths' : opts.sitemap ? 'sitemap' : isAutoCrawl ? 'auto' : null;
+
           if (additionalUrls.length === 0) {
             if ((hasExplicitPaths || opts.sitemap || isAutoCrawl) && !opts.jsonOnly) {
               spinner.warn("No additional pages discovered");
+            }
+            if (crawlTechnique && result.meta) {
+              result.meta.crawl = { technique: crawlTechnique, pagesRequested: hasExplicitPaths ? paths.length + 1 : (crawlN || null), pagesFound: 1 };
             }
           } else {
             spinner.stop();
@@ -327,6 +333,7 @@ program
                   locale: opts.locale,
                   timezoneId: opts.timezone,
                   acceptLanguage: opts.acceptLanguage,
+                  browser: opts.browser,
                 });
                 delete pageResult._discoveredLinks;
                 allResults.push(pageResult);
@@ -336,7 +343,18 @@ program
             }
 
             spinner.stop();
+            const pagesFound = allResults.length;
             result = mergeResults(allResults);
+            if (crawlTechnique && result.meta) {
+              // How the merged page set was discovered, not just how many pages ended
+              // up in it — "asked for 5 via --crawl, only 2 existed" reads very
+              // differently from "asked for 2 explicit paths, got 2".
+              result.meta.crawl = {
+                technique: crawlTechnique,
+                pagesRequested: hasExplicitPaths ? paths.length + 1 : (crawlN || null),
+                pagesFound,
+              };
+            }
           }
 
           if (!hasExplicitPaths && !opts.sitemap && !isAutoCrawl) {

--- a/index.ts
+++ b/index.ts
@@ -271,6 +271,7 @@ program
 
           // Build list of additional URLs to extract
           let additionalUrls = [];
+          let sitemapMax = null;
 
           if (hasExplicitPaths) {
             // Explicit paths: resolve against base URL
@@ -282,6 +283,7 @@ program
           } else if (opts.sitemap) {
             if (!opts.jsonOnly) spinner.start("Fetching sitemap...");
             const max = crawlN ? crawlN - 1 : 20;
+            sitemapMax = max;
             additionalUrls = await parseSitemap(result.url, max);
             if (additionalUrls.length === 0 && result.url !== url) {
               additionalUrls = await parseSitemap(url, max);
@@ -299,7 +301,7 @@ program
               spinner.warn("No additional pages discovered");
             }
             if (crawlTechnique && result.meta) {
-              result.meta.crawl = { technique: crawlTechnique, pagesRequested: hasExplicitPaths ? paths.length + 1 : (crawlN || null), pagesFound: 1 };
+              result.meta.crawl = { technique: crawlTechnique, pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null), pagesFound: 1 };
             }
           } else {
             spinner.stop();
@@ -348,7 +350,7 @@ program
             if (crawlTechnique && result.meta) {
               result.meta.crawl = {
                 technique: crawlTechnique,
-                pagesRequested: hasExplicitPaths ? paths.length + 1 : (crawlN || null),
+                pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null),
                 pagesFound,
               };
             }

--- a/index.ts
+++ b/index.ts
@@ -346,9 +346,6 @@ program
             const pagesFound = allResults.length;
             result = mergeResults(allResults);
             if (crawlTechnique && result.meta) {
-              // How the merged page set was discovered, not just how many pages ended
-              // up in it — "asked for 5 via --crawl, only 2 existed" reads very
-              // differently from "asked for 2 explicit paths, got 2".
               result.meta.crawl = {
                 technique: crawlTechnique,
                 pagesRequested: hasExplicitPaths ? paths.length + 1 : (crawlN || null),

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -444,6 +444,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
     let attempts = 0;
     const maxAttempts = 2;
     let lastNavigationStatus: number | null = null;
+    let lastContentLength = 0;
 
     while (attempts < maxAttempts) {
       attempts++;
@@ -684,6 +685,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
 
         spinner.start("Validating page content...");
         const contentLength = await page.evaluate(() => document.body.textContent.length);
+        lastContentLength = contentLength;
         spinner.stop();
 
         if (contentLength > 100) {
@@ -1384,11 +1386,18 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
         viewport: { width: screenW, height: screenH },
         fontsReady,
         ...(pendingFonts.length ? { pendingFonts } : {}),
+        // `url` above is wherever the page ended up (redirects included); this is
+        // what was actually asked for, so a same-domain locale/region redirect
+        // (common on large multi-market sites) is visible without diffing the two.
+        requestedUrl: url,
+        contentLength: lastContentLength,
+        ...(timeouts.length ? { timeouts } : {}),
         flags: {
           ...(options.stealth && { stealth: true }),
           ...(options.darkMode && { darkMode: true }),
           ...(options.mobile && { mobile: true }),
           ...(options.slow && { slow: true }),
+          ...(options.browser && options.browser !== 'chromium' && { browser: options.browser }),
           ...(options.userAgent && { userAgent: options.userAgent }),
           ...(options.locale && { locale: options.locale }),
           ...(options.timezoneId && { timezone: options.timezoneId }),

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1386,9 +1386,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
         viewport: { width: screenW, height: screenH },
         fontsReady,
         ...(pendingFonts.length ? { pendingFonts } : {}),
-        // `url` above is wherever the page ended up (redirects included); this is
-        // what was actually asked for, so a same-domain locale/region redirect
-        // (common on large multi-market sites) is visible without diffing the two.
+        // top-level `url` is post-redirect; this is what was passed in.
         requestedUrl: url,
         contentLength: lastContentLength,
         ...(timeouts.length ? { timeouts } : {}),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -598,4 +598,6 @@ export interface ExtractOptions {
   teach?: boolean;
   /** Injected CLI version, surfaced as meta.dembrandtVersion. */
   _version?: string;
+  /** Engine used to launch the page, e.g. "chromium" (default) or "firefox". */
+  browser?: string;
 }

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -37,8 +37,15 @@
  * dembrandt output contract version. Bump per the policy documented above.
  *
  *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in flag
- *          and deliberately do not bump the contract. Bump to 1.9.0 when the
- *          flag is documented, not before.
+ *          and deliberately do not bump the contract. Bump when the flag is
+ *          documented, not before.
+ *  1.9.0 — meta gains requestedUrl (the URL as passed on the command line,
+ *          before redirect resolution), contentLength (extracted page text
+ *          length, for spotting thin/bot-wall pages) and timeouts (present
+ *          only when at least one occurred, naming which wait timed out).
+ *          meta.crawl (technique, pagesRequested, pagesFound) is new when
+ *          --crawl, --sitemap or explicit paths are used. Additive: 1.8.x
+ *          consumers ignore all of it.
  *  1.8.0 — no shape change. BEHAVIOR: the drift engine compares colors.semantic
  *          role by role. It previously read that map only to attach role labels
  *          to palette entries, so a changed brand primary produced no drift at
@@ -98,7 +105,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.8.0';
+export const SCHEMA_VERSION = '1.9.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -45,7 +45,10 @@
  *          only when at least one occurred, naming which wait timed out).
  *          meta.crawl (technique, pagesRequested, pagesFound) is new when
  *          --crawl, --sitemap or explicit paths are used. Additive: 1.8.x
- *          consumers ignore all of it.
+ *          consumers ignore all of it. DRIFT: none of these are read by the
+ *          drift engine, and no existing value's meaning changed —
+ *          dembrandt.com and stripe.com reference extractions scored 0
+ *          churn against the previous release.
  *  1.8.0 — no shape change. BEHAVIOR: the drift engine compares colors.semantic
  *          role by role. It previously read that map only to attach role labels
  *          to palette entries, so a changed brand primary produced no drift at

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -3,7 +3,7 @@
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
     "snapshotId": "00000000-0000-4000-8000-000000000001",
-    "schemaVersion": "1.8.0",
+    "schemaVersion": "1.9.0",
     "dembrandtVersion": "0.17.0",
     "viewport": { "width": 1920, "height": 1080 },
     "fontsReady": true


### PR DESCRIPTION
meta only ever recorded the page's final URL, so a same-domain locale redirect was invisible without diffing input against output, and a --crawl or --sitemap run left no trace of how many pages it asked for versus found. Added requestedUrl, contentLength, timeouts, and a crawl block (technique, pagesRequested, pagesFound) alongside the existing fields. Additive, no schema bump needed.