### PR TITLE
chore(deps): bump playwright to 1.62.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chalk": "^5.6.2",
         "commander": "15.0.0",
         "ora": "9.4.1",
-        "playwright-core": "1.61.1",
+        "playwright-core": "1.62.1",
         "zod": "4.4.3"
       },
       "bin": {
@@ -26,8 +26,8 @@
         "@tailwindcss/cli": "4.3.2",
         "@types/node": "22.20.1",
         "eslint": "10.6.0",
-        "playwright": "1.61.1",
-        "playwright-core": "1.61.1",
+        "playwright": "1.62.1",
+        "playwright-core": "1.62.1",
         "tailwindcss": "4.3.2",
         "typescript": "6.0.3",
         "typescript-eslint": "8.63.0"
@@ -4483,35 +4483,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "chalk": "^5.6.2",
     "commander": "15.0.0",
     "ora": "9.4.1",
-    "playwright-core": "1.61.1",
+    "playwright-core": "1.62.1",
     "zod": "4.4.3"
   },
   "optionalDependencies": {
@@ -144,8 +144,8 @@
     "@tailwindcss/cli": "4.3.2",
     "@types/node": "22.20.1",
     "eslint": "10.6.0",
-    "playwright": "1.61.1",
-    "playwright-core": "1.61.1",
+    "playwright": "1.62.1",
+    "playwright-core": "1.62.1",
     "tailwindcss": "4.3.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.63.0"


### PR DESCRIPTION
Newer bundled Chromium to cut down on bot-wall false positives.

- playwright/playwright-core 1.61.1 -> 1.62.1 (published 2026-07-30)
- Verified: 682/682 tests green, live extraction against stripe.com works with the new binary

https://claude.ai/code/session_019JJX5CXmwtz5ogCy22yTM7