### PR TITLE
fix: ExtractionMeta type was missing four runtime fields

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -382,6 +382,26 @@ export interface ExtractionMeta {
    */
   errors?: ExtractorError[];
   /**
+   * The URL as passed on the command line or to the tool, before redirect
+   * resolution. Differs from the top-level `url` whenever the site redirected.
+   */
+  requestedUrl?: string;
+  /** Extracted page text length. Low values point at a thin or bot-wall page. */
+  contentLength?: number;
+  /** Names of waits that timed out during extraction, present only when at least one did. */
+  timeouts?: string[];
+  /**
+   * Present when `--crawl`, `--sitemap` or explicit paths were used to merge
+   * more than one page into this result.
+   */
+  crawl?: {
+    technique: 'explicit-paths' | 'sitemap' | 'auto';
+    /** How many pages were asked for, or null when the request had no fixed count. */
+    pagesRequested: number | null;
+    /** How many pages actually made it into the merged result. */
+    pagesFound: number;
+  };
+  /**
    * Human-readable notes on pages robots.txt disallowed but the run still
    * touched or skipped. The check is advisory: it never blocks extraction,
    * so this is the only record of what it flagged.


### PR DESCRIPTION
requestedUrl, contentLength, timeouts and crawl have been in the actual JSON output since schema 1.9.0, but nobody added them to the ExtractionMeta interface in lib/types.ts. A strict TypeScript consumer importing dembrandt/types (dembrandt-next found this while wiring up the new fields) had no way to read them without a cast.

Type-only change. No schema bump, the runtime shape hasn't moved, only the type catching up to what it already emits.