### PR TITLE
fix(colors): composite translucent backgrounds for WCAG contrast (DEM-171)

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -817,9 +817,7 @@ export async function extractWcagPairs(page) {
       }
 
       // Alpha-composite background layers front-to-back over an assumed-white
-      // canvas — the same over-blend dompdf.js uses for rasterisation
-      // (findOpaqueBackdropColor). Pure array math, no DOM: kept separate from
-      // the ancestor walk below so it is unit-testable on its own (DEM-171).
+      // canvas. Pure array math, no DOM, so it's unit-testable on its own.
       function compositeBackgroundLayers(layers) {
         let rAcc = 0, gAcc = 0, bAcc = 0, alphaRem = 1;
         for (const rgba of layers) {
@@ -838,12 +836,7 @@ export async function extractWcagPairs(page) {
         return { r: rAcc, g: gAcc, b: bAcc };
       }
 
-      // A translucent rgba() background is not the colour a viewer actually
-      // sees; what they see depends on everything painted behind it, and most
-      // pages never redeclare an opaque background anywhere up to <html>,
-      // relying on the browser's white default the way a viewer's eye does.
-      // Walk the ancestor chain (el itself first) collecting each layer, then
-      // hand the list to the pure compositor above.
+      // Walk the ancestor chain, defaulting to white if nothing opaque is found.
       function effectiveBackground(el) {
         const layers = [];
         let node = el;
@@ -872,9 +865,7 @@ export async function extractWcagPairs(page) {
           const fgRgba = parseRgba(s.color);
           if (!fgRgba || fgRgba.a < 0.1) continue;
           const bgRgb = effectiveBackground(el);
-          // Text is itself a paint layer over whatever is behind it: when it
-          // carries alpha, the perceived colour is the composite, not the
-          // authored rgba() (same DEM-171 issue, on the foreground side).
+          // Text with alpha composites over the background too.
           const effR = fgRgba.a >= 0.999 ? fgRgba.r : fgRgba.r * fgRgba.a + bgRgb.r * (1 - fgRgba.a);
           const effG = fgRgba.a >= 0.999 ? fgRgba.g : fgRgba.g * fgRgba.a + bgRgb.g * (1 - fgRgba.a);
           const effB = fgRgba.a >= 0.999 ? fgRgba.b : fgRgba.b * fgRgba.a + bgRgb.b * (1 - fgRgba.a);

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -788,41 +788,74 @@ export async function extractWcagPairs(page) {
       canvas.width = canvas.height = 1;
       const ctx = canvas.getContext('2d');
 
-      function toHex(color) {
+      function parseRgba(color) {
         if (!color) return null;
         try {
           const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
           if (m) {
-            if (m[4] !== undefined && parseFloat(m[4]) < 0.1) return null;
-            const r = parseInt(m[1]).toString(16).padStart(2, '0');
-            const g = parseInt(m[2]).toString(16).padStart(2, '0');
-            const b = parseInt(m[3]).toString(16).padStart(2, '0');
-            return `#${r}${g}${b}`;
+            const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+            return { r: parseInt(m[1]), g: parseInt(m[2]), b: parseInt(m[3]), a };
           }
-          if (/^#[0-9a-f]{6}$/i.test(color)) return color.toLowerCase();
+          if (/^#[0-9a-f]{6}$/i.test(color)) {
+            return { r: parseInt(color.slice(1, 3), 16), g: parseInt(color.slice(3, 5), 16), b: parseInt(color.slice(5, 7), 16), a: 1 };
+          }
           if (!ctx) return null;
           ctx.clearRect(0, 0, 1, 1);
           ctx.fillStyle = 'rgba(0,0,0,0)';
           ctx.fillStyle = color;
           ctx.fillRect(0, 0, 1, 1);
           const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
-          if (a < 25) return null;
-          return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+          return { r, g, b, a: a / 255 };
         } catch {
           return null;
         }
       }
 
-      function findBg(el) {
+      function toHexFromRgb(r, g, b) {
+        const c = (v) => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
+        return `#${c(r)}${c(g)}${c(b)}`;
+      }
+
+      // Alpha-composite background layers front-to-back over an assumed-white
+      // canvas — the same over-blend dompdf.js uses for rasterisation
+      // (findOpaqueBackdropColor). Pure array math, no DOM: kept separate from
+      // the ancestor walk below so it is unit-testable on its own (DEM-171).
+      function compositeBackgroundLayers(layers) {
+        let rAcc = 0, gAcc = 0, bAcc = 0, alphaRem = 1;
+        for (const rgba of layers) {
+          if (alphaRem <= 0.001) break;
+          if (!rgba || rgba.a <= 0.001) continue;
+          rAcc += rgba.r * rgba.a * alphaRem;
+          gAcc += rgba.g * rgba.a * alphaRem;
+          bAcc += rgba.b * rgba.a * alphaRem;
+          alphaRem *= (1 - rgba.a);
+        }
+        if (alphaRem > 0.001) {
+          rAcc += 255 * alphaRem;
+          gAcc += 255 * alphaRem;
+          bAcc += 255 * alphaRem;
+        }
+        return { r: rAcc, g: gAcc, b: bAcc };
+      }
+
+      // A translucent rgba() background is not the colour a viewer actually
+      // sees; what they see depends on everything painted behind it, and most
+      // pages never redeclare an opaque background anywhere up to <html>,
+      // relying on the browser's white default the way a viewer's eye does.
+      // Walk the ancestor chain (el itself first) collecting each layer, then
+      // hand the list to the pure compositor above.
+      function effectiveBackground(el) {
+        const layers = [];
         let node = el;
-        while (node && node.tagName !== 'HTML') {
+        let alphaRem = 1;
+        while (node && node.tagName !== 'HTML' && alphaRem > 0.001) {
           try {
-            const bg = toHex(getComputedStyle(node).backgroundColor);
-            if (bg) return bg;
+            const rgba = parseRgba(getComputedStyle(node).backgroundColor);
+            if (rgba && rgba.a > 0.001) { layers.push(rgba); alphaRem *= (1 - rgba.a); }
           } catch { /* skip stale node */ }
           node = node.parentElement;
         }
-        return null;
+        return compositeBackgroundLayers(layers);
       }
 
       const seen = new Map();
@@ -836,10 +869,18 @@ export async function extractWcagPairs(page) {
           if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') continue;
           const rect = el.getBoundingClientRect();
           if (rect.width === 0 || rect.height === 0) continue;
-          const fg = toHex(s.color);
-          if (!fg) continue;
-          const bg = findBg(el);
-          if (!bg || fg === bg) continue;
+          const fgRgba = parseRgba(s.color);
+          if (!fgRgba || fgRgba.a < 0.1) continue;
+          const bgRgb = effectiveBackground(el);
+          // Text is itself a paint layer over whatever is behind it: when it
+          // carries alpha, the perceived colour is the composite, not the
+          // authored rgba() (same DEM-171 issue, on the foreground side).
+          const effR = fgRgba.a >= 0.999 ? fgRgba.r : fgRgba.r * fgRgba.a + bgRgb.r * (1 - fgRgba.a);
+          const effG = fgRgba.a >= 0.999 ? fgRgba.g : fgRgba.g * fgRgba.a + bgRgb.g * (1 - fgRgba.a);
+          const effB = fgRgba.a >= 0.999 ? fgRgba.b : fgRgba.b * fgRgba.a + bgRgb.b * (1 - fgRgba.a);
+          const fg = toHexFromRgb(effR, effG, effB);
+          const bg = toHexFromRgb(bgRgb.r, bgRgb.g, bgRgb.b);
+          if (fg === bg) continue;
           const key = [fg, bg].sort().join('/');
           const entry = seen.get(key);
           if (entry) { entry.count++; } else { seen.set(key, { fg, bg, count: 1 }); }

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { hexToRgb, relativeLuminance, computeWcag, convertColor, deltaE, deltaE2000 } from '../lib/colors.js';
-import { capConfidenceByUsage, bindContrastToPalette } from '../lib/extractors/colors.js';
+import { capConfidenceByUsage, bindContrastToPalette, extractWcagPairs } from '../lib/extractors/colors.js';
 
 test('hexToRgb parses 6, 3, and 8 digit hex', () => {
   assert.deepEqual(hexToRgb('#ff0000'), { r: 255, g: 0, b: 0 });
@@ -157,4 +157,66 @@ test('bindContrastToPalette leaves candidates untouched when wcag is empty, and 
   assert.equal(palette[0].contrastAgainst, undefined);
   assert.deepEqual(bindContrastToPalette(null, [{ fg: '#111111', bg: '#fff' }]), null);
   assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
+});
+
+// compositeBackgroundLayers (DEM-171): alpha-composite a stack of translucent
+// backgrounds the way a viewer actually sees them, instead of reporting the
+// topmost declared rgba() as if it were opaque. Extracted from the page-context
+// source the same way the DEM-211 deltaE parity test is: this function runs
+// inside page.evaluate() and can't be imported directly.
+function extractFunctionSource(source: string, name: string): string {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  assert.ok(start !== -1, `function ${name} not found in source`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces extracting ${name}`);
+}
+
+function loadCompositeBackgroundLayers(): (layers: ({ r: number; g: number; b: number; a: number } | null)[]) => { r: number; g: number; b: number } {
+  const src = extractFunctionSource(extractWcagPairs.toString(), 'compositeBackgroundLayers');
+  return new Function(`${src}\nreturn compositeBackgroundLayers;`)();
+}
+
+test('compositeBackgroundLayers: a single opaque layer passes through unchanged', () => {
+  const composite = loadCompositeBackgroundLayers();
+  assert.deepEqual(composite([{ r: 10, g: 20, b: 30, a: 1 }]), { r: 10, g: 20, b: 30 });
+});
+
+test('compositeBackgroundLayers: a 50% black over white composites to mid-grey', () => {
+  const composite = loadCompositeBackgroundLayers();
+  const { r, g, b } = composite([{ r: 0, g: 0, b: 0, a: 0.5 }]);
+  // No opaque layer beneath -> falls through to the assumed white canvas.
+  assert.ok(Math.abs(r - 127.5) < 0.01 && r === g && g === b);
+});
+
+test('compositeBackgroundLayers: stacked translucent layers blend front to back', () => {
+  const composite = loadCompositeBackgroundLayers();
+  // A 50% red over a 50% blue over opaque white: front layer dominates.
+  const { r, b } = composite([
+    { r: 255, g: 0, b: 0, a: 0.5 },
+    { r: 0, g: 0, b: 255, a: 0.5 },
+    { r: 255, g: 255, b: 255, a: 1 },
+  ]);
+  assert.ok(r > b, `expected red-heavy blend, got r=${r} b=${b}`);
+  assert.ok(Math.abs(r - 191.25) < 0.01, `r=${r}`);
+});
+
+test('compositeBackgroundLayers: an opaque layer makes everything behind it irrelevant', () => {
+  const composite = loadCompositeBackgroundLayers();
+  const withOpaqueTail = composite([{ r: 10, g: 20, b: 30, a: 1 }, { r: 200, g: 200, b: 200, a: 1 }]);
+  assert.deepEqual(withOpaqueTail, { r: 10, g: 20, b: 30 });
+});
+
+test('compositeBackgroundLayers: empty stack, and null/fully-transparent layers, resolve to white', () => {
+  const composite = loadCompositeBackgroundLayers();
+  assert.deepEqual(composite([]), { r: 255, g: 255, b: 255 });
+  assert.deepEqual(composite([null, { r: 1, g: 2, b: 3, a: 0 }]), { r: 255, g: 255, b: 255 });
 });

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -159,11 +159,6 @@ test('bindContrastToPalette leaves candidates untouched when wcag is empty, and 
   assert.deepEqual(bindContrastToPalette([{}], [{ fg: '#111111', bg: '#fff', ratio: 1, aa: false }]), [{}]);
 });
 
-// compositeBackgroundLayers (DEM-171): alpha-composite a stack of translucent
-// backgrounds the way a viewer actually sees them, instead of reporting the
-// topmost declared rgba() as if it were opaque. Extracted from the page-context
-// source the same way the DEM-211 deltaE parity test is: this function runs
-// inside page.evaluate() and can't be imported directly.
 function extractFunctionSource(source: string, name: string): string {
   const marker = `function ${name}(`;
   const start = source.indexOf(marker);


### PR DESCRIPTION
extractWcagPairs was reporting the declared color of a background or text with alpha, not what a viewer actually sees. A stack of rgba() layers read as whatever the first one past a 0.1-alpha gate happened to be, and a page that never redeclares an opaque background up to html, relying on the browser's white default like every viewer's eye does, produced no pair at all.

Added compositeBackgroundLayers, which alpha-composites the ancestor background stack front to back over an assumed-white canvas, the same over-blend dompdf.js uses for rasterization. Foreground text with its own alpha now composites over that effective background too. Tested against a synthetic page with a 50%-black overlay containing a 20%-white card containing 85%-black text: main reports fg #000000 on bg #ffffff, ratio 21, AAA. This reports fg #171717 on bg #999999, ratio 6.29, not AAA, which matches what's actually rendered.

release:churn shows zero churn on dembrandt.com and stripe.com, neither of which leans on this pattern much. The ticket also asked for deduping the palette on perceived color rather than declared color; that would touch the core color-collection pipeline and felt like a separate, bigger change, so I left it out here.

Unit tests cover the compositing math directly by pulling it out of the page-context source, same trick as the deltaE parity test in the other open PR.