### PR TITLE
test: close unit-test gaps on pagesRequested and hasRenderedContent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { generateTailwindTheme } from "./lib/formatters/tailwind.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
 import { resolveCompare } from "./lib/compare.js";
 import { emitDriftAnnotations } from "./lib/ci-annotations.js";
-import { parseSitemap } from "./lib/discovery.js";
+import { parseSitemap, computePagesRequested } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
@@ -301,7 +301,11 @@ program
               spinner.warn("No additional pages discovered");
             }
             if (crawlTechnique && result.meta) {
-              result.meta.crawl = { technique: crawlTechnique, pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null), pagesFound: 1 };
+              result.meta.crawl = {
+                technique: crawlTechnique,
+                pagesRequested: computePagesRequested({ hasExplicitPaths, explicitPathCount: paths?.length || 0, isSitemap: !!opts.sitemap, sitemapMax, crawlN }),
+                pagesFound: 1,
+              };
             }
           } else {
             spinner.stop();
@@ -350,7 +354,7 @@ program
             if (crawlTechnique && result.meta) {
               result.meta.crawl = {
                 technique: crawlTechnique,
-                pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null),
+                pagesRequested: computePagesRequested({ hasExplicitPaths, explicitPathCount: paths?.length || 0, isSitemap: !!opts.sitemap, sitemapMax, crawlN }),
                 pagesFound,
               };
             }

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -245,3 +245,22 @@ export async function parseSitemap(baseUrl, maxPages) {
 
   return scored.slice(0, maxPages).map(l => l.href);
 }
+
+/**
+ * How many pages a multi-page run asked for, for meta.crawl.pagesRequested.
+ * `sitemapMax` is the resolved cap passed to parseSitemap (crawlN - 1, or the
+ * 20-page default when no --crawl N is given) — pagesRequested must read that
+ * resolved cap, not crawlN directly, or the default-sitemap case reports null
+ * instead of 21.
+ */
+export function computePagesRequested(opts: {
+  hasExplicitPaths: boolean;
+  explicitPathCount: number;
+  isSitemap: boolean;
+  sitemapMax: number | null;
+  crawlN: number | null;
+}): number | null {
+  if (opts.hasExplicitPaths) return opts.explicitPathCount + 1;
+  if (opts.isSitemap) return opts.sitemapMax !== null ? opts.sitemapMax + 1 : null;
+  return opts.crawlN || null;
+}

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { computePagesRequested } from '../lib/discovery.js';
+
+test('computePagesRequested: explicit paths count the homepage plus each path', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: true, explicitPathCount: 3, isSitemap: false, sitemapMax: null, crawlN: null }),
+    4,
+  );
+});
+
+test('computePagesRequested: sitemap without --crawl reports the 20-page default plus the homepage', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: true, sitemapMax: 20, crawlN: null }),
+    21,
+  );
+});
+
+test('computePagesRequested: sitemap combined with --crawl N reports sitemapMax + 1, not crawlN', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: true, sitemapMax: 4, crawlN: 5 }),
+    5,
+  );
+});
+
+test('computePagesRequested: auto-crawl reports crawlN directly', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: false, sitemapMax: null, crawlN: 5 }),
+    5,
+  );
+});
+
+test('computePagesRequested: no technique matched falls back to null', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: false, sitemapMax: null, crawlN: null }),
+    null,
+  );
+});

--- a/test/extractors-index.test.ts
+++ b/test/extractors-index.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extractBranding } from '../lib/extractors/index.js';
+
+function extractConstArrowSource(source: string, name: string): string {
+  const marker = `const ${name} = () =>`;
+  const start = source.indexOf(marker);
+  assert.ok(start !== -1, `const ${name} not found in source`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) { i++; break; }
+    }
+  }
+  while (source[i] !== ';') i++;
+  return source.slice(start, i + 1);
+}
+
+type MockStyle = { visibility?: string; display?: string; opacity?: string };
+type MockEl = { tagName: string; style?: MockStyle; getBoundingClientRect: () => { width: number; height: number } };
+
+function loadHasRenderedContent(elements: MockEl[]) {
+  const src = extractConstArrowSource(extractBranding.toString(), 'hasRenderedContent');
+  const mockDocument = {
+    body: {
+      querySelectorAll: () => elements,
+    },
+  };
+  const mockGetComputedStyle = (el: MockEl) => ({
+    visibility: el.style?.visibility ?? 'visible',
+    display: el.style?.display ?? 'block',
+    opacity: el.style?.opacity ?? '1',
+  });
+  const factory = new Function(
+    'document',
+    'getComputedStyle',
+    `${src}\nreturn hasRenderedContent;`,
+  );
+  return factory(
+    mockDocument,
+    mockGetComputedStyle,
+  ) as () => boolean;
+}
+
+function el(tagName: string, width: number, height: number, style?: MockStyle): MockEl {
+  return { tagName, style, getBoundingClientRect: () => ({ width, height }) };
+}
+
+test('hasRenderedContent: a sizable, visible, non-script element counts as rendered', () => {
+  assert.equal(loadHasRenderedContent([el('DIV', 400, 300)])(), true);
+});
+
+test('hasRenderedContent: script/style/link/meta tags never count, even if sizable', () => {
+  const els = [el('SCRIPT', 800, 600), el('STYLE', 800, 600), el('LINK', 800, 600), el('META', 800, 600)];
+  assert.equal(loadHasRenderedContent(els)(), false);
+});
+
+test('hasRenderedContent: elements below the size floor do not count', () => {
+  assert.equal(loadHasRenderedContent([el('DIV', 200, 100), el('SPAN', 50, 50)])(), false);
+});
+
+test('hasRenderedContent: a hidden or collapsed element does not count', () => {
+  const hidden = el('DIV', 400, 300, { visibility: 'hidden' });
+  const none = el('DIV', 400, 300, { display: 'none' });
+  const transparent = el('DIV', 400, 300, { opacity: '0' });
+  for (const e of [hidden, none, transparent]) {
+    assert.equal(loadHasRenderedContent([e])(), false);
+  }
+});
+
+test('hasRenderedContent: an empty page reports no rendered content', () => {
+  assert.equal(loadHasRenderedContent([])(), false);
+});


### PR DESCRIPTION
Both landed as bug fixes earlier today with no regression test. index.ts exports nothing, so nothing could import the pagesRequested logic to test it directly, and hasRenderedContent lives inside a page.evaluate-style closure inside extractBranding.

Pulled pagesRequested out into computePagesRequested in lib/discovery.ts, a plain function index.ts now calls instead of carrying the same ternary twice. hasRenderedContent gets tested the same way the deltaE and background-compositing fixes did earlier: pull its source out of extractBranding.toString() and eval it against a small mock DOM.

Went through the diff since 0.30.0 looking for any leftover any casts or untested logic before considering the branch release-ready. Full suite green, lint clean.