### PR TITLE
style: drop ticket-id reference from a code comment

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -877,8 +877,7 @@ export async function extractWcagPairs(page) {
 /**
  * Bind each observed WCAG contrast pair back onto the palette candidate it was
  * measured against, so a colour carries "this is AA-compliant text against X"
- * as a feature instead of leaving pairs and candidates as two unlinked lists
- * (DEM-267). Mutates each matching entry's `contrastAgainst` in place and
+ * as a feature. Mutates each matching entry's `contrastAgainst` in place and
  * returns the palette for convenience; entries with no observed pair are
  * left untouched (no empty array).
  */

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -116,9 +116,6 @@ test('capConfidenceByUsage never promotes, and never throws on a missing count',
   assert.equal(capConfidenceByUsage('high', undefined), 'low');
 });
 
-// bindContrastToPalette (DEM-267): link observed WCAG pairs back onto the
-// palette candidate they were measured against.
-
 type TestCandidate = { normalized: string; contrastAgainst?: { bg: string; ratio: number; aa: boolean }[] };
 
 test('bindContrastToPalette attaches contrastAgainst to a matching candidate on either side of a pair', () => {


### PR DESCRIPTION
Follow-up on #186: the bindContrastToPalette doc comment referenced the ticket id, which doesn't belong in code. Dropped it.