### PR TITLE
Guard flag combinations that silently do nothing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
 import { installBrowsers, bundledPlaywrightVersion } from "./lib/install-browser.js";
+import { guardWarnings, voiceNeedsOutputFile } from "./lib/cli-guards.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -114,30 +115,9 @@ program
     // Resolve API key: --key flag takes precedence over env var
     const apiKey: string | undefined = opts.key ?? process.env.DEMBRANDT_KEY;
 
-    if (opts.approve && !opts.compare) {
-      console.error(color.warning("! --approve has no effect without --compare <file>."));
-    }
+    const voiceWritesOutput: boolean = voiceNeedsOutputFile(opts, !!apiKey);
 
-    // --color-format governs the terminal colour column only. Silently ignoring
-    // it on an export path would read as a bug, so name the paths it misses.
-    if (opts.colorFormat && opts.colorFormat !== "hex") {
-      const unaffected = [
-        opts.jsonOnly && "--json-only",
-        opts.saveOutput && "--save-output",
-        opts.dtcg && "--dtcg",
-        opts.designMd && "--design-md",
-        opts.tailwind && "--tailwind",
-        opts.html && "--html",
-        opts.brandGuide && "--brand-guide",
-      ].filter(Boolean);
-      if (unaffected.length) {
-        console.error(
-          color.warning(
-            `! --color-format=${opts.colorFormat} applies to terminal output only; ${unaffected.join(", ")} ${unaffected.length > 1 ? "are" : "is"} unaffected. JSON carries hex, rgb, lch and oklch for every colour.`
-          )
-        );
-      }
-    }
+    for (const warning of guardWarnings(opts, paths)) console.error(color.warning(warning));
 
     // In --json-only mode, redirect all status output to stderr so stdout is clean JSON
     const originalConsoleLog = console.log;
@@ -466,8 +446,9 @@ program
       const savedNotices = [];
       let syncFailed = false;
 
-      // Save JSON output if --save-output or --dtcg is specified
-      if (opts.saveOutput || opts.dtcg) {
+      // Save JSON output if --save-output or --dtcg is specified, or if --voice
+      // was passed with nowhere else for the copy to go.
+      if (opts.saveOutput || opts.dtcg || voiceWritesOutput) {
         try {
           const domain = new URL(url).hostname.replace("www.", "");
           const timestamp = new Date()
@@ -482,6 +463,7 @@ program
           // extraction, --dtcg writes the tokens file. Both flags = both files.
           const saves = [];
           if (opts.saveOutput) saves.push({ data: result, suffix: '', label: 'JSON saved (--save-output)' });
+          else if (voiceWritesOutput) saves.push({ data: result, suffix: '', label: 'JSON saved (--voice)' });
           if (opts.dtcg) saves.push({ data: outputData, suffix: '.tokens', label: 'DTCG tokens saved (--dtcg)' });
           for (const { data, suffix, label } of saves) {
             const filename = `${timestamp}_v${version}${suffix}.json`;

--- a/index.ts
+++ b/index.ts
@@ -446,8 +446,6 @@ program
       const savedNotices = [];
       let syncFailed = false;
 
-      // Save JSON output if --save-output or --dtcg is specified, or if --voice
-      // was passed with nowhere else for the copy to go.
       if (opts.saveOutput || opts.dtcg || voiceWritesOutput) {
         try {
           const domain = new URL(url).hostname.replace("www.", "");

--- a/lib/cli-guards.ts
+++ b/lib/cli-guards.ts
@@ -1,0 +1,63 @@
+/**
+ * Flag-combination guards: pure predicates over parsed CLI options, so the
+ * "this flag did nothing" warnings are testable without launching a browser.
+ */
+
+export interface GuardOptions {
+  approve?: boolean;
+  compare?: string;
+  crawl?: number | null;
+  sitemap?: boolean;
+  colorFormat?: string;
+  voice?: boolean;
+  saveOutput?: boolean;
+  dtcg?: boolean;
+  jsonOnly?: boolean;
+  designMd?: boolean;
+  tailwind?: string | boolean;
+  html?: string | boolean;
+  brandGuide?: boolean;
+}
+
+/** Voice never reaches the terminal — no formatter prints it — so a lone --voice needs a JSON sink. */
+export function voiceNeedsOutputFile(opts: GuardOptions, hasApiKey: boolean): boolean {
+  return !!opts.voice && !opts.saveOutput && !opts.dtcg && !opts.jsonOnly && !hasApiKey;
+}
+
+/** Explicit paths are the page list, so discovery flags passed alongside them never run. */
+export function ignoredDiscoveryWarning(opts: GuardOptions, paths: string[] | undefined): string | null {
+  const count = paths?.length ?? 0;
+  if (!count) return null;
+  const ignored = [opts.crawl && "--crawl", opts.sitemap && "--sitemap"].filter(Boolean) as string[];
+  if (!ignored.length) return null;
+  const verb = ignored.length > 1 ? "are" : "is";
+  return `! ${ignored.join(" and ")} ${verb} ignored when paths are listed: extracting the ${count} given path${count === 1 ? "" : "s"}. Drop the paths to discover pages instead.`;
+}
+
+/** --color-format shapes the terminal column only; every export path keeps its own encoding. */
+export function colorFormatWarning(opts: GuardOptions): string | null {
+  if (!opts.colorFormat || opts.colorFormat === "hex") return null;
+  const unaffected = [
+    opts.jsonOnly && "--json-only",
+    opts.saveOutput && "--save-output",
+    opts.dtcg && "--dtcg",
+    opts.designMd && "--design-md",
+    opts.tailwind && "--tailwind",
+    opts.html && "--html",
+    opts.brandGuide && "--brand-guide",
+  ].filter(Boolean) as string[];
+  if (!unaffected.length) return null;
+  return `! --color-format=${opts.colorFormat} applies to terminal output only; ${unaffected.join(", ")} ${unaffected.length > 1 ? "are" : "is"} unaffected. JSON carries hex, rgb, lch and oklch for every colour.`;
+}
+
+/** --approve only means something against a local baseline file. */
+export function approveWarning(opts: GuardOptions): string | null {
+  return opts.approve && !opts.compare ? "! --approve has no effect without --compare <file>." : null;
+}
+
+/** Every guard warning for a run, in the order they are emitted. */
+export function guardWarnings(opts: GuardOptions, paths: string[] | undefined): string[] {
+  return [approveWarning(opts), ignoredDiscoveryWarning(opts, paths), colorFormatWarning(opts)].filter(
+    (w): w is string => w !== null,
+  );
+}

--- a/lib/cli-guards.ts
+++ b/lib/cli-guards.ts
@@ -19,7 +19,7 @@ export interface GuardOptions {
   brandGuide?: boolean;
 }
 
-/** Voice never reaches the terminal — no formatter prints it — so a lone --voice needs a JSON sink. */
+/** No formatter prints voice, so a lone --voice needs a JSON sink of its own. */
 export function voiceNeedsOutputFile(opts: GuardOptions, hasApiKey: boolean): boolean {
   return !!opts.voice && !opts.saveOutput && !opts.dtcg && !opts.jsonOnly && !hasApiKey;
 }
@@ -50,12 +50,11 @@ export function colorFormatWarning(opts: GuardOptions): string | null {
   return `! --color-format=${opts.colorFormat} applies to terminal output only; ${unaffected.join(", ")} ${unaffected.length > 1 ? "are" : "is"} unaffected. JSON carries hex, rgb, lch and oklch for every colour.`;
 }
 
-/** --approve only means something against a local baseline file. */
 export function approveWarning(opts: GuardOptions): string | null {
   return opts.approve && !opts.compare ? "! --approve has no effect without --compare <file>." : null;
 }
 
-/** Every guard warning for a run, in the order they are emitted. */
+/** Every applicable warning, in emit order. */
 export function guardWarnings(opts: GuardOptions, paths: string[] | undefined): string[] {
   return [approveWarning(opts), ignoredDiscoveryWarning(opts, paths), colorFormatWarning(opts)].filter(
     (w): w is string => w !== null,

--- a/test/cli-guards.test.ts
+++ b/test/cli-guards.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  approveWarning,
+  colorFormatWarning,
+  guardWarnings,
+  ignoredDiscoveryWarning,
+  voiceNeedsOutputFile,
+} from '../lib/cli-guards.js';
+
+/**
+ * Guards exist so a flag never silently does nothing. Each test pins a flag
+ * combination a user can actually type, not the shape of the predicate.
+ */
+
+test('--approve is only meaningful against a baseline', () => {
+  assert.match(approveWarning({ approve: true }) ?? '', /--approve has no effect/);
+  assert.equal(approveWarning({ approve: true, compare: 'base.json' }), null);
+  assert.equal(approveWarning({}), null);
+});
+
+test('discovery flags are called out whenever explicit paths win', () => {
+  assert.match(ignoredDiscoveryWarning({ crawl: 5 }, ['/pricing']) ?? '', /--crawl is ignored/);
+  assert.match(ignoredDiscoveryWarning({ sitemap: true }, ['/pricing']) ?? '', /--sitemap is ignored/);
+  // --crawl --sitemap together: both lose to the path list, so both are named.
+  assert.match(
+    ignoredDiscoveryWarning({ crawl: 5, sitemap: true }, ['/pricing']) ?? '',
+    /--crawl and --sitemap are ignored/,
+  );
+});
+
+test('the discovery warning counts the paths it is actually extracting', () => {
+  assert.match(ignoredDiscoveryWarning({ crawl: 5 }, ['/a']) ?? '', /the 1 given path\./);
+  assert.match(ignoredDiscoveryWarning({ crawl: 5 }, ['/a', '/b']) ?? '', /the 2 given paths\./);
+});
+
+test('no discovery warning without both a path list and a discovery flag', () => {
+  assert.equal(ignoredDiscoveryWarning({ crawl: 5 }, []), null);
+  assert.equal(ignoredDiscoveryWarning({ crawl: 5 }, undefined), null);
+  assert.equal(ignoredDiscoveryWarning({}, ['/pricing']), null);
+});
+
+test('--color-format names only the export paths present in the run', () => {
+  assert.equal(colorFormatWarning({ colorFormat: 'oklch' }), null);
+  assert.equal(colorFormatWarning({ colorFormat: 'hex', dtcg: true }), null);
+  const one = colorFormatWarning({ colorFormat: 'oklch', dtcg: true }) ?? '';
+  assert.match(one, /--dtcg is unaffected/);
+  assert.doesNotMatch(one, /--html/);
+  assert.match(colorFormatWarning({ colorFormat: 'rgb', dtcg: true, html: true }) ?? '', /--dtcg, --html are unaffected/);
+});
+
+test('--voice needs a sink of its own because no formatter prints it', () => {
+  assert.equal(voiceNeedsOutputFile({ voice: true }, false), true);
+  for (const sink of [{ saveOutput: true }, { dtcg: true }, { jsonOnly: true }]) {
+    assert.equal(voiceNeedsOutputFile({ voice: true, ...sink }, false), false);
+  }
+  // An API key means the extraction is synced, so the copy already has a home.
+  assert.equal(voiceNeedsOutputFile({ voice: true }, true), false);
+  assert.equal(voiceNeedsOutputFile({}, false), false);
+});
+
+test('--html and --tailwind do not count as voice sinks: neither renders voice', () => {
+  assert.equal(voiceNeedsOutputFile({ voice: true, html: true, tailwind: true }, false), true);
+});
+
+test('guardWarnings emits every applicable warning in emit order', () => {
+  const warnings = guardWarnings({ approve: true, crawl: 3, colorFormat: 'oklch', dtcg: true }, ['/pricing']);
+  assert.deepEqual(warnings.map((w) => w.slice(2, 11)), ['--approve', '--crawl i', '--color-f']);
+  assert.deepEqual(guardWarnings({}, undefined), []);
+});


### PR DESCRIPTION
Supersedes #196 and #197.

- `--sitemap` is ignored beside an explicit path list just as `--crawl` is; the warning names whichever was passed, and both when both were.
- `--voice` writes the JSON file it exists to produce when no other sink is present. No formatter renders voice, so `--html`/`--tailwind` do not count as sinks.
- Guards extracted to `lib/cli-guards.ts` as pure predicates, covered by 8 browser-free tests.