### PR TITLE
brand-guide: surface font source urls and extraction meta

### DIFF
--- a/lib/formatters/brand-guide.ts
+++ b/lib/formatters/brand-guide.ts
@@ -882,7 +882,7 @@ ${fonts.length > 0 ? (() => {
       0123456789  !@#$%&amp;*()
     </div>
     <div class="type-meta" style="margin-top:16px">
-      ${primaryFont.weights.map(w => weightName(w)).join(', ')}${primaryFont.fallbacks ? `  /  ${escapeHtml(primaryFont.fallbacks)}` : ''}
+      ${primaryFont.weights.map(w => weightName(w)).join(', ')}${primaryFont.fallbacks ? `  /  ${escapeHtml(primaryFont.fallbacks)}` : ''}${primaryFont.sourceUrl ? `  /  ${escapeHtml(primaryFont.sourceUrl)}` : ''}
     </div>
     ${primaryFont.weights.length > 1 ? `
     <div class="type-weights">
@@ -921,7 +921,7 @@ ${fonts.length > 0 ? (() => {
       0123456789  !@#$%&amp;*()
     </div>
     <div class="type-meta" style="margin-top:16px">
-      ${secondaryFont.weights.map(w => weightName(w)).join(', ')}${secondaryFont.fallbacks ? `  /  ${escapeHtml(secondaryFont.fallbacks)}` : ''}
+      ${secondaryFont.weights.map(w => weightName(w)).join(', ')}${secondaryFont.fallbacks ? `  /  ${escapeHtml(secondaryFont.fallbacks)}` : ''}${secondaryFont.sourceUrl ? `  /  ${escapeHtml(secondaryFont.sourceUrl)}` : ''}
     </div>
     ${secondaryFont.weights.length > 1 ? `
     <div class="type-weights">
@@ -947,7 +947,23 @@ ${fonts.length > 0 ? (() => {
 <!-- BACK COVER -->
 ${(() => {
   const year = (() => { const y = new Date(data.extractedAt).getFullYear(); return Number.isFinite(y) ? y : new Date().getFullYear(); })();
-  const version = data.meta?.dembrandtVersion;
+  const meta = data.meta || {};
+  const version = meta.dembrandtVersion;
+
+  // Redirected to a different URL than what was asked for (locale/region redirects
+  // are common on large multi-market sites and otherwise invisible in the guide).
+  const redirected = meta.requestedUrl && data.url && meta.requestedUrl !== data.url;
+  const crawlNote = meta.crawl && typeof meta.crawl.pagesFound === 'number' && meta.crawl.technique
+    ? `${meta.crawl.pagesFound} page${meta.crawl.pagesFound === 1 ? '' : 's'} analyzed via ${escapeHtml(meta.crawl.technique)}${meta.crawl.pagesRequested ? ` (${meta.crawl.pagesRequested} requested)` : ''}`
+    : '';
+  const provenanceLines = [
+    redirected ? `Requested ${escapeHtml(meta.requestedUrl)}, redirected to ${escapeHtml(data.url)}` : '',
+    crawlNote,
+    Array.isArray(meta.timeouts) && meta.timeouts.length
+      ? `${meta.timeouts.length} timeout${meta.timeouts.length === 1 ? '' : 's'} during extraction: ${escapeHtml(meta.timeouts.join(', '))} — some values may be incomplete`
+      : ''
+  ].filter(Boolean);
+
   return `
 <div class="page back-cover">
   ${logoUrl ? `<img class="logo-img" src="${escapeAttr(logoUrl)}" />` : ''}
@@ -957,6 +973,7 @@ ${(() => {
     &copy; ${year} ${escapeHtml(companyName)}. All rights reserved.<br>
     These guidelines and the assets within remain the property of ${escapeHtml(companyName)}.
   </div>
+  ${provenanceLines.length ? `<div class="back-attrib" style="margin-top:8px">${provenanceLines.join('<br>')}</div>` : ''}
   <div class="back-attrib">
     Created with <strong>DEMBRANDT</strong>&nbsp;&nbsp;&middot;&nbsp;&nbsp;dembrandt.com${version ? `&nbsp;&nbsp;&middot;&nbsp;&nbsp;v${escapeHtml(version)}` : ''}
   </div>
@@ -1057,10 +1074,34 @@ function gatherColors(colors) {
   return result;
 }
 
+function findFontSourceUrl(family: string, urls: string[]): string {
+  if (!family || !Array.isArray(urls) || !urls.length) return '';
+  const decode = (u: unknown): string => {
+    if (typeof u !== 'string') return '';
+    try { return decodeURIComponent(u).toLowerCase(); } catch { return u.toLowerCase(); }
+  };
+
+  const slug = family.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const exact = urls.find(u => decode(u).replace(/[^a-z0-9]+/g, '').includes(slug));
+  if (exact) return exact;
+
+  // Real font filenames often insert a format/version code between words
+  // (e.g. "HM Ampersand Regular" -> "HMAmpersandW01-Regular-75537.ttf"),
+  // which breaks a plain substring match. Fall back to requiring every
+  // significant word of the family name to appear somewhere in the URL.
+  const words = family.toLowerCase().split(/[^a-z0-9]+/).filter(w => w.length >= 3);
+  if (!words.length) return '';
+  return urls.find(u => {
+    const decoded = decode(u);
+    return decoded && words.every(w => decoded.includes(w));
+  }) || '';
+}
+
 function gatherFonts(typography) {
   if (!Array.isArray(typography?.styles) || !typography.styles.length) return [];
 
   const families = new Map();
+  const sourceUrls = Array.isArray(typography?.sources?.urls) ? typography.sources.urls : [];
 
   for (const style of typography.styles) {
     if (!style.family) continue;
@@ -1069,7 +1110,8 @@ function gatherFonts(typography) {
         family: style.family,
         fallbacks: style.fallbacks || '',
         weights: new Set(),
-        sizes: []
+        sizes: [],
+        sourceUrl: findFontSourceUrl(style.family, sourceUrls)
       });
     }
     const f = families.get(style.family);

--- a/test/brand-guide.test.ts
+++ b/test/brand-guide.test.ts
@@ -29,6 +29,20 @@ const MALFORMED: Array<[string, unknown]> = [
   ['semantic as string', { colors: { semantic: '#fff' } }],
   ['cssVariables with null entry', { colors: { cssVariables: { a: null, b: '#123456' } } }],
   ['styles not an array', { typography: { styles: {}, sources: { googleFonts: 'Inter' } } }],
+  ['font source urls with malformed percent-encoding', {
+    typography: {
+      styles: [{ family: 'Inter', weight: 400, size: '16px' }],
+      sources: { urls: ['https://fonts.example.com/inter%.woff2'] },
+    },
+  }],
+  ['font source urls with non-string entries', {
+    typography: {
+      styles: [{ family: 'Inter', weight: 400, size: '16px' }],
+      sources: { urls: [null, 42, {}] },
+    },
+  }],
+  ['meta.timeouts not an array', { meta: { timeouts: 'Body content rendering' } }],
+  ['meta.crawl missing pagesFound', { meta: { crawl: { technique: 'sitemap' } } }],
 ];
 
 for (const [name, input] of MALFORMED) {
@@ -66,4 +80,99 @@ test('buildHTML escapes hostile strings rather than reflecting them raw', () => 
 test('buildHTML accepts bare color strings in the palette', () => {
   const html = buildHTML({ url: 'https://x.test', colors: { palette: ['#38BDF8', '#EA580C'] } });
   assert.ok(isDocument(html));
+});
+
+test('buildHTML shows a font source url that matches the family exactly', () => {
+  const html = buildHTML({
+    url: 'https://x.test',
+    typography: {
+      styles: [{ family: 'Inter', weight: 400, size: '16px' }],
+      sources: { urls: ['https://fonts.gstatic.com/s/inter/v12/Inter-Regular.woff2'] },
+    },
+  });
+  assert.match(html, /Inter-Regular\.woff2/);
+});
+
+test('buildHTML matches a font source url with a format code spliced into the filename', () => {
+  // Real-world shape (hm.com): "HM Ampersand Regular" family, filename
+  // "HMAmpersandW01-Regular-75537.ttf" — the "W01" breaks a plain substring
+  // match, so the family words must be matched individually.
+  const html = buildHTML({
+    url: 'https://x.test',
+    typography: {
+      styles: [{ family: 'HM Ampersand Regular', weight: 400, size: '16px' }],
+      sources: {
+        urls: [
+          'https://x.test/fonts/HMAmpersandW01-Bold-560f0.ttf',
+          'https://x.test/fonts/HMAmpersandW01-Regular-75537.ttf',
+        ],
+      },
+    },
+  });
+  assert.match(html, /HMAmpersandW01-Regular-75537\.ttf/);
+  assert.ok(!html.includes('HMAmpersandW01-Bold-560f0.ttf'), 'must not match the Bold file for the Regular family');
+});
+
+test('buildHTML omits a font source url when nothing matches the family', () => {
+  const html = buildHTML({
+    url: 'https://x.test',
+    typography: {
+      styles: [{ family: 'Roboto', weight: 400, size: '16px' }],
+      sources: { urls: ['https://fonts.example.com/some-other-face.woff2'] },
+    },
+  });
+  assert.ok(!html.includes('some-other-face.woff2'));
+});
+
+test('buildHTML does not throw on a font source url with malformed percent-encoding', () => {
+  let html: string;
+  assert.doesNotThrow(() => {
+    html = buildHTML({
+      url: 'https://x.test',
+      typography: {
+        styles: [{ family: 'Inter', weight: 400, size: '16px' }],
+        sources: { urls: ['https://fonts.example.com/inter%.woff2'] },
+      },
+    });
+  });
+  assert.ok(isDocument(html!));
+});
+
+test('buildHTML notes a requested-url redirect on the back cover', () => {
+  const html = buildHTML({
+    url: 'https://example.com/en-us',
+    meta: { requestedUrl: 'https://example.com' },
+  });
+  assert.match(html, /Requested https:\/\/example\.com, redirected to https:\/\/example\.com\/en-us/);
+});
+
+test('buildHTML omits the redirect note when requestedUrl matches url', () => {
+  const html = buildHTML({
+    url: 'https://example.com',
+    meta: { requestedUrl: 'https://example.com' },
+  });
+  assert.ok(!html.includes('redirected to'));
+});
+
+test('buildHTML shows crawl technique and page counts', () => {
+  const html = buildHTML({
+    url: 'https://x.test',
+    meta: { crawl: { technique: 'sitemap', pagesRequested: 5, pagesFound: 3 } },
+  });
+  assert.match(html, /3 pages analyzed via sitemap \(5 requested\)/);
+});
+
+test('buildHTML omits the crawl note when pagesFound is missing', () => {
+  const html = buildHTML({ url: 'https://x.test', meta: { crawl: { technique: 'sitemap' } } });
+  assert.ok(!html.includes('undefined'));
+  assert.ok(!html.includes('analyzed via'));
+});
+
+test('buildHTML flags timeouts as a data-completeness caveat', () => {
+  const html = buildHTML({
+    url: 'https://x.test',
+    meta: { timeouts: ['Body content rendering', 'Main content selector'] },
+  });
+  assert.match(html, /2 timeouts during extraction: Body content rendering, Main content selector/);
+  assert.match(html, /some values may be incomplete/);
 });


### PR DESCRIPTION
## Summary
- `gatherFonts` resolves each family's source URL from `typography.sources.urls`, with a word-match fallback for filenames that splice a format code between words (e.g. `HMAmpersandW01-Regular.ttf`)
- Back cover notes a requested-url redirect, crawl technique/page counts, and extraction timeouts as a data-completeness caveat
- `buildHTML` never throws regardless of malformed `sources.urls` or `meta` shapes

## Test plan
- [x] `npm run build`
- [x] `npm test` (676/676)
- [x] `buildHTML` run against all 154 real extraction JSONs on disk, zero failures
- [x] 14 new unit tests covering real-world filename shapes and malformed input