### PR TITLE
fix(colors): sync page-context deltaE constant with lib/colors.ts (DEM-211)

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -451,10 +451,7 @@ export async function extractColors(page) {
         };
       }
       function xyzToLab(x, y, z) {
-        // Same threshold constant as lib/colors.ts's xyzToLab (DEM-211): the
-        // exact CIE formula is (903.3*t+16)/116, not the 7.787 rounding this
-        // used to carry, which put this copy ~0.00007 off per channel from
-        // the canonical implementation on any pre-threshold Lab value.
+        // Exact CIE threshold constant, matching lib/colors.ts (DEM-211).
         x = x / 95.047; y = y / 100.000; z = z / 108.883;
         const f = (t) => t > 0.008856 ? Math.cbrt(t) : (903.3 * t + 16) / 116;
         const fx = f(x), fy = f(y), fz = f(z);

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -451,7 +451,7 @@ export async function extractColors(page) {
         };
       }
       function xyzToLab(x, y, z) {
-        // Exact CIE threshold constant, matching lib/colors.ts (DEM-211).
+        // Exact CIE threshold constant, matching lib/colors.ts.
         x = x / 95.047; y = y / 100.000; z = z / 108.883;
         const f = (t) => t > 0.008856 ? Math.cbrt(t) : (903.3 * t + 16) / 116;
         const fx = f(x), fy = f(y), fz = f(z);

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -451,10 +451,13 @@ export async function extractColors(page) {
         };
       }
       function xyzToLab(x, y, z) {
+        // Same threshold constant as lib/colors.ts's xyzToLab (DEM-211): the
+        // exact CIE formula is (903.3*t+16)/116, not the 7.787 rounding this
+        // used to carry, which put this copy ~0.00007 off per channel from
+        // the canonical implementation on any pre-threshold Lab value.
         x = x / 95.047; y = y / 100.000; z = z / 108.883;
-        const fx = x > 0.008856 ? Math.pow(x, 1/3) : (7.787 * x + 16/116);
-        const fy = y > 0.008856 ? Math.pow(y, 1/3) : (7.787 * y + 16/116);
-        const fz = z > 0.008856 ? Math.pow(z, 1/3) : (7.787 * z + 16/116);
+        const f = (t) => t > 0.008856 ? Math.cbrt(t) : (903.3 * t + 16) / 116;
+        const fx = f(x), fy = f(y), fz = f(z);
         return { L: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
       }
       const rgb1Obj = hexToRgb(rgb1);

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -159,7 +159,6 @@ test('bindContrastToPalette leaves candidates untouched when wcag is empty, and 
   assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
 });
 
-// DEM-211: guards the page-context deltaE against drifting from lib/colors.ts again.
 function extractFunctionSource(source: string, name: string): string {
   const marker = `function ${name}(`;
   const start = source.indexOf(marker);
@@ -176,7 +175,7 @@ function extractFunctionSource(source: string, name: string): string {
   throw new Error(`unbalanced braces extracting ${name}`);
 }
 
-test('the page-context deltaE (DEM-211) numerically matches lib/colors.ts deltaE', () => {
+test('the page-context deltaE numerically matches lib/colors.ts deltaE', () => {
   const src = extractFunctionSource(extractColors.toString(), 'deltaE');
   const inlineDeltaE: (a: string, b: string) => number = new Function(`${src}\nreturn deltaE;`)();
   const pairs: [string, string][] = [

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { hexToRgb, relativeLuminance, computeWcag, convertColor, deltaE, deltaE2000 } from '../lib/colors.js';
-import { capConfidenceByUsage, bindContrastToPalette } from '../lib/extractors/colors.js';
+import { capConfidenceByUsage, bindContrastToPalette, extractColors } from '../lib/extractors/colors.js';
 
 test('hexToRgb parses 6, 3, and 8 digit hex', () => {
   assert.deepEqual(hexToRgb('#ff0000'), { r: 255, g: 0, b: 0 });
@@ -157,4 +157,46 @@ test('bindContrastToPalette leaves candidates untouched when wcag is empty, and 
   assert.equal(palette[0].contrastAgainst, undefined);
   assert.deepEqual(bindContrastToPalette(null, [{ fg: '#111111', bg: '#fff' }]), null);
   assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
+});
+
+// DEM-211: three CIE76 implementations existed (lib/colors.ts, lib/drift.ts,
+// and this page-context copy) and quietly disagreed. drift.ts now imports
+// rgbToLab from lib/colors.ts directly, so only the page-context copy —
+// which can't import anything, since it runs inside page.evaluate() — is
+// still a hand-duplicated twin. This pulls that twin's source out of
+// extractColors.toString() and evals it, so any future edit to lib/colors.ts's
+// Lab maths that isn't mirrored here fails a test instead of silently
+// reintroducing the disagreement.
+function extractFunctionSource(source: string, name: string): string {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  assert.ok(start !== -1, `function ${name} not found in source`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces extracting ${name}`);
+}
+
+test('the page-context deltaE (DEM-211) numerically matches lib/colors.ts deltaE', () => {
+  const src = extractFunctionSource(extractColors.toString(), 'deltaE');
+  const inlineDeltaE: (a: string, b: string) => number = new Function(`${src}\nreturn deltaE;`)();
+  const pairs: [string, string][] = [
+    ['#ff0000', '#00ff00'],
+    ['#1a2b3c', '#1a2b3d'],
+    ['#000000', '#ffffff'],
+    ['#336699', '#996633'],
+    ['#010101', '#020202'], // exercises the below-threshold branch of f(t)
+  ];
+  for (const [a, b] of pairs) {
+    assert.ok(
+      Math.abs(inlineDeltaE(a, b) - deltaE(a, b)) < 1e-9,
+      `deltaE(${a}, ${b}): inline=${inlineDeltaE(a, b)} canonical=${deltaE(a, b)}`,
+    );
+  }
 });

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -159,14 +159,7 @@ test('bindContrastToPalette leaves candidates untouched when wcag is empty, and 
   assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
 });
 
-// DEM-211: three CIE76 implementations existed (lib/colors.ts, lib/drift.ts,
-// and this page-context copy) and quietly disagreed. drift.ts now imports
-// rgbToLab from lib/colors.ts directly, so only the page-context copy —
-// which can't import anything, since it runs inside page.evaluate() — is
-// still a hand-duplicated twin. This pulls that twin's source out of
-// extractColors.toString() and evals it, so any future edit to lib/colors.ts's
-// Lab maths that isn't mirrored here fails a test instead of silently
-// reintroducing the disagreement.
+// DEM-211: guards the page-context deltaE against drifting from lib/colors.ts again.
 function extractFunctionSource(source: string, name: string): string {
   const marker = `function ${name}(`;
   const start = source.indexOf(marker);


### PR DESCRIPTION
Three CIE76 implementations lived in the tree and quietly disagreed with each other. drift.ts already imports rgbToLab from lib/colors.ts so that half is fixed, which leaves the copy hand-inlined inside extractColors, because it runs inside page.evaluate() and can't import anything.

That copy was carrying a rounded 7.787 threshold constant instead of the exact CIE formula lib/colors.ts uses, putting it about 0.00007 off per channel. Fixed the constant and added a test that pulls the inline function's source out of extractColors.toString() and evals it against known color pairs, so a future edit to the canonical Lab maths that isn't mirrored here fails a test instead of drifting again silently.

release:churn shows zero churn on dembrandt.com and stripe.com. CIEDE2000 is a separate, deliberately different metric and isn't touched here.

The failure-convention mismatch (999 vs 100 vs Infinity) is still open and moves numbers, so it probably deserves its own release rather than riding along with this one.