### PR TITLE
feat: check robots.txt for crawled pages and in the MCP server

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { checkRobotsTxt } from "./lib/robots.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
@@ -147,9 +147,11 @@ program
 
     const spinner = ora({ text: "Starting extraction...", ...spinnerOptions(opts.jsonOnly) }).start();
 
+    let entryRobotsWarning = null;
     try {
       const robots = await checkRobotsTxt(url);
       if (robots.status === "ok" && robots.allowed === false) {
+        entryRobotsWarning = `robots.txt disallows ${url} (rule: "${robots.rule}")`;
         spinner.warn(
           chalk.hex("#FFB86C")(
             `robots.txt disallows this path (rule: "${robots.rule}"). Proceeding anyway — respect the site's terms.`
@@ -269,6 +271,10 @@ program
             _version: version,
           });
 
+          if (entryRobotsWarning && result.meta) {
+            result.meta.robotsWarnings = [entryRobotsWarning];
+          }
+
           // Build list of additional URLs to extract
           let additionalUrls = [];
           let sitemapMax = null;
@@ -293,6 +299,28 @@ program
           }
 
           delete result._discoveredLinks;
+
+          if (additionalUrls.length > 0) {
+            const robotsRules = await fetchRobotsRules(result.url);
+            const { allowed, disallowed } = filterAllowedUrls(additionalUrls, robotsRules);
+            if (disallowed.length > 0) {
+              if (!opts.jsonOnly) {
+                spinner.warn(
+                  chalk.hex("#FFB86C")(
+                    `robots.txt disallows ${disallowed.length} discovered page(s), skipping: ${disallowed.map(d => d.url).join(', ')}`
+                  )
+                );
+                spinner.start("Continuing...");
+              }
+              additionalUrls = allowed;
+              if (result.meta) {
+                result.meta.robotsWarnings = [
+                  ...(result.meta.robotsWarnings || []),
+                  `robots.txt disallowed ${disallowed.length} discovered page(s): ${disallowed.map(d => d.url).join(', ')}`,
+                ];
+              }
+            }
+          }
 
           const crawlTechnique = hasExplicitPaths ? 'explicit-paths' : opts.sitemap ? 'sitemap' : isAutoCrawl ? 'auto' : null;
 

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { generateTailwindTheme } from "./lib/formatters/tailwind.js";
 import { generateHtmlReport } from "./lib/formatters/html.js";
 import { resolveCompare } from "./lib/compare.js";
 import { emitDriftAnnotations } from "./lib/ci-annotations.js";
-import { parseSitemap } from "./lib/discovery.js";
+import { parseSitemap, computePagesRequested } from "./lib/discovery.js";
 import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
@@ -301,7 +301,11 @@ program
               spinner.warn("No additional pages discovered");
             }
             if (crawlTechnique && result.meta) {
-              result.meta.crawl = { technique: crawlTechnique, pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null), pagesFound: 1 };
+              result.meta.crawl = {
+                technique: crawlTechnique,
+                pagesRequested: computePagesRequested({ hasExplicitPaths, explicitPathCount: paths?.length || 0, isSitemap: !!opts.sitemap, sitemapMax, crawlN }),
+                pagesFound: 1,
+              };
             }
           } else {
             spinner.stop();
@@ -350,7 +354,7 @@ program
             if (crawlTechnique && result.meta) {
               result.meta.crawl = {
                 technique: crawlTechnique,
-                pagesRequested: hasExplicitPaths ? paths.length + 1 : opts.sitemap ? sitemapMax + 1 : (crawlN || null),
+                pagesRequested: computePagesRequested({ hasExplicitPaths, explicitPathCount: paths?.length || 0, isSitemap: !!opts.sitemap, sitemapMax, crawlN }),
                 pagesFound,
               };
             }

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -245,3 +245,22 @@ export async function parseSitemap(baseUrl, maxPages) {
 
   return scored.slice(0, maxPages).map(l => l.href);
 }
+
+/**
+ * How many pages a multi-page run asked for, for meta.crawl.pagesRequested.
+ * `sitemapMax` is the resolved cap passed to parseSitemap (crawlN - 1, or the
+ * 20-page default when no --crawl N is given) — pagesRequested must read that
+ * resolved cap, not crawlN directly, or the default-sitemap case reports null
+ * instead of 21.
+ */
+export function computePagesRequested(opts: {
+  hasExplicitPaths: boolean;
+  explicitPathCount: number;
+  isSitemap: boolean;
+  sitemapMax: number | null;
+  crawlN: number | null;
+}): number | null {
+  if (opts.hasExplicitPaths) return opts.explicitPathCount + 1;
+  if (opts.isSitemap) return opts.sitemapMax !== null ? opts.sitemapMax + 1 : null;
+  return opts.crawlN || null;
+}

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -14,13 +14,20 @@ export type RobotsResult =
   | { status: "unavailable"; robotsUrl: string }
   | { status: "ok"; robotsUrl: string; allowed: boolean; rule: string | null };
 
-export async function checkRobotsTxt(
+export type RobotsRules =
+  | { status: "unavailable" }
+  | { status: "ok"; robotsUrl: string; rules: RobotsRule[] };
+
+/**
+ * Fetch and parse robots.txt for the target's origin once, so a multi-page
+ * crawl can check every discovered URL against it without one request per page.
+ */
+export async function fetchRobotsRules(
   targetUrl: string,
   { timeoutMs = 5000 }: { timeoutMs?: number } = {},
-): Promise<RobotsResult> {
+): Promise<RobotsRules> {
   const u = new URL(targetUrl);
   const robotsUrl = `${u.protocol}//${u.host}/robots.txt`;
-  const path = u.pathname || "/";
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -31,19 +38,60 @@ export async function checkRobotsTxt(
       signal: controller.signal,
       headers: { "User-Agent": UA },
     });
-    if (!res.ok) return { status: "unavailable", robotsUrl };
+    if (!res.ok) return { status: "unavailable" };
     body = await res.text();
   } catch {
-    return { status: "unavailable", robotsUrl };
+    return { status: "unavailable" };
   } finally {
     clearTimeout(timer);
   }
 
   const groups = parseRobots(body);
   const rules = matchGroup(groups, UA) || matchGroup(groups, "*") || [];
-  const decision = evaluate(rules, path);
+  return { status: "ok", robotsUrl, rules };
+}
 
-  return { status: "ok", robotsUrl, ...decision };
+export function evaluatePath(rules: RobotsRule[], path: string): { allowed: boolean; rule: string | null } {
+  return evaluate(rules, path);
+}
+
+export async function checkRobotsTxt(
+  targetUrl: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<RobotsResult> {
+  const u = new URL(targetUrl);
+  const rules = await fetchRobotsRules(targetUrl, opts);
+  if (rules.status === "unavailable") {
+    return { status: "unavailable", robotsUrl: `${u.protocol}//${u.host}/robots.txt` };
+  }
+  return { status: "ok", robotsUrl: rules.robotsUrl, ...evaluatePath(rules.rules, u.pathname || "/") };
+}
+
+/**
+ * Split discovered crawl URLs into those robots.txt allows and those it
+ * doesn't, using an already-fetched rule set. Unavailable robots.txt allows
+ * everything through, matching checkRobotsTxt's fail-open behaviour.
+ */
+export function filterAllowedUrls(
+  urls: string[],
+  robotsRules: RobotsRules,
+): { allowed: string[]; disallowed: { url: string; rule: string | null }[] } {
+  if (robotsRules.status !== "ok") return { allowed: urls, disallowed: [] };
+  const allowed: string[] = [];
+  const disallowed: { url: string; rule: string | null }[] = [];
+  for (const url of urls) {
+    let path = "/";
+    try {
+      path = new URL(url).pathname || "/";
+    } catch {
+      allowed.push(url);
+      continue;
+    }
+    const decision = evaluatePath(robotsRules.rules, path);
+    if (decision.allowed) allowed.push(url);
+    else disallowed.push({ url, rule: decision.rule });
+  }
+  return { allowed, disallowed };
 }
 
 function parseRobots(text: string): RobotsGroup[] {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -381,6 +381,12 @@ export interface ExtractionMeta {
    * an empty value, so a single broken extractor never aborts the whole run.
    */
   errors?: ExtractorError[];
+  /**
+   * Human-readable notes on pages robots.txt disallowed but the run still
+   * touched or skipped. The check is advisory: it never blocks extraction,
+   * so this is the only record of what it flagged.
+   */
+  robotsWarnings?: string[];
 }
 
 /** A single fault-isolated extractor failure. */

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -39,6 +39,12 @@
  *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in flag
  *          and deliberately do not bump the contract. Bump when the flag is
  *          documented, not before.
+ *  1.11.0 — meta gains robotsWarnings: human-readable notes on pages robots.txt
+ *          disallowed, whether that was the entry URL or a page discovered
+ *          during --crawl/--sitemap/MCP pages. The check stays advisory (it
+ *          never blocks extraction), so this is the only record of what it
+ *          flagged. Additive: 1.10.x consumers ignore it. DRIFT: not read by
+ *          the drift engine.
  *  1.10.0 — colors.palette entries gain contrastAgainst: [{bg, ratio, aa}],
  *          the WCAG pairs (from `wcag`, --wcag only) this candidate was
  *          actually observed against on the page, sorted by ratio descending
@@ -119,7 +125,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.10.0';
+export const SCHEMA_VERSION = '1.11.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -23,6 +23,7 @@ import { mergeResults } from "./lib/merger.js";
 import { additionalPages, discoveryBudget, extractOptions, isMultiPage, launchArgs } from "./lib/mcp/options.js";
 import type { Extraction, ExtractionRequest } from "./lib/mcp/options.js";
 import { JobQueue, resolveExtraction } from "./lib/mcp/jobs.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls } from "./lib/robots.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -98,13 +99,32 @@ async function runExtraction(url: string, options: ExtractionRequest = {}) {
       discoverLinks: discoveryBudget(options),
     });
 
+    const entryRobots = await checkRobotsTxt(url).catch(() => null);
+    if (entryRobots?.status === "ok" && entryRobots.allowed === false && first.meta) {
+      first.meta.robotsWarnings = [`robots.txt disallows ${url} (rule: "${entryRobots.rule}")`];
+    }
+
     if (!isMultiPage(options)) {
       delete first._discoveredLinks;
       return { ok: true, data: first };
     }
 
-    const extraUrls = await additionalPages(first, url, options);
+    let extraUrls = await additionalPages(first, url, options);
     delete first._discoveredLinks;
+
+    if (extraUrls.length > 0) {
+      const robotsRules = await fetchRobotsRules(first.url);
+      const { allowed, disallowed } = filterAllowedUrls(extraUrls, robotsRules);
+      if (disallowed.length > 0) {
+        extraUrls = allowed;
+        if (first.meta) {
+          first.meta.robotsWarnings = [
+            ...(first.meta.robotsWarnings || []),
+            `robots.txt disallowed ${disallowed.length} discovered page(s): ${disallowed.map((d) => d.url).join(", ")}`,
+          ];
+        }
+      }
+    }
 
     const results = [first];
     for (const pageUrl of extraUrls) {

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { computePagesRequested } from '../lib/discovery.js';
+
+test('computePagesRequested: explicit paths count the homepage plus each path', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: true, explicitPathCount: 3, isSitemap: false, sitemapMax: null, crawlN: null }),
+    4,
+  );
+});
+
+test('computePagesRequested: sitemap without --crawl reports the 20-page default plus the homepage', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: true, sitemapMax: 20, crawlN: null }),
+    21,
+  );
+});
+
+test('computePagesRequested: sitemap combined with --crawl N reports sitemapMax + 1, not crawlN', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: true, sitemapMax: 4, crawlN: 5 }),
+    5,
+  );
+});
+
+test('computePagesRequested: auto-crawl reports crawlN directly', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: false, sitemapMax: null, crawlN: 5 }),
+    5,
+  );
+});
+
+test('computePagesRequested: no technique matched falls back to null', () => {
+  assert.equal(
+    computePagesRequested({ hasExplicitPaths: false, explicitPathCount: 0, isSitemap: false, sitemapMax: null, crawlN: null }),
+    null,
+  );
+});

--- a/test/extractors-index.test.ts
+++ b/test/extractors-index.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extractBranding } from '../lib/extractors/index.js';
+
+function extractConstArrowSource(source: string, name: string): string {
+  const marker = `const ${name} = () =>`;
+  const start = source.indexOf(marker);
+  assert.ok(start !== -1, `const ${name} not found in source`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) { i++; break; }
+    }
+  }
+  while (source[i] !== ';') i++;
+  return source.slice(start, i + 1);
+}
+
+type MockStyle = { visibility?: string; display?: string; opacity?: string };
+type MockEl = { tagName: string; style?: MockStyle; getBoundingClientRect: () => { width: number; height: number } };
+
+function loadHasRenderedContent(elements: MockEl[]) {
+  const src = extractConstArrowSource(extractBranding.toString(), 'hasRenderedContent');
+  const mockDocument = {
+    body: {
+      querySelectorAll: () => elements,
+    },
+  };
+  const mockGetComputedStyle = (el: MockEl) => ({
+    visibility: el.style?.visibility ?? 'visible',
+    display: el.style?.display ?? 'block',
+    opacity: el.style?.opacity ?? '1',
+  });
+  const factory = new Function(
+    'document',
+    'getComputedStyle',
+    `${src}\nreturn hasRenderedContent;`,
+  );
+  return factory(
+    mockDocument,
+    mockGetComputedStyle,
+  ) as () => boolean;
+}
+
+function el(tagName: string, width: number, height: number, style?: MockStyle): MockEl {
+  return { tagName, style, getBoundingClientRect: () => ({ width, height }) };
+}
+
+test('hasRenderedContent: a sizable, visible, non-script element counts as rendered', () => {
+  assert.equal(loadHasRenderedContent([el('DIV', 400, 300)])(), true);
+});
+
+test('hasRenderedContent: script/style/link/meta tags never count, even if sizable', () => {
+  const els = [el('SCRIPT', 800, 600), el('STYLE', 800, 600), el('LINK', 800, 600), el('META', 800, 600)];
+  assert.equal(loadHasRenderedContent(els)(), false);
+});
+
+test('hasRenderedContent: elements below the size floor do not count', () => {
+  assert.equal(loadHasRenderedContent([el('DIV', 200, 100), el('SPAN', 50, 50)])(), false);
+});
+
+test('hasRenderedContent: a hidden or collapsed element does not count', () => {
+  const hidden = el('DIV', 400, 300, { visibility: 'hidden' });
+  const none = el('DIV', 400, 300, { display: 'none' });
+  const transparent = el('DIV', 400, 300, { opacity: '0' });
+  for (const e of [hidden, none, transparent]) {
+    assert.equal(loadHasRenderedContent([e])(), false);
+  }
+});
+
+test('hasRenderedContent: an empty page reports no rendered content', () => {
+  assert.equal(loadHasRenderedContent([])(), false);
+});

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -3,7 +3,7 @@
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
     "snapshotId": "00000000-0000-4000-8000-000000000001",
-    "schemaVersion": "1.10.0",
+    "schemaVersion": "1.11.0",
     "dembrandtVersion": "0.17.0",
     "viewport": { "width": 1920, "height": 1080 },
     "fontsReady": true

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls } from '../lib/robots.js';
+
+function withMockFetch<T>(body: string | null, status: number, run: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    body === null
+      ? Promise.reject(new Error('network error'))
+      : { ok: status >= 200 && status < 300, text: async () => body }) as unknown as typeof fetch;
+  return run().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test('evaluatePath: a disallow rule blocks the matching path', () => {
+  assert.deepEqual(evaluatePath([{ type: 'disallow', value: '/admin' }], '/admin/users'), {
+    allowed: false,
+    rule: '/admin',
+  });
+});
+
+test('evaluatePath: no matching rule allows by default', () => {
+  assert.deepEqual(evaluatePath([{ type: 'disallow', value: '/admin' }], '/pricing'), {
+    allowed: true,
+    rule: null,
+  });
+});
+
+test('evaluatePath: the longest matching rule wins regardless of order', () => {
+  const rules = [
+    { type: 'disallow' as const, value: '/checkout' },
+    { type: 'allow' as const, value: '/checkout/status' },
+  ];
+  assert.deepEqual(evaluatePath(rules, '/checkout/status'), { allowed: true, rule: '/checkout/status' });
+  assert.deepEqual(evaluatePath(rules, '/checkout/pay'), { allowed: false, rule: '/checkout' });
+});
+
+test('evaluatePath: wildcard and end-anchor patterns match correctly', () => {
+  assert.deepEqual(evaluatePath([{ type: 'disallow', value: '/sources/*' }], '/sources/abc'), {
+    allowed: false,
+    rule: '/sources/*',
+  });
+  assert.deepEqual(evaluatePath([{ type: 'disallow', value: '/handoff$' }], '/handoff/extra'), {
+    allowed: true,
+    rule: null,
+  });
+});
+
+test('fetchRobotsRules: parses the matching user-agent group', async () => {
+  const body = 'User-agent: Dembrandt\nDisallow: /private\n\nUser-agent: *\nDisallow: /\n';
+  const rules = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(rules.status, 'ok');
+  if (rules.status === 'ok') {
+    assert.deepEqual(rules.rules, [{ type: 'disallow', value: '/private' }]);
+  }
+});
+
+test('fetchRobotsRules: falls back to * when there is no Dembrandt-specific group', async () => {
+  const body = 'User-agent: *\nDisallow: /admin\n';
+  const rules = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(rules.status, 'ok');
+  if (rules.status === 'ok') assert.deepEqual(rules.rules, [{ type: 'disallow', value: '/admin' }]);
+});
+
+test('fetchRobotsRules: unavailable on a non-2xx response or network failure', async () => {
+  assert.deepEqual(await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
+  assert.deepEqual(await withMockFetch(null, 0, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
+});
+
+test('checkRobotsTxt: evaluates the target path against the fetched rules', async () => {
+  const body = 'User-agent: *\nDisallow: /admin\n';
+  const result = await withMockFetch(body, 200, () => checkRobotsTxt('https://example.com/admin/users'));
+  assert.deepEqual(result, { status: 'ok', robotsUrl: 'https://example.com/robots.txt', allowed: false, rule: '/admin' });
+});
+
+test('filterAllowedUrls: splits urls by robots decision', () => {
+  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', rules: [{ type: 'disallow' as const, value: '/admin' }] };
+  const { allowed, disallowed } = filterAllowedUrls(
+    ['https://example.com/pricing', 'https://example.com/admin/users'],
+    rules,
+  );
+  assert.deepEqual(allowed, ['https://example.com/pricing']);
+  assert.deepEqual(disallowed, [{ url: 'https://example.com/admin/users', rule: '/admin' }]);
+});
+
+test('filterAllowedUrls: an unavailable robots.txt allows everything through', () => {
+  const { allowed, disallowed } = filterAllowedUrls(['https://example.com/anything'], { status: 'unavailable' });
+  assert.deepEqual(allowed, ['https://example.com/anything']);
+  assert.deepEqual(disallowed, []);
+});
+
+test('filterAllowedUrls: a malformed URL is passed through rather than dropped', () => {
+  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', rules: [] };
+  const { allowed, disallowed } = filterAllowedUrls(['not a url'], rules);
+  assert.deepEqual(allowed, ['not a url']);
+  assert.deepEqual(disallowed, []);
+});


### PR DESCRIPTION
robots.txt only got checked once, on the entry URL, in index.ts. Everything --crawl, --sitemap and the MCP pages option discovered got extracted without anyone asking whether those specific paths were actually allowed, and the MCP server, which is the path we now promote, didn't check robots at all, not even for the URL the agent typed.

lib/robots.ts now fetches and parses robots.txt once per origin instead of once per path, and exposes that as a pair of pure functions so the CLI crawl loop and the MCP server can both filter their discovered URLs against it before extracting. A disallowed page gets skipped and named in a new meta.robotsWarnings field rather than silently walked into. The check stays advisory, same as before: it warns, it never blocks.

Tested this against a small local site with a robots.txt disallowing one linked page, and it showed up correctly skipped and named in the warning. Schema moved from 1.10.0 to 1.11.0 for the new field, additive only, and release:churn is clean on both reference sites.

Open to a follow-up that surfaces robotsWarnings more visibly in the CLI's own run summary rather than just the JSON, if that seems worth doing.