### PR TITLE
Let below-fold logos through without a home link when they self-identify

### DIFF
--- a/lib/extractors/logo-heuristics.ts
+++ b/lib/extractors/logo-heuristics.ts
@@ -160,9 +160,14 @@ export function isOwnBrandMark(altText: unknown, fileUrl: unknown, siteDomain: u
     .replace(/\b(on[-_]?white|on[-_]?black|white|black|dark|light|colou?r|mono|full|small|large|[0-9]+x|2x|3x|v?[0-9]{1,4})\b/gi, ' ')
     .replace(/[^a-z0-9]+/gi, '')
     .toLowerCase();
-  // Squash the domain root through the same pipeline as alt/filename so a
-  // hyphenated brand ("my-shop.com") still matches "My Shop logo".
-  const root = squash((typeof siteDomain === 'string' ? siteDomain : '').split('.')[0]);
+  // Strip non-alphanumerics from the domain root so a hyphenated brand
+  // ("my-shop.com") still matches "My Shop logo" — but skip the noise-word
+  // and variant-number removal from squash(), which is tuned for filenames
+  // and alt text: a purely numeric root ("123.com") would otherwise be
+  // stripped to nothing by the "[0-9]{1,4}" variant-suffix rule.
+  const root = (typeof siteDomain === 'string' ? siteDomain : '').split('.')[0]
+    .replace(/[^a-z0-9]+/gi, '')
+    .toLowerCase();
   if (!root || root.length < 2) return false;
   // A root under 4 chars (ba, hp, ge...) is too common a substring of
   // unrelated words to trust with includes() ("zex" inside "Buzzexchange") —

--- a/lib/extractors/logo-heuristics.ts
+++ b/lib/extractors/logo-heuristics.ts
@@ -146,6 +146,29 @@ export function isLogoSized(width: unknown, height: unknown, minLongEdge = 24): 
   return Math.max(w, h) >= minLongEdge;
 }
 
+/**
+ * Does this alt text or filename explicitly name the site's OWN brand? The below-fold
+ * pre-scan otherwise drops every non-home-linked mark to keep out partner/customer walls —
+ * but a footer logo is often not wrapped in a home link at all, and gets discarded along
+ * with them. A mark that self-identifies as the site's own brand should survive that guard
+ * even without a home link.
+ */
+export function isOwnBrandMark(altText: unknown, fileUrl: unknown, siteDomain: unknown): boolean {
+  const root = (typeof siteDomain === 'string' ? siteDomain : '').toLowerCase().split('.')[0];
+  if (!root || root.length < 2) return false;
+  const squash = (s: unknown) => (typeof s === 'string' ? s : '')
+    .replace(/\b(logos?|logotypes?|logomarks?|brandmarks?|wordmarks?|icons?|brands?|marks?)\b/gi, ' ')
+    .replace(/\.(svg|png|webp|avif|jpe?g|gif)\b/gi, ' ')
+    .replace(/\b(on[-_]?white|on[-_]?black|white|black|dark|light|colou?r|mono|full|small|large|[0-9]+x|2x|3x|v?[0-9]{1,4})\b/gi, ' ')
+    .replace(/[^a-z0-9]+/gi, '')
+    .toLowerCase();
+  const alt = squash(altText);
+  if (alt.length >= 2 && alt.includes(root)) return true;
+  const fileName = typeof fileUrl === 'string' ? (fileUrl.split(/[/?#]/).filter(Boolean).pop() || '') : '';
+  const file = squash(fileName);
+  return file.length >= 2 && file.includes(root);
+}
+
 // Serialized twins, injected into page.evaluate so the browser runs identical code.
 // Order matters only for readability; none reference each other.
 export const LOGO_HEURISTICS_SOURCE: string = [
@@ -155,4 +178,5 @@ export const LOGO_HEURISTICS_SOURCE: string = [
   positionFraction,
   fitPaintedBox,
   isLogoSized,
+  isOwnBrandMark,
 ].map((fn) => fn.toString()).join('\n\n');

--- a/lib/extractors/logo-heuristics.ts
+++ b/lib/extractors/logo-heuristics.ts
@@ -154,19 +154,28 @@ export function isLogoSized(width: unknown, height: unknown, minLongEdge = 24): 
  * even without a home link.
  */
 export function isOwnBrandMark(altText: unknown, fileUrl: unknown, siteDomain: unknown): boolean {
-  const root = (typeof siteDomain === 'string' ? siteDomain : '').toLowerCase().split('.')[0];
-  if (!root || root.length < 2) return false;
   const squash = (s: unknown) => (typeof s === 'string' ? s : '')
     .replace(/\b(logos?|logotypes?|logomarks?|brandmarks?|wordmarks?|icons?|brands?|marks?)\b/gi, ' ')
     .replace(/\.(svg|png|webp|avif|jpe?g|gif)\b/gi, ' ')
     .replace(/\b(on[-_]?white|on[-_]?black|white|black|dark|light|colou?r|mono|full|small|large|[0-9]+x|2x|3x|v?[0-9]{1,4})\b/gi, ' ')
     .replace(/[^a-z0-9]+/gi, '')
     .toLowerCase();
-  const alt = squash(altText);
-  if (alt.length >= 2 && alt.includes(root)) return true;
+  // Squash the domain root through the same pipeline as alt/filename so a
+  // hyphenated brand ("my-shop.com") still matches "My Shop logo".
+  const root = squash((typeof siteDomain === 'string' ? siteDomain : '').split('.')[0]);
+  if (!root || root.length < 2) return false;
+  // A root under 4 chars (ba, hp, ge...) is too common a substring of
+  // unrelated words to trust with includes() ("zex" inside "Buzzexchange") —
+  // require it to stand as a whole word instead. squash() already strips
+  // word boundaries, so the word check runs on the un-squashed, merely
+  // tokenized text.
+  const tokenize = (s: unknown) => (typeof s === 'string' ? s : '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  const matches = (s: unknown) => root.length >= 4
+    ? squash(s).includes(root)
+    : tokenize(s).includes(root);
+  if (matches(altText)) return true;
   const fileName = typeof fileUrl === 'string' ? (fileUrl.split(/[/?#]/).filter(Boolean).pop() || '') : '';
-  const file = squash(fileName);
-  return file.length >= 2 && file.includes(root);
+  return matches(fileName);
 }
 
 // Serialized twins, injected into page.evaluate so the browser runs identical code.

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -94,13 +94,14 @@ export async function extractLogo(page, url) {
     // code. guardExtractor wraps this whole evaluate, so even a rehydration failure only
     // yields an empty logo result for this one site — never a crash.
     const H = new Function(heuristicsSource +
-      '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')() as {
+      '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized, isOwnBrandMark };')() as {
         isHomeHref: (href: any, origin: any) => boolean;
         classifyContextByPosition: (top: any, docHeight: any, foldY?: number) => 'header'|'footer'|'hero'|'body';
         thirdPartyBrandFromAlt: (alt: any, site: any) => string | null;
         positionFraction: (token: any) => number;
         fitPaintedBox: (content: any, intrinsic: any, fit: any, px?: number, py?: number) => { x: number; y: number; width: number; height: number };
         isLogoSized: (w: any, h: any, minLongEdge?: number) => boolean;
+        isOwnBrandMark: (alt: any, fileUrl: any, site: any) => boolean;
       };
 
     // A customer / partner logo wall is a STRUCTURAL pattern, not a naming one: three or
@@ -680,12 +681,16 @@ export async function extractLogo(page, url) {
             // names a different brand in its alt or file name, it is not ours — skip it.
             // (A partner strip of "logo-<Brand>.svg" images slipped in here: the pre-scan
             // never ran the third-party guard that findLogosInZone applies.)
+            const altText = (el.getAttribute('alt') || '');
             if (!homeLinked) {
-              const altText = (el.getAttribute('alt') || '');
               if (H.thirdPartyBrandFromAlt(altText, siteDomain) || inLogoWall(el)) continue;
             }
             const belowFold = rect.top > 500;
-            if (belowFold && !homeLinked) continue; // below the fold, only our own home-linked mark
+            // A below-fold mark normally needs a home link to prove it's ours — but a footer
+            // logo is often not linked at all. If its alt or filename self-identifies as the
+            // site's own brand, that's proof enough without the link.
+            const ownBrand = homeLinked || H.isOwnBrandMark(altText, el.getAttribute('src') || el.getAttribute('href') || '', siteDomain);
+            if (belowFold && !ownBrand) continue; // below the fold, only our own mark qualifies
             const context = !belowFold ? 'header'
               : (rect.top > document.documentElement.scrollHeight - 1200 ? 'footer' : 'body');
             const score = scoreLogo(el, context) + 20; // bonus for semantic match

--- a/test/logo-heuristics.test.ts
+++ b/test/logo-heuristics.test.ts
@@ -255,6 +255,12 @@ test('isOwnBrandMark: a hyphenated domain root matches an unhyphenated brand nam
   assert.equal(isOwnBrandMark('My Shop logo', null, 'my-shop.com'), true);
 });
 
+test('isOwnBrandMark: a purely numeric domain root is not stripped to nothing', () => {
+  // squash()'s variant-suffix rule ([0-9]{1,4}) would otherwise erase "123"
+  // entirely when it's run over the domain root instead of just alt/filename.
+  assert.equal(isOwnBrandMark('123 Inc', null, '123.com'), true);
+});
+
 // ---- serialization contract ------------------------------------------------
 test('LOGO_HEURISTICS_SOURCE re-hydrates to functions that behave identically', () => {
   const H = new Function(LOGO_HEURISTICS_SOURCE +

--- a/test/logo-heuristics.test.ts
+++ b/test/logo-heuristics.test.ts
@@ -241,6 +241,20 @@ test('isOwnBrandMark: defensive against null / non-string / short site root', ()
   assert.equal(isOwnBrandMark(42 as any, 42 as any, 'acme.com'), false);
 });
 
+test('isOwnBrandMark: a short domain root does not match as a substring of an unrelated word', () => {
+  // "zex.com" must not let "Buzzexchange Ltd" through just because "zex" sits inside it.
+  assert.equal(isOwnBrandMark('Buzzexchange Ltd', null, 'zex.com'), false);
+});
+
+test('isOwnBrandMark: a short domain root still matches as its own word', () => {
+  assert.equal(isOwnBrandMark('Zex Inc', null, 'zex.com'), true);
+  assert.equal(isOwnBrandMark(null, '/img/zex-logo.svg', 'zex.com'), true);
+});
+
+test('isOwnBrandMark: a hyphenated domain root matches an unhyphenated brand name', () => {
+  assert.equal(isOwnBrandMark('My Shop logo', null, 'my-shop.com'), true);
+});
+
 // ---- serialization contract ------------------------------------------------
 test('LOGO_HEURISTICS_SOURCE re-hydrates to functions that behave identically', () => {
   const H = new Function(LOGO_HEURISTICS_SOURCE +

--- a/test/logo-heuristics.test.ts
+++ b/test/logo-heuristics.test.ts
@@ -7,6 +7,7 @@ import {
   positionFraction,
   fitPaintedBox,
   isLogoSized,
+  isOwnBrandMark,
   LOGO_HEURISTICS_SOURCE,
 } from '../lib/extractors/logo-heuristics.js';
 
@@ -213,10 +214,37 @@ test('isLogoSized: defensive against zero / negative / NaN / non-numeric', () =>
   assert.equal(isLogoSized('40' as any, undefined as any), false);
 });
 
+// ---- isOwnBrandMark ---------------------------------------------------------
+test('isOwnBrandMark: alt text naming the site brand matches', () => {
+  assert.equal(isOwnBrandMark('Acme Corp', null, 'acme.com'), true);
+  assert.equal(isOwnBrandMark('acme.com logo', null, 'acme.com'), true);
+});
+
+test('isOwnBrandMark: filename naming the site brand matches when alt is absent', () => {
+  assert.equal(isOwnBrandMark(null, 'https://cdn.x.com/assets/acme.com.webp', 'acme.com'), true);
+  assert.equal(isOwnBrandMark('', '/img/acme-logo-single-white.svg', 'acme.com'), true);
+});
+
+test('isOwnBrandMark: a different brand in alt or filename does not match', () => {
+  assert.equal(isOwnBrandMark('Globex Inc', null, 'acme.com'), false);
+  assert.equal(isOwnBrandMark(null, '/logos/partner-globex.svg', 'acme.com'), false);
+});
+
+test('isOwnBrandMark: generic alt with no brand signal does not match', () => {
+  assert.equal(isOwnBrandMark('Logo', null, 'acme.com'), false);
+  assert.equal(isOwnBrandMark(null, null, 'acme.com'), false);
+});
+
+test('isOwnBrandMark: defensive against null / non-string / short site root', () => {
+  assert.equal(isOwnBrandMark(undefined as any, undefined as any, undefined as any), false);
+  assert.equal(isOwnBrandMark('Acme', null, 'a'), false);
+  assert.equal(isOwnBrandMark(42 as any, 42 as any, 'acme.com'), false);
+});
+
 // ---- serialization contract ------------------------------------------------
 test('LOGO_HEURISTICS_SOURCE re-hydrates to functions that behave identically', () => {
   const H = new Function(LOGO_HEURISTICS_SOURCE +
-    '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized };')();
+    '\nreturn { isHomeHref, classifyContextByPosition, thirdPartyBrandFromAlt, positionFraction, fitPaintedBox, isLogoSized, isOwnBrandMark };')();
   assert.equal(typeof H.isHomeHref, 'function');
   assert.equal(H.isHomeHref('/', 'https://x.com'), isHomeHref('/', 'https://x.com'));
   assert.equal(H.classifyContextByPosition(7500, 8000), classifyContextByPosition(7500, 8000));
@@ -226,6 +254,7 @@ test('LOGO_HEURISTICS_SOURCE re-hydrates to functions that behave identically', 
     fitPaintedBox(box(0, 0, 200, 200), { width: 400, height: 100 }, 'contain'),
   );
   assert.equal(H.isLogoSized(16, 16), isLogoSized(16, 16));
+  assert.equal(H.isOwnBrandMark('acme.com logo', null, 'acme.com'), isOwnBrandMark('acme.com logo', null, 'acme.com'));
 });
 
 test('LOGO_HEURISTICS_SOURCE is self-contained: no module refs leak in', () => {


### PR DESCRIPTION
The below-fold pre-scan only accepted a mark whose link pointed at the home page, so a genuinely site-owned footer logo that isn't wrapped in any link at all was dropped along with partner and customer logo walls. This adds a narrow, pure heuristic, isOwnBrandMark, that checks a candidate's alt text or filename against the site's own domain and lets it through on that signal even without a home link.

The change is additive: existing home-linked and above-fold behavior is untouched, and the new path only widens what below-fold non-home-linked marks can qualify.

Unit tests cover matching alt text, matching filename, a different brand's alt or filename, generic text with no brand signal, and defensive input handling, plus the serialization round-trip that runs the same code inside the page. Full suite passes with no regressions.