### PR TITLE
feat(colors): bind WCAG contrast pairs to palette candidates (DEM-267)

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -873,3 +873,38 @@ export async function extractWcagPairs(page) {
 
   return pairs.sort((a, b) => b.count - a.count);
 }
+
+/**
+ * Bind each observed WCAG contrast pair back onto the palette candidate it was
+ * measured against, so a colour carries "this is AA-compliant text against X"
+ * as a feature instead of leaving pairs and candidates as two unlinked lists
+ * (DEM-267). Mutates each matching entry's `contrastAgainst` in place and
+ * returns the palette for convenience; entries with no observed pair are
+ * left untouched (no empty array).
+ */
+export function bindContrastToPalette(palette: unknown, wcagPairs: unknown): unknown {
+  if (!Array.isArray(palette) || !Array.isArray(wcagPairs) || !wcagPairs.length) return palette;
+  const byColor = new Map<string, { bg: string; ratio: number; aa: boolean }[]>();
+  const add = (self: string, other: string, ratio: number, aa: boolean) => {
+    if (!self || !other) return;
+    if (!byColor.has(self)) byColor.set(self, []);
+    byColor.get(self).push({ bg: other, ratio, aa });
+  };
+  for (const p of wcagPairs) {
+    if (!p || !p.fg || !p.bg) continue;
+    add(p.fg, p.bg, p.ratio, p.aa);
+    add(p.bg, p.fg, p.ratio, p.aa);
+  }
+  for (const entry of palette) {
+    if (!entry || !entry.normalized) continue;
+    const matches = byColor.get(entry.normalized);
+    if (!matches || !matches.length) continue;
+    const byOther = new Map();
+    for (const m of matches) {
+      const prev = byOther.get(m.bg);
+      if (!prev || m.ratio > prev.ratio) byOther.set(m.bg, m);
+    }
+    entry.contrastAgainst = Array.from(byOther.values()).sort((a, b) => b.ratio - a.ratio).slice(0, 10);
+  }
+  return palette;
+}

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -10,7 +10,7 @@ import { extractSpacing, extractBorderRadius, extractBorders, extractShadows } f
 import { extractButtonStyles, extractInputStyles, extractLinkStyles, extractBadgeStyles } from './components.js';
 import { extractBreakpoints, detectIconSystem, detectFrameworks, extractGradients, extractMotion, extractMotionStatic, FREEZE_STYLE_ID } from './breakpoints.js';
 import { extractTeach } from './teach.js';
-import { extractWcagPairs } from './colors.js';
+import { extractWcagPairs, bindContrastToPalette } from './colors.js';
 import { SCHEMA_VERSION } from '../version.js';
 import { buildContextOptions, parseCookies, parseScreenSize, DEFAULT_LOCALE } from './context-config.js';
 import { guardExtractor } from './guard.js';
@@ -1390,6 +1390,8 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
       } catch {
         spinner.stop();
       }
+
+      bindContrastToPalette(colors.palette, wcag);
     }
 
     // Self-hosted font files, deduped and sorted. fontRequests is a Set filled

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,12 @@ export interface PaletteColor {
   /** Precomputed notations of `normalized`; see convertColor() */
   lch?: string;
   oklch?: string;
+  /**
+   * WCAG contrast pairs this candidate was actually seen against on the page
+   * (from `wcag`, when --wcag is on). Sorted by ratio descending, deduped by
+   * the other colour. Absent when --wcag is off or this colour was in no pair.
+   */
+  contrastAgainst?: { bg: string; ratio: number; aa: boolean }[];
 }
 
 /**

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -39,6 +39,13 @@
  *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in flag
  *          and deliberately do not bump the contract. Bump when the flag is
  *          documented, not before.
+ *  1.10.0 — colors.palette entries gain contrastAgainst: [{bg, ratio, aa}],
+ *          the WCAG pairs (from `wcag`, --wcag only) this candidate was
+ *          actually observed against on the page, sorted by ratio descending
+ *          and deduped by the other colour (DEM-267). Behind --wcag, same as
+ *          `wcag` itself: absent entirely when the flag is off. Additive:
+ *          1.9.x consumers ignore it. DRIFT: not read by the drift engine;
+ *          candidate colour values and ordering are unchanged.
  *  1.9.0 — meta gains requestedUrl (the URL as passed on the command line,
  *          before redirect resolution), contentLength (extracted page text
  *          length, for spotting thin/bot-wall pages) and timeouts (present
@@ -108,7 +115,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.9.0';
+export const SCHEMA_VERSION = '1.10.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { hexToRgb, relativeLuminance, computeWcag, convertColor, deltaE, deltaE2000 } from '../lib/colors.js';
-import { capConfidenceByUsage } from '../lib/extractors/colors.js';
+import { capConfidenceByUsage, bindContrastToPalette } from '../lib/extractors/colors.js';
 
 test('hexToRgb parses 6, 3, and 8 digit hex', () => {
   assert.deepEqual(hexToRgb('#ff0000'), { r: 255, g: 0, b: 0 });
@@ -114,4 +114,47 @@ test('capConfidenceByUsage demotes a single-occurrence medium', () => {
 test('capConfidenceByUsage never promotes, and never throws on a missing count', () => {
   assert.equal(capConfidenceByUsage('low', 900), 'low');
   assert.equal(capConfidenceByUsage('high', undefined), 'low');
+});
+
+// bindContrastToPalette (DEM-267): link observed WCAG pairs back onto the
+// palette candidate they were measured against.
+
+type TestCandidate = { normalized: string; contrastAgainst?: { bg: string; ratio: number; aa: boolean }[] };
+
+test('bindContrastToPalette attaches contrastAgainst to a matching candidate on either side of a pair', () => {
+  const palette: TestCandidate[] = [{ normalized: '#111111' }, { normalized: '#ffffff' }, { normalized: '#ff0000' }];
+  const wcag = [{ fg: '#111111', bg: '#ffffff', ratio: 18.1, aa: true }];
+  bindContrastToPalette(palette, wcag);
+  assert.deepEqual(palette[0].contrastAgainst, [{ bg: '#ffffff', ratio: 18.1, aa: true }]);
+  assert.deepEqual(palette[1].contrastAgainst, [{ bg: '#111111', ratio: 18.1, aa: true }]);
+  assert.equal(palette[2].contrastAgainst, undefined);
+});
+
+test('bindContrastToPalette dedupes by the other colour, keeping the higher ratio', () => {
+  const palette: TestCandidate[] = [{ normalized: '#111111' }];
+  const wcag = [
+    { fg: '#111111', bg: '#ffffff', ratio: 15, aa: true },
+    { fg: '#111111', bg: '#ffffff', ratio: 18.1, aa: true },
+  ];
+  bindContrastToPalette(palette, wcag);
+  assert.deepEqual(palette[0].contrastAgainst, [{ bg: '#ffffff', ratio: 18.1, aa: true }]);
+});
+
+test('bindContrastToPalette sorts by ratio descending and caps at 10', () => {
+  const palette: TestCandidate[] = [{ normalized: '#111111' }];
+  const wcag = Array.from({ length: 15 }, (_, i) => ({
+    fg: '#111111', bg: `#${String(i).padStart(6, '0')}`, ratio: i + 1, aa: true,
+  }));
+  bindContrastToPalette(palette, wcag);
+  assert.equal(palette[0].contrastAgainst?.length, 10);
+  assert.equal(palette[0].contrastAgainst?.[0].ratio, 15);
+  assert.equal(palette[0].contrastAgainst?.[9].ratio, 6);
+});
+
+test('bindContrastToPalette leaves candidates untouched when wcag is empty, and never throws on malformed input', () => {
+  const palette: TestCandidate[] = [{ normalized: '#111111' }];
+  assert.equal(bindContrastToPalette(palette, []), palette);
+  assert.equal(palette[0].contrastAgainst, undefined);
+  assert.deepEqual(bindContrastToPalette(null, [{ fg: '#111111', bg: '#fff' }]), null);
+  assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
 });

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -3,7 +3,7 @@
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
     "snapshotId": "00000000-0000-4000-8000-000000000001",
-    "schemaVersion": "1.9.0",
+    "schemaVersion": "1.10.0",
     "dembrandtVersion": "0.17.0",
     "viewport": { "width": 1920, "height": 1080 },
     "fontsReady": true


### PR DESCRIPTION
extractors/colors.ts computes contrast pairs and per-color candidate metadata separately with no link between them, so a palette entry carried usage count and context score but nothing about what it's actually readable against on the page.

Added bindContrastToPalette: with --wcag on, each palette entry gains contrastAgainst, the pairs it was observed in, deduped by the other color, sorted by ratio, capped at ten. Bumped the schema from 1.9.0 to 1.10.0 since it's additive but genuinely worth reading, not just noise a consumer can ignore.

Verified against stripe.com live: 18 of 34 palette colors picked up contrastAgainst. Full test suite green.