### PR TITLE
fix(report): render logo/inputs/links; bake SVG var() fills, fix bg sampling

### DIFF
--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -416,7 +416,7 @@ export async function extractLogo(page, url) {
           // Bake the resolved color in so `currentColor` fills render standalone.
           if (color) clone.style.color = color;
           if (!clone.getAttribute('xmlns')) clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-          // fill/stroke may be var(--token) from the page's own CSS — bake the computed value in.
+          // fill/stroke may be var(--token) from the page's own CSS; bake the computed value in.
           const origEls = el.querySelectorAll('*');
           const cloneEls = clone.querySelectorAll('*');
           origEls.forEach((orig, i) => {

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -189,7 +189,7 @@ export async function extractLogo(page, url) {
         [rect.left + rect.width / 2, rect.bottom + 6],
       ];
       for (const [x, y] of points) {
-        if (x < 0 || y < 0) continue;
+        if (x < 0 || y < 0 || x >= innerWidth || y >= innerHeight) continue;
         const hit = document.elementFromPoint(x, y);
         if (!hit || el.contains(hit) || hit.contains(el)) continue;
         const bg = bgFromAncestors(hit);

--- a/lib/extractors/logo.ts
+++ b/lib/extractors/logo.ts
@@ -163,16 +163,39 @@ export async function extractLogo(page, url) {
       } catch { return null; }
     }
 
-    function findBgColor(el) {
-      let node = el;
+    // Walk an element's own ancestors for the first solid background-color;
+    // null if one paints an image/gradient instead (can't reduce that to one hex).
+    function bgFromAncestors(node) {
       while (node && node.tagName !== 'HTML') {
         try {
-          const bg = toHex(getComputedStyle(node).backgroundColor);
+          const style = getComputedStyle(node);
+          if (style.backgroundImage && style.backgroundImage !== 'none') return null;
+          const bg = toHex(style.backgroundColor);
           if (bg) return bg;
         } catch {}
         node = node.parentElement;
       }
       return null;
+    }
+
+    function findBgColor(el) {
+      // Prefer what's actually painted at a point beside the logo (handles a
+      // transparent header over a hero) over el's own DOM ancestors.
+      const rect = el.getBoundingClientRect();
+      const points = [
+        [rect.left - 6, rect.top + rect.height / 2],
+        [rect.right + 6, rect.top + rect.height / 2],
+        [rect.left + rect.width / 2, rect.top - 6],
+        [rect.left + rect.width / 2, rect.bottom + 6],
+      ];
+      for (const [x, y] of points) {
+        if (x < 0 || y < 0) continue;
+        const hit = document.elementFromPoint(x, y);
+        if (!hit || el.contains(hit) || hit.contains(el)) continue;
+        const bg = bgFromAncestors(hit);
+        if (bg) return bg;
+      }
+      return bgFromAncestors(el);
     }
 
     function isLight(hex) {
@@ -393,6 +416,21 @@ export async function extractLogo(page, url) {
           // Bake the resolved color in so `currentColor` fills render standalone.
           if (color) clone.style.color = color;
           if (!clone.getAttribute('xmlns')) clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+          // fill/stroke may be var(--token) from the page's own CSS — bake the computed value in.
+          const origEls = el.querySelectorAll('*');
+          const cloneEls = clone.querySelectorAll('*');
+          origEls.forEach((orig, i) => {
+            const c = cloneEls[i];
+            if (!c) return;
+            const cs = getComputedStyle(orig);
+            (['fill', 'stroke'] as const).forEach(attr => {
+              const raw = orig.getAttribute(attr);
+              if (raw && raw !== 'none' && !/^#[0-9a-f]{3,8}$/i.test(raw)) {
+                const resolved = toHex(cs[attr]);
+                if (resolved) c.setAttribute(attr, resolved);
+              }
+            });
+          });
           const serialized = clone.outerHTML;
           // Skip pathological inline SVGs (sprite sheets, embedded rasters).
           if (serialized && serialized.length <= 50000) {

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -72,7 +72,6 @@ function isHttpUrl(u: string): boolean {
   }
 }
 
-/** An <img> src: an http(s) URL, or a data: URI already inlined by extraction. */
 function isSafeImgSrc(u: string): boolean {
   return isHttpUrl(u) || /^data:image\//i.test(u.trim());
 }
@@ -353,7 +352,6 @@ function paletteSection(result: BrandingResult): string {
   return section("Palette", `<div class="colors">${cards}</div>`, undefined, all);
 }
 
-/** The extracted brand mark, plus any favicons. */
 function logoSection(result: BrandingResult): string {
   const logo = result.logo;
   const favicons = result.favicons ?? [];
@@ -556,7 +554,6 @@ function buttonsSection(result: BrandingResult): string {
   return section("Buttons", `<div class="row">${previews}</div>`, undefined, all);
 }
 
-/** A rendered `<input>` preview per style. */
 function inputsSection(result: BrandingResult): string {
   const raw = result.components?.inputs;
   const list: InputStyle[] = Array.isArray(raw) ? raw : raw?.text ?? [];
@@ -581,7 +578,7 @@ function inputsSection(result: BrandingResult): string {
   return section("Inputs", `<div class="row">${previews}</div>`, undefined, all);
 }
 
-/** Link swatches: default + hover colour, so an underline/colour change reads at a glance. */
+/** Hover colour is shown only when it differs, so a real state change stands out. */
 function linksSection(result: BrandingResult): string {
   const links = result.components?.links ?? [];
   if (!links.length) return "";

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -19,6 +19,8 @@ import type {
   TypographyStyle,
   ButtonStyle,
   BadgeStyle,
+  InputStyle,
+  LinkStyle,
   WcagPair,
   CssState,
 } from "../types.js";
@@ -58,6 +60,21 @@ function safeCss(value: unknown): string {
   // hex, rgb/rgba, hsl/hsla, named-ish words, numbers+units, commas, %, spaces, parens, dots, slashes (for line-height font shorthand)
   if (/^[#0-9a-zA-Z().,%\s/\-+]+$/.test(v) && !/[<>{};]/.test(v)) return v;
   return "";
+}
+
+/** Only http(s) links may be rendered as `<a>`/`<img src>` — no javascript:/file: URLs from extracted content. */
+function isHttpUrl(u: string): boolean {
+  try {
+    const p = new URL(u).protocol;
+    return p === "http:" || p === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** An <img> src: an http(s) URL, or a data: URI already inlined by extraction. */
+function isSafeImgSrc(u: string): boolean {
+  return isHttpUrl(u) || /^data:image\//i.test(u.trim());
 }
 
 /* -------------------------------- styles -------------------------------- */
@@ -336,6 +353,38 @@ function paletteSection(result: BrandingResult): string {
   return section("Palette", `<div class="colors">${cards}</div>`, undefined, all);
 }
 
+/** The extracted brand mark, plus any favicons. */
+function logoSection(result: BrandingResult): string {
+  const logo = result.logo;
+  const favicons = result.favicons ?? [];
+  const parts: string[] = [];
+  if (logo) {
+    const src = logo.dataUri || logo.url;
+    const img = src && isSafeImgSrc(src) ? `<img src="${esc(src)}" alt="${esc(logo.alt || logo.ariaLabel || "logo")}" style="max-height:48px;max-width:220px;object-fit:contain;background:${safeCss(logo.background) || "transparent"}">` : "";
+    const meta: string[] = [];
+    if (logo.width && logo.height) meta.push(`${logo.width}×${logo.height}`);
+    if (logo.safeZone) {
+      const z = logo.safeZone;
+      meta.push(`safe zone ${z.top}/${z.right}/${z.bottom}/${z.left}`);
+    }
+    const swatches = (logo.svgColors ?? [])
+      .map((c) => `<span class="sw2" style="width:16px;height:16px;background:${safeCss(c) || "transparent"}"></span>`)
+      .join("");
+    if (img || meta.length || swatches) {
+      parts.push(`<div class="row">${img}<div>${meta.length ? `<p class="sub">${esc(meta.join(" · "))}</p>` : ""}${swatches ? `<div class="row" style="gap:4px;margin-top:4px">${swatches}</div>` : ""}</div></div>`);
+    }
+  }
+  if (favicons.length) {
+    const icons = favicons
+      .filter((f) => isSafeImgSrc(f.url))
+      .map((f) => `<img src="${esc(f.url)}" alt="${esc(f.type)}" title="${esc(f.type)}${f.sizes ? ` ${esc(f.sizes)}` : ""}" style="width:24px;height:24px;object-fit:contain">`)
+      .join("");
+    if (icons) parts.push(`<div class="row" style="margin-top:12px">${icons}</div>`);
+  }
+  if (!parts.length) return "";
+  return section("Logo", parts.join(""), "logo");
+}
+
 function semanticSection(result: BrandingResult): string {
   const sem = Object.entries(result.colors?.semantic ?? {}).filter(([, v]) => v);
   if (!sem.length) return "";
@@ -396,14 +445,6 @@ function typographySection(result: BrandingResult): string {
     ...(srcs.selfHostedFonts ?? []),
   ];
   const srcLine = fams.length ? `<p class="sub">Sources: ${esc(fams.join(", "))}</p>` : "";
-  const isHttpUrl = (u: string): boolean => {
-    try {
-      const p = new URL(u).protocol;
-      return p === "http:" || p === "https:";
-    } catch {
-      return false;
-    }
-  };
   const fontUrls = (srcs.urls ?? []).filter(isHttpUrl);
   const urlsLine = fontUrls.length
     ? `<p class="sub">Font files: ${fontUrls.map((u) => `<a href="${esc(u)}">${esc(u)}</a>`).join(", ")}</p>`
@@ -506,7 +547,58 @@ function buttonsSection(result: BrandingResult): string {
       return `<button class="previewbtn" style="${esc(style)}">${esc(b.text || "Button")}</button>`;
     })
     .join(" ");
-  return section("Buttons", `<div class="row">${previews}</div>`);
+  const all = buttons
+    .map((b: ButtonStyle) => {
+      const st = b.states?.default ?? {};
+      return `${b.text || "Button"}: ${[st.backgroundColor, st.color, st.borderRadius].filter(Boolean).join(" / ")}`;
+    })
+    .join("\n");
+  return section("Buttons", `<div class="row">${previews}</div>`, undefined, all);
+}
+
+/** A rendered `<input>` preview per style. */
+function inputsSection(result: BrandingResult): string {
+  const raw = result.components?.inputs;
+  const list: InputStyle[] = Array.isArray(raw) ? raw : raw?.text ?? [];
+  if (!list.length) return "";
+  const previews = list
+    .slice(0, 8)
+    .map((i: InputStyle) => {
+      const st = i.states?.default ?? {};
+      const style = [
+        st.backgroundColor ? `background:${safeCss(st.backgroundColor)}` : "",
+        st.color ? `color:${safeCss(st.color)}` : "",
+        i.borderRadius ? `border-radius:${safeCss(i.borderRadius)}` : "",
+        i.padding ? `padding:${safeCss(i.padding)}` : "padding:8px 12px",
+        i.border ? `border:${safeCss(i.border)}` : "border:1px solid var(--line)",
+      ]
+        .filter(Boolean)
+        .join(";");
+      return `<input class="previewbtn" style="${esc(style)}" placeholder="${esc(i.type || "text")}" readonly>`;
+    })
+    .join(" ");
+  const all = list.map((i) => [i.type, i.border, i.borderRadius].filter(Boolean).join(" / ")).join("\n");
+  return section("Inputs", `<div class="row">${previews}</div>`, undefined, all);
+}
+
+/** Link swatches: default + hover colour, so an underline/colour change reads at a glance. */
+function linksSection(result: BrandingResult): string {
+  const links = result.components?.links ?? [];
+  if (!links.length) return "";
+  const chips = links
+    .slice(0, 12)
+    .map((l: LinkStyle) => {
+      const d = l.states?.default ?? {};
+      const h = l.states?.hover;
+      const style = [d.color ? `color:${safeCss(d.color)}` : "", d.textDecoration ? `text-decoration:${safeCss(d.textDecoration)}` : "", l.fontWeight ? `font-weight:${safeCss(l.fontWeight)}` : ""]
+        .filter(Boolean)
+        .join(";");
+      const hoverNote = h?.color && h.color !== d.color ? ` <span class="sub">hover ${esc(h.color)}</span>` : "";
+      return `<span class="badgepv"><a href="#" style="${esc(style)}" onclick="return false">Link</a>${hoverNote}</span>`;
+    })
+    .join(" ");
+  const all = links.map((l) => [l.states?.default?.color, l.states?.hover?.color].filter(Boolean).join(" -> ")).join("\n");
+  return section("Links", `<div class="row">${chips}</div>`, undefined, all);
 }
 
 function badgesSection(result: BrandingResult): string {
@@ -526,7 +618,8 @@ function badgesSection(result: BrandingResult): string {
       return `<span class="badgepv" style="${esc(style)}">${esc(bd.styleType || "badge")}</span>`;
     })
     .join(" ");
-  return section("Badges", `<div class="row">${chips}</div>`);
+  const all = list.map((bd: BadgeStyle) => [bd.styleType, bd.backgroundColor, bd.color].filter(Boolean).join(" / ")).join("\n");
+  return section("Badges", `<div class="row">${chips}</div>`, undefined, all);
 }
 
 function wcagSection(result: BrandingResult): string {
@@ -679,12 +772,15 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
   const body = [
     options.drift ? driftSection(options.drift, result, options.baselineLabel) : "",
     findingsSection(fr),
+    logoSection(result),
     paletteSection(result),
     semanticSection(result),
     typographySection(result),
     cardRow(spacingSection(result), radiusSection(result)),
     shadowsSection(result),
     buttonsSection(result),
+    inputsSection(result),
+    linksSection(result),
     badgesSection(result),
     wcagSection(result),
     metaSection(result),

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -101,8 +101,6 @@ test('Mode B renders a drift banner and a Drift gauge', () => {
   assert.match(html, />Drift</);
 });
 
-/* ---------------------------- logo / inputs / links ---------------------------- */
-
 test('the logo section renders the mark, its dimensions and its svg colours', () => {
   const html = generateHtmlReport(fixture({
     logo: {

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -100,3 +100,72 @@ test('Mode B renders a drift banner and a Drift gauge', () => {
   assert.match(html, />(DRIFT|STABLE)</);
   assert.match(html, />Drift</);
 });
+
+/* ---------------------------- logo / inputs / links ---------------------------- */
+
+test('the logo section renders the mark, its dimensions and its svg colours', () => {
+  const html = generateHtmlReport(fixture({
+    logo: {
+      source: 'svg',
+      url: 'https://example.com/logo.svg',
+      dataUri: 'data:image/svg+xml;base64,PHN2Zy8+',
+      width: 120,
+      height: 32,
+      alt: 'Example',
+      svgColors: ['#133174'],
+      safeZone: { top: 8, right: 8, bottom: 8, left: 8 },
+      background: '#ffffff',
+    },
+  }));
+  assert.match(html, /id="logo"/);
+  assert.match(html, /src="data:image\/svg\+xml;base64,PHN2Zy8/);
+  assert.match(html, /120×32/);
+  assert.match(html, /safe zone 8\/8\/8\/8/);
+  assert.match(html, /background:#ffffff/);
+});
+
+test('a logo with no usable image or metadata drops the section instead of rendering an empty card', () => {
+  const html = generateHtmlReport(fixture({ logo: { source: 'img', url: '' } }));
+  assert.doesNotMatch(html, /id="logo"/);
+});
+
+test('non-http logo and favicon sources are refused as image srcs', () => {
+  const html = generateHtmlReport(fixture({
+    logo: { source: 'img', url: 'javascript:alert(1)', width: 10, height: 10 },
+    favicons: [
+      { type: 'icon', url: 'file:///etc/passwd', sizes: null },
+      { type: 'apple-touch-icon', url: 'https://example.com/apple.png', sizes: '180x180' },
+    ],
+  }));
+  assert.doesNotMatch(html, /javascript:alert/);
+  assert.doesNotMatch(html, /file:\/\/\//);
+  assert.match(html, /src="https:\/\/example\.com\/apple\.png"/);
+});
+
+test('inputs render from either the array or the { text } shape', () => {
+  const style = { type: 'email', border: '1px solid #ccc', borderRadius: '6px', states: { default: { backgroundColor: '#fff', color: '#111' } } };
+  for (const inputs of [[style], { text: [style] }]) {
+    const html = generateHtmlReport(fixture({ components: { buttons: [], inputs, links: [], badges: [] } }));
+    assert.match(html, /Inputs/);
+    assert.match(html, /placeholder="email"/);
+    assert.match(html, /border-radius:6px/);
+  }
+});
+
+test('a link shows its hover colour only when hover actually differs', () => {
+  const link = (hover: string) => ({ states: { default: { color: '#0055ff', textDecoration: 'underline' }, hover: { color: hover } } });
+  const changed = generateHtmlReport(fixture({ components: { buttons: [], inputs: [], links: [link('#003399')], badges: [] } }));
+  assert.match(changed, /hover #003399/);
+  const same = generateHtmlReport(fixture({ components: { buttons: [], inputs: [], links: [link('#0055ff')], badges: [] } }));
+  assert.match(same, /Links/);
+  assert.doesNotMatch(same, /hover #0055ff/);
+});
+
+test('component sections carry a Copy all payload built from every entry, not just the previewed ones', () => {
+  const links = Array.from({ length: 15 }, (_, i) => ({ states: { default: { color: `#0000${String(i).padStart(2, '0')}` } } }));
+  const html = generateHtmlReport(fixture({ components: { buttons: [], inputs: [], links, badges: [] } }));
+  const chips = (html.match(/class="badgepv"/g) ?? []).length;
+  assert.equal(chips, 12);
+  const copy = html.match(/data-copy="([^"]*)"/g) ?? [];
+  assert.ok(copy.some((c) => c.includes('#000000') && c.includes('#000014')), 'copy payload must span past the 12 rendered chips');
+});


### PR DESCRIPTION
## Summary
- HTML report was missing logo/favicon, inputs, and links sections despite extraction already producing that data
- Inline SVG logos using `fill="var(--token)")` rendered invisible once serialized standalone — bakes the computed value in now
- `findBgColor` walked DOM ancestors and missed a hero image painted behind a transparent header — now samples via `elementFromPoint`
- buttons/badges sections now get the same "Copy all" button as every other section

## Test plan
- [x] `npm test` (722/722)
- [x] `tsc --noEmit`
- [x] Rendered against 4 real fixtures (stripe, apple, anthropic, bmw) — no crashes
- [x] Live-tested against gucci.com, confirmed the var()-fill bug with a headless screenshot before/after
- [x] XSS check: javascript: URLs and script-injection in logo fields don't reach the output

Claude-Session: https://claude.ai/code/session_01PsK5rqySni6Bf84fguP6XD