### PR TITLE
trace the emitting version from every export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -493,7 +493,7 @@ program
           const pdfFilename = `${pdfDomain}-brand-guide-${pdfDate}-${pdfTime}.pdf`;
           const pdfPath = join(pdfDir, pdfFilename);
           spinner.start("Generating PDF brand guide...");
-          await generatePDF(result, pdfPath, browser);
+          await generatePDF(result, pdfPath, browser, { version });
           spinner.stop();
           savedNotices.push(
             chalk.dim(
@@ -545,7 +545,7 @@ program
             mkdirSync(twDir, { recursive: true });
             twPath = join(twDir, "theme.css");
           }
-          writeFileSync(twPath, generateTailwindTheme(result));
+          writeFileSync(twPath, generateTailwindTheme(result, { version }));
           const twLabel =
             typeof opts.tailwind === "string" ? opts.tailwind : `output/${twDomain}/theme.css`;
           savedNotices.push(

--- a/index.ts
+++ b/index.ts
@@ -517,7 +517,7 @@ program
           const mdDir = join(process.cwd(), "output", mdDomain);
           mkdirSync(mdDir, { recursive: true });
           const mdPath = join(mdDir, "DESIGN.md");
-          writeFileSync(mdPath, generateDesignMd(result));
+          writeFileSync(mdPath, generateDesignMd(result, { version }));
           savedNotices.push(
             chalk.dim(
               `💾 DESIGN.md saved (--design-md): ${color.info(

--- a/lib/formatters/brand-guide.ts
+++ b/lib/formatters/brand-guide.ts
@@ -138,10 +138,11 @@ function weightName(w) {
   return map[w] || `Weight ${w}`;
 }
 
-export function buildHTML(data) {
+export function buildHTML(data, options: { version?: string } = {}) {
   // Public entry point: callers may pass adapted/partial token data (e.g. from a
   // parsed design.md), so never assume a fully-formed extraction result.
   if (!data || typeof data !== 'object') data = {};
+  const toolVersion = options.version ?? data.meta?.dembrandtVersion;
 
   let domain;
   try { domain = new URL(data.url).hostname.replace('www.', ''); }
@@ -653,7 +654,7 @@ export function buildHTML(data) {
   <div class="domain">${escapeHtml(companyName)}</div>
   <div class="rule"></div>
   <div class="subtitle">Brand Guidelines</div>
-  <div class="cover-meta">${escapeHtml(domain)}&nbsp;&nbsp;&middot;&nbsp;&nbsp;${date}${data.meta?.dembrandtVersion ? `&nbsp;&nbsp;&middot;&nbsp;&nbsp;v${escapeHtml(data.meta.dembrandtVersion)}` : ''}</div>
+  <div class="cover-meta">${escapeHtml(domain)}&nbsp;&nbsp;&middot;&nbsp;&nbsp;${date}${toolVersion ? `&nbsp;&nbsp;&middot;&nbsp;&nbsp;v${escapeHtml(toolVersion)}` : ''}</div>
 </div>
 
 <!-- TABLE OF CONTENTS -->
@@ -948,7 +949,7 @@ ${fonts.length > 0 ? (() => {
 ${(() => {
   const year = (() => { const y = new Date(data.extractedAt).getFullYear(); return Number.isFinite(y) ? y : new Date().getFullYear(); })();
   const meta = data.meta || {};
-  const version = meta.dembrandtVersion;
+  const version = toolVersion;
 
   // Redirected to a different URL than what was asked for (locale/region redirects
   // are common on large multi-market sites and otherwise invisible in the guide).

--- a/lib/formatters/brand-guide.ts
+++ b/lib/formatters/brand-guide.ts
@@ -142,7 +142,9 @@ export function buildHTML(data, options: { version?: string } = {}) {
   // Public entry point: callers may pass adapted/partial token data (e.g. from a
   // parsed design.md), so never assume a fully-formed extraction result.
   if (!data || typeof data !== 'object') data = {};
-  const toolVersion = options.version ?? data.meta?.dembrandtVersion;
+  // The extractor's version owns the stamp: it is the release the token values
+  // came from. The renderer only fills in for data that never carried one.
+  const toolVersion = data.meta?.dembrandtVersion ?? options.version;
 
   let domain;
   try { domain = new URL(data.url).hostname.replace('www.', ''); }

--- a/lib/formatters/html.ts
+++ b/lib/formatters/html.ts
@@ -763,7 +763,7 @@ export function generateHtmlReport(result: BrandingResult, options: HtmlReportOp
   } catch {
     /* leave as-is */
   }
-  const version = options.version ?? result.meta?.dembrandtVersion ?? "";
+  const version = result.meta?.dembrandtVersion ?? options.version ?? "";
   const fr = computeFindings(result);
 
   const body = [

--- a/lib/formatters/markdown.ts
+++ b/lib/formatters/markdown.ts
@@ -26,11 +26,6 @@ import { convertColor, deltaE } from '../colors.js';
  */
 export const DESIGN_MD_TARGET_SPEC = '0.4';
 
-/**
- * @param result - dembrandt extraction result
- * @param options.version - renderer version, used when the extraction carries no meta
- * @returns DESIGN.md content
- */
 export function generateDesignMd(result: any, options: { version?: string } = {}) {
   const domain = getDomain(result);
   const name = getName(result, domain);

--- a/lib/formatters/markdown.ts
+++ b/lib/formatters/markdown.ts
@@ -27,10 +27,11 @@ import { convertColor, deltaE } from '../colors.js';
 export const DESIGN_MD_TARGET_SPEC = '0.4';
 
 /**
- * @param {object} result - dembrandt extraction result
- * @returns {string} DESIGN.md content
+ * @param result - dembrandt extraction result
+ * @param options.version - renderer version, used when the extraction carries no meta
+ * @returns DESIGN.md content
  */
-export function generateDesignMd(result: any) {
+export function generateDesignMd(result: any, options: { version?: string } = {}) {
   const domain = getDomain(result);
   const name = getName(result, domain);
   const colorRoles = buildColorRoles(result);
@@ -60,7 +61,7 @@ export function generateDesignMd(result: any) {
     hasComponentEvidence(result) ? buildComponentsSection(result) : null,
   ].filter(Boolean);
 
-  const version = result.meta?.dembrandtVersion;
+  const version = options.version ?? result.meta?.dembrandtVersion;
   const attribution = `<!-- dembrandt${version ? ` v${version}` : ''} -->`;
 
   return `---\n${toYaml(frontMatter)}---\n\n${sections.join('\n\n')}\n\n${attribution}\n`;

--- a/lib/formatters/markdown.ts
+++ b/lib/formatters/markdown.ts
@@ -60,7 +60,10 @@ export function generateDesignMd(result: any) {
     hasComponentEvidence(result) ? buildComponentsSection(result) : null,
   ].filter(Boolean);
 
-  return `---\n${toYaml(frontMatter)}---\n\n${sections.join('\n\n')}\n`;
+  const version = result.meta?.dembrandtVersion;
+  const attribution = `<!-- dembrandt${version ? ` v${version}` : ''} -->`;
+
+  return `---\n${toYaml(frontMatter)}---\n\n${sections.join('\n\n')}\n\n${attribution}\n`;
 }
 
 function getDomain(result) {

--- a/lib/formatters/markdown.ts
+++ b/lib/formatters/markdown.ts
@@ -56,7 +56,7 @@ export function generateDesignMd(result: any, options: { version?: string } = {}
     hasComponentEvidence(result) ? buildComponentsSection(result) : null,
   ].filter(Boolean);
 
-  const version = options.version ?? result.meta?.dembrandtVersion;
+  const version = result.meta?.dembrandtVersion ?? options.version;
   const attribution = `<!-- dembrandt${version ? ` v${version}` : ''} -->`;
 
   return `---\n${toYaml(frontMatter)}---\n\n${sections.join('\n\n')}\n\n${attribution}\n`;

--- a/lib/formatters/pdf.ts
+++ b/lib/formatters/pdf.ts
@@ -61,8 +61,8 @@ export async function inlineLogoForPdf(data, fetchImpl = fetch) {
  * @param {Object} data - Extraction results from extractBranding()
  * @param {string} outputPath - Path to write the PDF
  */
-export async function generatePDF(data, outputPath, existingBrowser) {
-  const html = buildHTML(await inlineLogoForPdf(data));
+export async function generatePDF(data, outputPath, existingBrowser, options: { version?: string } = {}) {
+  const html = buildHTML(await inlineLogoForPdf(data), options);
   const ownBrowser = !existingBrowser;
   let browser = existingBrowser;
   if (!browser) {

--- a/lib/formatters/tailwind.ts
+++ b/lib/formatters/tailwind.ts
@@ -119,7 +119,7 @@ const MAX_COLORS = 24;
  * @param result - dembrandt extraction result, or any partial of it
  * @returns CSS: a provenance header, `@import "tailwindcss"`, one `@theme` block
  */
-export function generateTailwindTheme(result: TailwindThemeInput): string {
+export function generateTailwindTheme(result: TailwindThemeInput, options: { version?: string } = {}): string {
   const sections: ThemeSection[] = [
     { title: 'Colors', entries: buildColors(result) },
     { title: 'Typography', entries: buildTypography(result) },
@@ -131,7 +131,7 @@ export function generateTailwindTheme(result: TailwindThemeInput): string {
 
   const body = sections.map(renderSection).join('\n\n');
 
-  return `${buildHeader(result)}\n@import "tailwindcss";\n\n@theme {\n${body}\n}\n`;
+  return `${buildHeader(result, options.version ?? result.meta?.dembrandtVersion)}\n@import "tailwindcss";\n\n@theme {\n${body}\n}\n`;
 }
 
 /** Render one section, aligning trailing provenance comments within it. */
@@ -148,9 +148,8 @@ function renderSection(section: ThemeSection): string {
   return `  /* ${section.title} */\n${lines.join('\n')}`;
 }
 
-function buildHeader(result: TailwindThemeInput): string {
+function buildHeader(result: TailwindThemeInput, version?: string): string {
   const source = result.url ?? 'an unknown page';
-  const version = result.meta?.dembrandtVersion;
   const stamp = result.extractedAt ? ` on ${result.extractedAt}` : '';
 
   return [

--- a/lib/formatters/tailwind.ts
+++ b/lib/formatters/tailwind.ts
@@ -131,7 +131,7 @@ export function generateTailwindTheme(result: TailwindThemeInput, options: { ver
 
   const body = sections.map(renderSection).join('\n\n');
 
-  return `${buildHeader(result, options.version ?? result.meta?.dembrandtVersion)}\n@import "tailwindcss";\n\n@theme {\n${body}\n}\n`;
+  return `${buildHeader(result, result.meta?.dembrandtVersion ?? options.version)}\n@import "tailwindcss";\n\n@theme {\n${body}\n}\n`;
 }
 
 /** Render one section, aligning trailing provenance comments within it. */

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -377,7 +377,7 @@ async function main() {
     ({ result, job_id }: any) => {
       const source = resolveExtraction(result, job_id, "result", jobQueue);
       if (!source.ok) return errorResult(source.error);
-      return { content: [{ type: "text", text: generateDesignMd(source.value) }] };
+      return { content: [{ type: "text", text: generateDesignMd(source.value, { version }) }] };
     },
   );
 

--- a/test/brand-guide.test.ts
+++ b/test/brand-guide.test.ts
@@ -176,3 +176,17 @@ test('buildHTML flags timeouts as a data-completeness caveat', () => {
   assert.match(html, /2 timeouts during extraction: Body content rendering, Main content selector/);
   assert.match(html, /some values may be incomplete/);
 });
+
+test('buildHTML stamps the renderer version when the data carries no meta', () => {
+  const rendered = buildHTML({ url: 'https://example.com' }, { version: '1.2.3' });
+  assert.match(rendered, /v1\.2\.3/);
+
+  const optionWins = buildHTML(
+    { url: 'https://example.com', meta: { dembrandtVersion: '0.0.1' } },
+    { version: '1.2.3' },
+  );
+  assert.match(optionWins, /v1\.2\.3/);
+  assert.doesNotMatch(optionWins, /v0\.0\.1/);
+
+  assert.match(buildHTML({ url: 'https://example.com' }), /Created with <strong>DEMBRANDT/);
+});

--- a/test/brand-guide.test.ts
+++ b/test/brand-guide.test.ts
@@ -177,16 +177,17 @@ test('buildHTML flags timeouts as a data-completeness caveat', () => {
   assert.match(html, /some values may be incomplete/);
 });
 
-test('buildHTML stamps the renderer version when the data carries no meta', () => {
+test('buildHTML falls back to the renderer version only when the data carries none', () => {
   const rendered = buildHTML({ url: 'https://example.com' }, { version: '1.2.3' });
   assert.match(rendered, /v1\.2\.3/);
 
-  const optionWins = buildHTML(
+  // Re-rendering an old snapshot must keep saying which release extracted it.
+  const extractorWins = buildHTML(
     { url: 'https://example.com', meta: { dembrandtVersion: '0.0.1' } },
     { version: '1.2.3' },
   );
-  assert.match(optionWins, /v1\.2\.3/);
-  assert.doesNotMatch(optionWins, /v0\.0\.1/);
+  assert.match(extractorWins, /v0\.0\.1/);
+  assert.doesNotMatch(extractorWins, /v1\.2\.3/);
 
   assert.match(buildHTML({ url: 'https://example.com' }), /Created with <strong>DEMBRANDT/);
 });

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -167,3 +167,22 @@ test('component sections carry a Copy all payload built from every entry, not ju
   const copy = html.match(/data-copy="([^"]*)"/g) ?? [];
   assert.ok(copy.some((c) => c.includes('#000000') && c.includes('#000014')), 'copy payload must span past the 12 rendered chips');
 });
+
+test('the report stamps the extracting version, falling back to the renderer', () => {
+  const extracted = generateHtmlReport(
+    fixture({ meta: { dembrandtVersion: '0.0.1' } }),
+    { version: '1.2.3' },
+  );
+  assert.match(extracted, /<meta name="generator" content="dembrandt 0\.0\.1">/);
+  assert.doesNotMatch(extracted, /1\.2\.3/);
+
+  const rendered = generateHtmlReport(fixture({ meta: {} }), { version: '1.2.3' });
+  assert.match(rendered, /<meta name="generator" content="dembrandt 1\.2\.3">/);
+
+  // MCP renders stored extractions with no version option at all.
+  assert.match(
+    generateHtmlReport(fixture({ meta: { dembrandtVersion: '0.0.1' } })),
+    /<meta name="generator" content="dembrandt 0\.0\.1">/,
+  );
+  assert.match(generateHtmlReport(fixture({ meta: {} })), /content="dembrandt">/);
+});

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -160,6 +160,9 @@ test('generateDesignMd ends with a dembrandt attribution comment', () => {
   });
   assert.match(versioned, /\n<!-- dembrandt v9\.9\.9 -->\n$/);
 
+  const rendererVersion = generateDesignMd({ url: 'https://attribution.example' }, { version: '1.2.3' });
+  assert.match(rendererVersion, /\n<!-- dembrandt v1\.2\.3 -->\n$/);
+
   const unversioned = generateDesignMd({ url: 'https://attribution.example' });
   assert.match(unversioned, /\n<!-- dembrandt -->\n$/);
 });

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -152,3 +152,14 @@ test('generateDesignMd omits hidden input borders and empty component sections',
   assert.doesNotMatch(output, /\ncomponents:/);
   assert.doesNotMatch(output, /## Components/);
 });
+
+test('generateDesignMd ends with a dembrandt attribution comment', () => {
+  const versioned = generateDesignMd({
+    url: 'https://attribution.example',
+    meta: { dembrandtVersion: '9.9.9' },
+  });
+  assert.match(versioned, /\n<!-- dembrandt v9\.9\.9 -->\n$/);
+
+  const unversioned = generateDesignMd({ url: 'https://attribution.example' });
+  assert.match(unversioned, /\n<!-- dembrandt -->\n$/);
+});

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -163,6 +163,12 @@ test('generateDesignMd ends with a dembrandt attribution comment', () => {
   const rendererVersion = generateDesignMd({ url: 'https://attribution.example' }, { version: '1.2.3' });
   assert.match(rendererVersion, /\n<!-- dembrandt v1\.2\.3 -->\n$/);
 
+  const extractorWins = generateDesignMd(
+    { url: 'https://attribution.example', meta: { dembrandtVersion: '9.9.9' } },
+    { version: '1.2.3' },
+  );
+  assert.match(extractorWins, /\n<!-- dembrandt v9\.9\.9 -->\n$/);
+
   const unversioned = generateDesignMd({ url: 'https://attribution.example' });
   assert.match(unversioned, /\n<!-- dembrandt -->\n$/);
 });

--- a/test/tailwind.test.ts
+++ b/test/tailwind.test.ts
@@ -317,3 +317,20 @@ test('generateTailwindTheme degrades to a valid file on an empty extraction', ()
 test('the targeted Tailwind major is pinned so tailwind:check can detect drift', () => {
   assert.equal(TAILWIND_TARGET_MAJOR, 4);
 });
+
+test('theme header stamps the renderer version when the extraction carries no meta', () => {
+  const bare: TailwindThemeInput = { ...sample, meta: undefined };
+  const withMeta = generateTailwindTheme({ ...sample, meta: { dembrandtVersion: '0.0.1' } });
+  assert.match(withMeta, /^ \* dembrandt v0\.0\.1$/m);
+
+  const rendered = generateTailwindTheme(bare, { version: '1.2.3' });
+  assert.match(rendered, /^ \* dembrandt v1\.2\.3$/m);
+
+  const optionWins = generateTailwindTheme(
+    { ...sample, meta: { dembrandtVersion: '0.0.1' } },
+    { version: '1.2.3' },
+  );
+  assert.match(optionWins, /^ \* dembrandt v1\.2\.3$/m);
+
+  assert.doesNotMatch(generateTailwindTheme(bare), /dembrandt v/);
+});

--- a/test/tailwind.test.ts
+++ b/test/tailwind.test.ts
@@ -318,7 +318,7 @@ test('the targeted Tailwind major is pinned so tailwind:check can detect drift',
   assert.equal(TAILWIND_TARGET_MAJOR, 4);
 });
 
-test('theme header stamps the renderer version when the extraction carries no meta', () => {
+test('theme header falls back to the renderer version only when the extraction carries none', () => {
   const bare: TailwindThemeInput = { ...sample, meta: undefined };
   const withMeta = generateTailwindTheme({ ...sample, meta: { dembrandtVersion: '0.0.1' } });
   assert.match(withMeta, /^ \* dembrandt v0\.0\.1$/m);
@@ -326,11 +326,11 @@ test('theme header stamps the renderer version when the extraction carries no me
   const rendered = generateTailwindTheme(bare, { version: '1.2.3' });
   assert.match(rendered, /^ \* dembrandt v1\.2\.3$/m);
 
-  const optionWins = generateTailwindTheme(
+  const extractorWins = generateTailwindTheme(
     { ...sample, meta: { dembrandtVersion: '0.0.1' } },
     { version: '1.2.3' },
   );
-  assert.match(optionWins, /^ \* dembrandt v1\.2\.3$/m);
+  assert.match(extractorWins, /^ \* dembrandt v0\.0\.1$/m);
 
   assert.doesNotMatch(generateTailwindTheme(bare), /dembrandt v/);
 });


### PR DESCRIPTION
Exports carry the emitting version unevenly today, which makes a version mismatch awkward to trace: a DESIGN.md or a theme file turns up in a bug report and the release behind it has to be guessed from the token values.

- Every format stamps tool name and version, in the shape its own spec already allows, so nothing downstream has to change to read it.
- `meta.dembrandtVersion` records the release that extracted and is nullable by contract, so adapted or inline extractions stamped nothing. Formatters now prefer `options.version`, matching what the html formatter already did.
- Extractor version and renderer version still share one field. That is fine for a file on disk, less fine for anything that stores extractions and re-renders them later, but splitting them is a schema bump and can wait.