### PR TITLE
Say so when --crawl is ignored

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -118,6 +118,16 @@ program
       console.error(color.warning("! --approve has no effect without --compare <file>."));
     }
 
+    // Explicit paths are a page list, and discovery is what runs when there is
+    // none, so the two cannot both be in charge. Passing both looked like it
+    // would extract the paths and then crawl for more, and it silently did the
+    // paths alone.
+    if (opts.crawl && paths?.length && !opts.sitemap) {
+      console.error(color.warning(
+        `! --crawl is ignored when paths are listed: extracting the ${paths.length} given path${paths.length === 1 ? "" : "s"}. Drop the paths to crawl instead.`,
+      ));
+    }
+
     // --color-format governs the terminal colour column only. Silently ignoring
     // it on an export path would read as a bug, so name the paths it misses.
     if (opts.colorFormat && opts.colorFormat !== "hex") {


### PR DESCRIPTION
`dembrandt example.com /pricing /docs --crawl=3` extracts the two listed paths and ignores the crawl.

That is the right behaviour: explicit paths are a page list, discovery is what runs when there is none, and both cannot be in charge. The problem is that nothing said so, and the command reads as "extract these, then find more".

This prints a warning naming the flag that did nothing and what ran instead, in the shape the `--approve` warning already uses. `--crawl` with `--sitemap` is untouched, since there the number is the page cap and does have an effect.

`meta.crawl.pagesRequested` was already correct for this case (paths + 1), so no metadata changes.

Build, lint and the 722 tests pass.