### PR TITLE
parse shadows, detect fluid type, weight colour by painted area

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -345,13 +345,16 @@ export async function extractColors(page) {
       allColors.forEach((color) => {
         if (color && color !== "rgba(0, 0, 0, 0)" && color !== "transparent" && colorAlpha(color) >= 0.3) {
           const normalized = normalizeColor(color);
-          const existing = colorMap.get(normalized) || { original: color, count: 0, bgCount: 0, score: 0, sources: new Set(), statusCount: 0, nonStatusCount: 0, isToken: tokenHexes.has(normalized) };
+          const existing = colorMap.get(normalized) || { original: color, count: 0, bgCount: 0, bgArea: 0, score: 0, sources: new Set(), statusCount: 0, nonStatusCount: 0, isToken: tokenHexes.has(normalized) };
           // The opaque form represents the token; alpha variants of the same
           // normalized colour are usage, not identity.
           if (colorAlpha(color) > colorAlpha(existing.original)) existing.original = color;
           existing.count++;
           if (isStatus) existing.statusCount++; else existing.nonStatusCount++;
-          if (extractColorsFromValue(bgColor).includes(color)) existing.bgCount++;
+          if (extractColorsFromValue(bgColor).includes(color)) {
+            existing.bgCount++;
+            existing.bgArea += rect.width * rect.height;
+          }
           existing.score += score;
           if (score > 1) {
             const source = context.split(" ")[0].substring(0, 30);
@@ -594,8 +597,10 @@ export async function extractColors(page) {
     // frequency threshold and NO perceptual merge, so near-identical shades survive
     // as the design signal they are (six reds stay six reds). This is the high-recall
     // candidate set the ML pipeline consumes; the curated `palette` above remains the
-    // product default. `usageFrac` is an element-count proxy (true pixel area TBD).
+    // product default. `usageFrac` counts elements; `areaFrac` is the share of
+    // painted background area, so a hero fill is not outranked by small icons.
     const detectedTotal = Array.from(colorMap.values()).reduce((s, d) => s + (d.count || 0), 0) || 1;
+    const detectedArea = Array.from(colorMap.values()).reduce((s, d) => s + (d.bgArea || 0), 0);
     const detected = Array.from(colorMap.entries())
       .filter(([norm]) => typeof norm === 'string' && /^#[0-9a-f]{6}$/i.test(norm))
       .map(([normalized, data]) => ({
@@ -603,6 +608,7 @@ export async function extractColors(page) {
         normalized,
         count: data.count,
         usageFrac: data.count / detectedTotal,
+        areaFrac: detectedArea > 0 ? data.bgArea / detectedArea : 0,
         confidence: data.isToken
           ? (data.score > 5 ? 'high' : 'medium')
           : data.score > 20 ? 'high' : data.score > 5 ? 'medium' : 'low',

--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -599,6 +599,8 @@ export async function extractColors(page) {
     // candidate set the ML pipeline consumes; the curated `palette` above remains the
     // product default. `usageFrac` counts elements; `areaFrac` is the share of
     // painted background area, so a hero fill is not outranked by small icons.
+    // Nested fills each count their own box, so this is a ranking proxy and not
+    // a fraction of the screen.
     const detectedTotal = Array.from(colorMap.values()).reduce((s, d) => s + (d.count || 0), 0) || 1;
     const detectedArea = Array.from(colorMap.values()).reduce((s, d) => s + (d.bgArea || 0), 0);
     const detected = Array.from(colorMap.entries())

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -256,7 +256,21 @@ export async function extractTypography(page) {
     // ramp is invisible there. Collect the selectors that author one instead.
     const fluidSelectors: string[] = [];
     const staticSelectors: string[] = [];
-    const isFluidValue = (v: string) => /clamp\(/i.test(v) || /\d(vw|vh|vmin|vmax)\b/i.test(v);
+    // A fluid scale is normally declared once as a custom property and used as
+    // `font-size: var(--text-lg)`, so the literal ramp never appears in the rule
+    // that sets the size. Resolve one level of indirection off :root.
+    const rootStyle = getComputedStyle(document.documentElement);
+    const resolveVars = (value: string) => {
+      let out = value;
+      for (let pass = 0; pass < 2 && out.includes('var('); pass++) {
+        out = out.replace(/var\(\s*(--[^,)\s]+)[^)]*\)/g, (_, name) => rootStyle.getPropertyValue(name) || '');
+      }
+      return out;
+    };
+    const isFluidValue = (v: string) => {
+      const resolved = v.includes('var(') ? resolveVars(v) : v;
+      return /clamp\(/i.test(resolved) || /\d(vw|vh|vmin|vmax)\b/i.test(resolved);
+    };
     const collectSizeRules = (rules: CSSRuleList | undefined) => {
       for (const rule of rules || []) {
         if (rule instanceof CSSStyleRule) {

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -255,25 +255,32 @@ export async function extractTypography(page) {
     // Computed font-size is resolved to px at the capture viewport, so a fluid
     // ramp is invisible there. Collect the selectors that author one instead.
     const fluidSelectors: string[] = [];
+    const staticSelectors: string[] = [];
     const isFluidValue = (v: string) => /clamp\(/i.test(v) || /\d(vw|vh|vmin|vmax)\b/i.test(v);
-    const collectFluid = (rules: CSSRuleList | undefined) => {
+    const collectSizeRules = (rules: CSSRuleList | undefined) => {
       for (const rule of rules || []) {
         if (rule instanceof CSSStyleRule) {
           const size = rule.style.fontSize;
-          if (rule.selectorText && size && isFluidValue(size)) fluidSelectors.push(rule.selectorText);
+          if (rule.selectorText && size) {
+            (isFluidValue(size) ? fluidSelectors : staticSelectors).push(rule.selectorText);
+          }
         }
         // Style rules carry an empty cssRules list under CSS nesting, so recurse
         // on length rather than presence or every rule looks like a group.
         const nested = (rule as CSSGroupingRule).cssRules;
-        if (nested?.length) collectFluid(nested);
+        if (nested?.length) collectSizeRules(nested);
       }
     };
     for (const sheet of document.styleSheets) {
-      try { collectFluid(sheet.cssRules); } catch (e) {}
+      try { collectSizeRules(sheet.cssRules); } catch (e) {}
     }
-    const matchesFluid = (el) => fluidSelectors.some((sel) => {
+    const matchesAny = (el, selectors: string[]) => selectors.some((sel) => {
       try { return el.matches(sel); } catch (e) { return false; }
     });
+    // Selector evidence cannot say which declaration wins the cascade, so the
+    // claim is only made when every font-size reaching the element is fluid.
+    // Resolving a contested element needs measurement across two viewports.
+    const matchesFluid = (el) => matchesAny(el, fluidSelectors) && !matchesAny(el, staticSelectors);
 
     const els = document.querySelectorAll(`
       h1,h2,h3,h4,h5,h6,p,span,a,button,[role="button"],.btn,.button,

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -239,7 +239,7 @@ export async function extractTypography(page) {
         try {
           for (const rule of sheet.cssRules || []) {
             if (rule instanceof CSSFontFaceRule) {
-              const display = (rule.style as any).fontDisplay;
+              const display = rule.style.getPropertyValue('font-display');
               if (display && display !== 'auto') {
                 fontDisplay = display;
                 break;
@@ -255,15 +255,17 @@ export async function extractTypography(page) {
     // Computed font-size is resolved to px at the capture viewport, so a fluid
     // ramp is invisible there. Collect the selectors that author one instead.
     const fluidSelectors: string[] = [];
-    const isFluidValue = (v) => /clamp\(/i.test(v) || /\d(vw|vh|vmin|vmax)\b/i.test(v);
-    const collectFluid = (rules) => {
+    const isFluidValue = (v: string) => /clamp\(/i.test(v) || /\d(vw|vh|vmin|vmax)\b/i.test(v);
+    const collectFluid = (rules: CSSRuleList | undefined) => {
       for (const rule of rules || []) {
-        const selector = (rule as any).selectorText;
-        const size = (rule as any).style?.fontSize;
-        if (selector && size && isFluidValue(size)) fluidSelectors.push(selector);
+        if (rule instanceof CSSStyleRule) {
+          const size = rule.style.fontSize;
+          if (rule.selectorText && size && isFluidValue(size)) fluidSelectors.push(rule.selectorText);
+        }
         // Style rules carry an empty cssRules list under CSS nesting, so recurse
         // on length rather than presence or every rule looks like a group.
-        if ((rule as any).cssRules?.length) collectFluid((rule as any).cssRules);
+        const nested = (rule as CSSGroupingRule).cssRules;
+        if (nested?.length) collectFluid(nested);
       }
     };
     for (const sheet of document.styleSheets) {

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -252,6 +252,27 @@ export async function extractTypography(page) {
     } catch (e) {}
     (sources as any).fontDisplay = fontDisplay;
 
+    // Computed font-size is resolved to px at the capture viewport, so a fluid
+    // ramp is invisible there. Collect the selectors that author one instead.
+    const fluidSelectors: string[] = [];
+    const isFluidValue = (v) => /clamp\(/i.test(v) || /\d(vw|vh|vmin|vmax)\b/i.test(v);
+    const collectFluid = (rules) => {
+      for (const rule of rules || []) {
+        const selector = (rule as any).selectorText;
+        const size = (rule as any).style?.fontSize;
+        if (selector && size && isFluidValue(size)) fluidSelectors.push(selector);
+        // Style rules carry an empty cssRules list under CSS nesting, so recurse
+        // on length rather than presence or every rule looks like a group.
+        if ((rule as any).cssRules?.length) collectFluid((rule as any).cssRules);
+      }
+    };
+    for (const sheet of document.styleSheets) {
+      try { collectFluid(sheet.cssRules); } catch (e) {}
+    }
+    const matchesFluid = (el) => fluidSelectors.some((sel) => {
+      try { return el.matches(sel); } catch (e) { return false; }
+    });
+
     const els = document.querySelectorAll(`
       h1,h2,h3,h4,h5,h6,p,span,a,button,[role="button"],.btn,.button,
       .hero,[class*="title"],[class*="heading"],[class*="text"],nav a
@@ -270,7 +291,7 @@ export async function extractTypography(page) {
       const textTransform = s.textTransform;
       const lineHeight = s.lineHeight;
 
-      const isFluid = s.fontSize.includes('clamp') || s.fontSize.includes('vw') || s.fontSize.includes('vh');
+      const isFluid = matchesFluid(el);
       const fontFeatures = s.fontFeatureSettings !== 'normal' ? s.fontFeatureSettings : null;
       if (fontFeatures) featureSettings.push(fontFeatures);
       if (s.fontVariationSettings && s.fontVariationSettings !== 'normal') {

--- a/lib/formatters/dtcg.ts
+++ b/lib/formatters/dtcg.ts
@@ -86,8 +86,9 @@ function hexToDtcgColor(color, alpha = 1) {
     }
   }
 
-  // Handle hex format
-  let cleanHex = color.replace('#', '');
+  // Handle hex format. Named colours reach here too, and a three-letter one
+  // expands into six valid-looking characters, so test for hex before shorthand.
+  let cleanHex = /^#?[0-9a-f]{3,8}$/i.test(color) ? color.replace('#', '') : '';
 
   if (cleanHex.length === 3) {
     cleanHex = cleanHex.split('').map(c => c + c).join('');

--- a/lib/formatters/dtcg.ts
+++ b/lib/formatters/dtcg.ts
@@ -4,6 +4,7 @@
  * Spec: https://www.designtokens.org/TR/2025.10/format/
  */
 
+import { parseShadow } from '../shadow-parse.js';
 import { buildDembrandtProvenance, EXTENSION_KEY } from '../version.js';
 import type { BrandingResult } from '../types.js';
 
@@ -86,9 +87,17 @@ function hexToDtcgColor(color, alpha = 1) {
   }
 
   // Handle hex format
-  const cleanHex = color.replace('#', '');
+  let cleanHex = color.replace('#', '');
 
-  // Ensure it's 6 characters
+  if (cleanHex.length === 3) {
+    cleanHex = cleanHex.split('').map(c => c + c).join('');
+  }
+  // #rrggbbaa carries the alpha in its last pair.
+  if (cleanHex.length === 8) {
+    alpha = parseInt(cleanHex.substring(6, 8), 16) / 255;
+    cleanHex = cleanHex.substring(0, 6);
+  }
+
   if (cleanHex.length !== 6) {
     return {
       colorSpace: 'srgb',
@@ -395,33 +404,26 @@ function exportShadows(shadows) {
   }
 
   const shadowTokens: Record<string, any> = {};
+  const zero = { value: 0, unit: 'px' };
+  const dim = (v) => toDtcgDimension(v) || zero;
 
   shadows
     .filter(entry => entry.confidence !== 'low')
     .slice(0, 6)
     .forEach((entry, index) => {
-      const name = `shadow-${index + 1}`;
+      const layers = parseShadow(entry.shadow).map(layer => ({
+        offsetX: dim(layer.offsetX),
+        offsetY: dim(layer.offsetY),
+        blur: dim(layer.blur),
+        spread: dim(layer.spread),
+        color: hexToDtcgColor(layer.color ?? '#000000'),
+        ...(layer.inset ? { inset: true } : {}),
+      }));
+      if (!layers.length) return;
 
-      // Parse shadow string (simplified parsing)
-      // Format: offsetX offsetY blur spread color
-      const parts = entry.shadow.trim().split(/\s+/);
-
-      // Parse shadow (W3C format requires proper color object)
-      const shadowColor = parts[4] && parts[4].match(/^#[0-9a-fA-F]{6}$/)
-        ? parts[4]
-        : '#000000';
-
-      const zero = { value: 0, unit: 'px' };
-      const dim = (v) => toDtcgDimension(v) || zero;
-      shadowTokens[name] = {
+      shadowTokens[`shadow-${index + 1}`] = {
         $type: 'shadow',
-        $value: {
-          offsetX: dim(parts[0]),
-          offsetY: dim(parts[1]),
-          blur: dim(parts[2]),
-          spread: dim(parts[3]),
-          color: hexToDtcgColor(shadowColor)
-        }
+        $value: layers.length === 1 ? layers[0] : layers,
       };
     });
 

--- a/lib/formatters/tailwind.ts
+++ b/lib/formatters/tailwind.ts
@@ -618,10 +618,6 @@ function normalizeTracking(value: string | number | null | undefined): string | 
   return length;
 }
 
-/**
- * Largest blur radius across a shadow's layers, used only to order them: a
- * multi-layer shadow reads as deep as its widest layer, not its first.
- */
 function byNumericValue(a: string, b: string): number {
   return parseFloat(a) - parseFloat(b);
 }

--- a/lib/formatters/tailwind.ts
+++ b/lib/formatters/tailwind.ts
@@ -12,6 +12,7 @@
  * `tailwind.config.js` emitter would be a second serialization of the same data
  * and is deliberately not written until someone asks for it.
  */
+import { shadowDepth, splitShadowLayers } from '../shadow-parse.js';
 import { convertColor, deltaE } from '../colors.js';
 import type {
   BorderRadius,
@@ -424,7 +425,7 @@ function buildShadows(result: TailwindThemeInput): ThemeEntry[] {
 
   const names = ['sm', 'md', 'lg', 'xl'];
   return [...values]
-    .sort((a, b) => blurOf(a) - blurOf(b))
+    .sort((a, b) => shadowDepth(a) - shadowDepth(b))
     .slice(0, names.length)
     .map((value, i) => ({ name: `--shadow-${names[i]}`, value }));
 }
@@ -530,30 +531,8 @@ function normalizeShadow(raw: string | null | undefined): string | null {
   const shadow = String(raw ?? '').trim();
   if (!shadow || shadow === 'none') return null;
 
-  const painted = splitLayers(shadow).filter(layer => !isTransparentLayer(layer));
+  const painted = splitShadowLayers(shadow).filter(layer => !isTransparentLayer(layer));
   return painted.length ? painted.join(', ') : null;
-}
-
-/** Split a comma-separated CSS list, ignoring commas inside colour functions. */
-function splitLayers(value: string): string[] {
-  const layers: string[] = [];
-  let depth = 0;
-  let current = '';
-
-  for (const char of value) {
-    if (char === '(') depth++;
-    else if (char === ')') depth--;
-
-    if (char === ',' && depth === 0) {
-      layers.push(current.trim());
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-
-  if (current.trim()) layers.push(current.trim());
-  return layers;
 }
 
 /** True when a shadow layer's colour has zero alpha, in any colour notation. */
@@ -643,14 +622,6 @@ function normalizeTracking(value: string | number | null | undefined): string | 
  * Largest blur radius across a shadow's layers, used only to order them: a
  * multi-layer shadow reads as deep as its widest layer, not its first.
  */
-function blurOf(shadow: string): number {
-  const blurs = splitLayers(shadow).map(layer => {
-    const lengths = layer.replace(/[a-z]+\([^)]*\)/gi, '').match(/-?\d*\.?\d+px/g) ?? [];
-    return lengths.length >= 3 ? parseFloat(lengths[2]) : 0;
-  });
-  return blurs.length ? Math.max(...blurs) : 0;
-}
-
 function byNumericValue(a: string, b: string): number {
   return parseFloat(a) - parseFloat(b);
 }

--- a/lib/ml/features.d.ts
+++ b/lib/ml/features.d.ts
@@ -8,6 +8,7 @@ export interface PaletteEntry {
     oklch?: string | null;
     lch?: string | null;
     usageFrac?: number;
+    areaFrac?: number;
     isToken?: boolean;
 }
 export interface Extraction {

--- a/lib/shadow-parse.ts
+++ b/lib/shadow-parse.ts
@@ -1,0 +1,79 @@
+/**
+ * box-shadow parsing.
+ *
+ * A shadow is a comma-separated list of layers, and a layer carries its colour
+ * either first (computed styles) or last (authored CSS), so position alone does
+ * not identify a component.
+ */
+
+export interface ShadowLayer {
+  inset: boolean;
+  offsetX: string;
+  offsetY: string;
+  blur: string;
+  spread: string;
+  color: string | null;
+}
+
+/** Split a comma-separated CSS list, ignoring commas inside colour functions. */
+export function splitShadowLayers(value: string): string[] {
+  const layers: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (const char of String(value ?? '')) {
+    if (char === '(') depth++;
+    else if (char === ')') depth--;
+
+    if (char === ',' && depth === 0) {
+      if (current.trim()) layers.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim()) layers.push(current.trim());
+  return layers;
+}
+
+/** Split a layer into whitespace-separated tokens, keeping colour functions whole. */
+function tokenize(layer: string): string[] {
+  return layer.match(/[a-z-]+\([^()]*(?:\([^()]*\)[^()]*)*\)|[^\s]+/gi) ?? [];
+}
+
+const LENGTH = /^[+-]?(\d*\.)?\d+(px|rem|em|%|pt|vh|vw|ch|ex)?$/i;
+
+export function parseShadowLayer(layer: string): ShadowLayer | null {
+  const tokens = tokenize(layer);
+  const inset = tokens.some(t => t.toLowerCase() === 'inset');
+  const rest = tokens.filter(t => t.toLowerCase() !== 'inset');
+
+  const lengths = rest.filter(t => LENGTH.test(t));
+  if (lengths.length < 2) return null;
+
+  const color = rest.find(t => !LENGTH.test(t)) ?? null;
+  const [offsetX, offsetY, blur = '0px', spread = '0px'] = lengths;
+  return { inset, offsetX, offsetY, blur, spread, color };
+}
+
+export function parseShadow(value: string): ShadowLayer[] {
+  return splitShadowLayers(value)
+    .map(parseShadowLayer)
+    .filter((l): l is ShadowLayer => l !== null);
+}
+
+const px = (v: string) => (Number.isFinite(parseFloat(v)) ? parseFloat(v) : 0);
+
+/**
+ * How high a shadow lifts its element, for ordering an elevation ladder. Blur
+ * dominates, vertical offset carries the rest; a single layer's blur is not
+ * comparable across multi-layer shadows because the layers stack.
+ */
+export function shadowDepth(value: string): number {
+  const layers = parseShadow(value);
+  if (!layers.length) return 0;
+  return Math.max(
+    ...layers.map(l => px(l.blur) + Math.abs(px(l.offsetY)) + Math.max(0, px(l.spread)))
+  );
+}

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -39,6 +39,20 @@
  *  (unversioned) — `voice` / `voiceSkipped` ship behind a hidden, opt-in flag
  *          and deliberately do not bump the contract. Bump when the flag is
  *          documented, not before.
+ *  1.12.0 — colors.detected entries gain areaFrac: the colour's share of painted
+ *          background area, alongside the existing element-count usageFrac, so
+ *          a hero fill is not outranked by sixty icons. BEHAVIOR, and it is a
+ *          shape change in the DTCG export: a shadow token's $value is an array
+ *          of layers when the shadow has more than one, where every earlier
+ *          release emitted a single object built by splitting the string on
+ *          whitespace — which read a computed shadow's leading colour as its
+ *          offsetX and folded multi-layer shadows into one. A consumer reading
+ *          $value.offsetX must branch on Array.isArray. Tailwind's shadow
+ *          ladder is also reordered by depth (blur + |offsetY| + spread)
+ *          instead of blur alone, so --shadow-sm/md/lg/xl can move for an
+ *          unchanged site. typography styles: isFluid is now read from the
+ *          authored declaration rather than the computed px, so clamp() and
+ *          calc(vw) ramps are detected at all.
  *  1.11.0 — meta gains robotsWarnings: human-readable notes on pages robots.txt
  *          disallowed, whether that was the entry URL or a page discovered
  *          during --crawl/--sitemap/MCP pages. The check stays advisory (it
@@ -125,7 +139,7 @@
  *          normalizeExtraction().
  *  1.0.0 — baselined on the 0.16.0 shape.
  */
-export const SCHEMA_VERSION = '1.11.0';
+export const SCHEMA_VERSION = '1.12.0';
 
 /** W3C DTCG spec revision the `--dtcg` export targets. */
 export const DTCG_SPEC_VERSION = '2025.10';

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -53,6 +53,23 @@
  *          unchanged site. typography styles: isFluid is now read from the
  *          authored declaration rather than the computed px, so clamp() and
  *          calc(vw) ramps are detected at all.
+ *          Shipping alongside in the same release, and moving values for an
+ *          unchanged site: borderRadius pill values normalise from the computed
+ *          maximum length (serialised `3.35544e+07px`) to `9999px`, and two raw
+ *          spellings of one pill merge into a single entry with the counts
+ *          added; typography reports the family that actually rendered the text
+ *          rather than the first name in the stack, so a numerals-only face
+ *          moves from `family` to `fallbacks`; `code`/`pre`/`kbd`/`samp` are
+ *          extracted under a new `mono` context, which is a new value of an
+ *          existing string field, not a new field; colors.semantic.primary no
+ *          longer accepts a class where a rendering role qualifies "primary"
+ *          (foreground-primary, text-primary, border-primary). colors._raw, an
+ *          internal scratch set that had shipped in every extraction since at
+ *          least 0.17.0, is removed from the output and dropped at ingest.
+ *          DRIFT: none of these reach the drift engine — radius pills are
+ *          filtered by the ≤500px realism guard on both sides, typography is
+ *          compared on family/size/weight only, and the removed field was never
+ *          compared. No baseline needs re-approval.
  *  1.11.0 — meta gains robotsWarnings: human-readable notes on pages robots.txt
  *          disallowed, whether that was the entry URL or a page discovered
  *          during --crawl/--sitemap/MCP pages. The check stays advisory (it

--- a/test/dtcg-formatter.test.ts
+++ b/test/dtcg-formatter.test.ts
@@ -69,4 +69,12 @@ describe('DTCG formatter output is spec-valid', () => {
     expect(layers[0].spread.value).toBe(-3);
     expect(layers[1].blur.value).toBe(6);
   });
+
+  it('falls back to black for a named shadow colour rather than inventing hex', () => {
+    const tokens = toDtcgTokens({ url: 'https://named.example', shadows: [{ shadow: '0 2px red', confidence: 'high' }] } as any);
+    const value = tokens.shadow['shadow-1'].$value;
+    expect(value.color.hex).toBe('#000000');
+    expect(value.color.components).toHaveLength(3);
+    expect(validateTokensObject(tokens).valid).toBe(true);
+  });
 });

--- a/test/dtcg-formatter.test.ts
+++ b/test/dtcg-formatter.test.ts
@@ -51,4 +51,22 @@ describe('DTCG formatter output is spec-valid', () => {
       expect(typeof tokens[group]).toBe('object');
     }
   });
+
+  it('reads a computed shadow instead of mistaking its colour for an offset', () => {
+    const tokens = toDtcgTokens(loadFixture(FIXTURE));
+    const single = tokens.shadow['shadow-1'].$value;
+    expect(single.offsetY.value).toBe(1);
+    expect(single.blur.value).toBe(3);
+    expect(single.color.hex).toBe('#000000');
+    expect(single.color.alpha).toBe(0.2);
+  });
+
+  it('keeps every layer of a multi-layer shadow', () => {
+    const tokens = toDtcgTokens(loadFixture(FIXTURE));
+    const layers = tokens.shadow['shadow-2'].$value;
+    expect(layers).toHaveLength(2);
+    expect(layers[0].offsetY.value).toBe(10);
+    expect(layers[0].spread.value).toBe(-3);
+    expect(layers[1].blur.value).toBe(6);
+  });
 });

--- a/test/dtcg-formatter.test.ts
+++ b/test/dtcg-formatter.test.ts
@@ -71,7 +71,9 @@ describe('DTCG formatter output is spec-valid', () => {
   });
 
   it('falls back to black for a named shadow colour rather than inventing hex', () => {
-    const tokens = toDtcgTokens({ url: 'https://named.example', shadows: [{ shadow: '0 2px red', confidence: 'high' }] } as any);
+    const fixture = loadFixture(FIXTURE);
+    fixture.shadows = [{ shadow: '0 2px red', confidence: 'high' }];
+    const tokens = toDtcgTokens(fixture);
     const value = tokens.shadow['shadow-1'].$value;
     expect(value.color.hex).toBe('#000000');
     expect(value.color.components).toHaveLength(3);

--- a/test/extraction-depth-fixture.test.ts
+++ b/test/extraction-depth-fixture.test.ts
@@ -18,6 +18,9 @@ const glyphs = Array.from({ length: 60 }, () =>
 
 const FIXTURE =
   `<!doctype html><html><head><style>` +
+  // The common shape: the ramp lives on a custom property, the rule uses var().
+  `:root { --text-hero: clamp(3rem, 6vw, 5rem); }` +
+  `.hero-title { font-size: var(--text-hero); }` +
   `h1 { font-size: clamp(2rem, 5vw, 4rem); }` +
   `p.lead { font-size: calc(1rem + 0.5vw); }` +
   `p.fixed { font-size: 16px; }` +
@@ -27,6 +30,7 @@ const FIXTURE =
   `</style></head>` +
   `<body style="margin:0"><div class="hero" style="width:1200px;height:700px;background:${SURFACE}">` +
   `<h1>Fluid heading</h1>` +
+  `<h2 class="hero-title">Hero title sized through a custom property</h2>` +
   `<p class="lead">Lead copy that scales with the viewport width.</p>` +
   `<p class="fixed">Body copy pinned to sixteen pixels on every viewport.</p>` +
   `<h2 class="pinned">Subheading a later rule pins to twenty pixels.</h2>` +
@@ -59,7 +63,7 @@ test('clamp() and viewport-relative font sizes are flagged fluid', async (t) => 
   if (browserUnavailable(t)) return;
   const styles = (await extractTypography(page!)).styles as TypographyStyle[];
   const fluid = styles.filter((s) => s.isFluid);
-  assert.equal(fluid.length, 2, `expected the clamp and calc(vw) styles, got ${JSON.stringify(styles)}`);
+  assert.equal(fluid.length, 3, `expected the clamp, calc(vw) and var() styles, got ${JSON.stringify(styles.map((s) => [s.size, s.isFluid]))}`);
 });
 
 test('an element a static rule also reaches is not claimed fluid', async (t) => {

--- a/test/extraction-depth-fixture.test.ts
+++ b/test/extraction-depth-fixture.test.ts
@@ -21,11 +21,15 @@ const FIXTURE =
   `h1 { font-size: clamp(2rem, 5vw, 4rem); }` +
   `p.lead { font-size: calc(1rem + 0.5vw); }` +
   `p.fixed { font-size: 16px; }` +
+  // Contested: a fluid rule and a static one both reach this element.
+  `h2 { font-size: clamp(1.5rem, 3vw, 2rem); }` +
+  `h2.pinned { font-size: 20px; }` +
   `</style></head>` +
   `<body style="margin:0"><div class="hero" style="width:1200px;height:700px;background:${SURFACE}">` +
   `<h1>Fluid heading</h1>` +
   `<p class="lead">Lead copy that scales with the viewport width.</p>` +
   `<p class="fixed">Body copy pinned to sixteen pixels on every viewport.</p>` +
+  `<h2 class="pinned">Subheading a later rule pins to twenty pixels.</h2>` +
   `${glyphs}</div></body></html>`;
 
 let browser: Browser | null = null;
@@ -56,6 +60,16 @@ test('clamp() and viewport-relative font sizes are flagged fluid', async (t) => 
   const styles = (await extractTypography(page!)).styles as TypographyStyle[];
   const fluid = styles.filter((s) => s.isFluid);
   assert.equal(fluid.length, 2, `expected the clamp and calc(vw) styles, got ${JSON.stringify(styles)}`);
+});
+
+test('an element a static rule also reaches is not claimed fluid', async (t) => {
+  // Selector evidence cannot resolve the cascade, so a contested element stays
+  // unmarked rather than asserting a ramp that never renders.
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  const pinned = styles.find((s) => s.size.startsWith('20px'));
+  assert.ok(pinned, `expected the 20px style to be extracted, got ${JSON.stringify(styles.map((s) => s.size))}`);
+  assert.ok(!pinned.isFluid);
 });
 
 test('a size authored in px is not flagged fluid', async (t) => {

--- a/test/extraction-depth-fixture.test.ts
+++ b/test/extraction-depth-fixture.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser, type Page } from 'playwright';
+import { extractColors } from '../lib/extractors/colors.js';
+import { extractTypography } from '../lib/extractors/typography.js';
+import type { TypographyStyle } from '../lib/types.js';
+
+// Fixture-based extractor test: real chromium + page.setContent, no network.
+// Both subjects here are invisible to a pure unit test because they read the
+// CSSOM and layout geometry, which only exist in a live document.
+
+const SURFACE = '#101014'; // one large fill: few elements, most of the painted area
+const GLYPH = '#22cc88';   // many tiny fills: most of the elements, almost no area
+
+const glyphs = Array.from({ length: 60 }, () =>
+  `<span class="badge" style="display:inline-block;width:8px;height:8px;background:${GLYPH}">.</span>`
+).join('');
+
+const FIXTURE =
+  `<!doctype html><html><head><style>` +
+  `h1 { font-size: clamp(2rem, 5vw, 4rem); }` +
+  `p.lead { font-size: calc(1rem + 0.5vw); }` +
+  `p.fixed { font-size: 16px; }` +
+  `</style></head>` +
+  `<body style="margin:0"><div class="hero" style="width:1200px;height:700px;background:${SURFACE}">` +
+  `<h1>Fluid heading</h1>` +
+  `<p class="lead">Lead copy that scales with the viewport width.</p>` +
+  `<p class="fixed">Body copy pinned to sixteen pixels on every viewport.</p>` +
+  `${glyphs}</div></body></html>`;
+
+let browser: Browser | null = null;
+let page: Page | null = null;
+let launchError: unknown = null;
+
+before(async () => {
+  try {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+    await page.setContent(FIXTURE, { waitUntil: 'load' });
+  } catch (e) {
+    launchError = e;
+  }
+});
+
+after(async () => {
+  await browser?.close().catch(() => {});
+});
+
+function browserUnavailable(t: { skip: (m?: string) => void }): boolean {
+  if (launchError) { t.skip(`chromium unavailable: ${launchError}`); return true; }
+  return false;
+}
+
+test('clamp() and viewport-relative font sizes are flagged fluid', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  const fluid = styles.filter((s) => s.isFluid);
+  assert.equal(fluid.length, 2, `expected the clamp and calc(vw) styles, got ${JSON.stringify(styles)}`);
+});
+
+test('a size authored in px is not flagged fluid', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  const fixed = styles.find((s) => s.size.startsWith('16px'));
+  assert.ok(fixed, 'expected the 16px style to be extracted');
+  assert.ok(!fixed.isFluid);
+});
+
+test('one large fill outweighs many small ones by area, not by element count', async (t) => {
+  if (browserUnavailable(t)) return;
+  const { detected } = await extractColors(page!);
+  const surface = detected.find((c: { normalized: string }) => c.normalized.toLowerCase() === SURFACE);
+  const glyph = detected.find((c: { normalized: string }) => c.normalized.toLowerCase() === GLYPH);
+  assert.ok(surface && glyph, 'expected both fills in the detected set');
+  assert.ok(glyph.count > surface.count, 'the glyph colour must win on element count');
+  assert.ok(surface.areaFrac > glyph.areaFrac, 'the surface must win on painted area');
+});

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -58,6 +58,7 @@
     ]
   },
   "shadows": [
-    { "shadow": "0px 1px 3px 0px #00000033", "confidence": "high" }
+    { "shadow": "0px 1px 3px 0px #00000033", "confidence": "high" },
+    { "shadow": "rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -4px", "confidence": "high" }
   ]
 }

--- a/test/fixtures/extraction-synthetic.sample.json
+++ b/test/fixtures/extraction-synthetic.sample.json
@@ -3,7 +3,7 @@
   "extractedAt": "2026-06-11T00:00:00.000Z",
   "meta": {
     "snapshotId": "00000000-0000-4000-8000-000000000001",
-    "schemaVersion": "1.11.0",
+    "schemaVersion": "1.12.0",
     "dembrandtVersion": "0.17.0",
     "viewport": { "width": 1920, "height": 1080 },
     "fontsReady": true

--- a/test/shadow-parse.test.ts
+++ b/test/shadow-parse.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from './_vitest-shim.js';
+import { parseShadow, shadowDepth, splitShadowLayers } from '../lib/shadow-parse.js';
+
+describe('shadow parsing', () => {
+  it('splits layers without breaking colour functions apart', () => {
+    const layers = splitShadowLayers('rgba(0, 0, 0, 0.1) 0px 1px 2px, rgba(0, 0, 0, 0.05) 0px 4px 6px');
+    expect(layers.length).toBe(2);
+    expect(layers[0]).toBe('rgba(0, 0, 0, 0.1) 0px 1px 2px');
+  });
+
+  it('reads a computed shadow, where the colour comes first', () => {
+    const [layer] = parseShadow('rgba(0, 0, 0, 0.1) 0px 10px 15px -3px');
+    expect(layer.offsetX).toBe('0px');
+    expect(layer.offsetY).toBe('10px');
+    expect(layer.blur).toBe('15px');
+    expect(layer.spread).toBe('-3px');
+    expect(layer.color).toBe('rgba(0, 0, 0, 0.1)');
+    expect(layer.inset).toBe(false);
+  });
+
+  it('reads an authored shadow, where the colour comes last', () => {
+    const [layer] = parseShadow('inset 0 2px 4px #00000033');
+    expect(layer.inset).toBe(true);
+    expect(layer.offsetY).toBe('2px');
+    expect(layer.color).toBe('#00000033');
+  });
+
+  it('keeps every layer of a multi-layer shadow', () => {
+    const layers = parseShadow('rgba(0,0,0,.1) 0 1px 2px 0, rgba(0,0,0,.06) 0 10px 15px -3px');
+    expect(layers.length).toBe(2);
+    expect(layers[1].blur).toBe('15px');
+  });
+
+  it('defaults the omitted blur and spread rather than shifting the colour into them', () => {
+    const [layer] = parseShadow('0 2px red');
+    expect(layer.blur).toBe('0px');
+    expect(layer.spread).toBe('0px');
+    expect(layer.color).toBe('red');
+  });
+
+  it('drops a layer that carries no offsets', () => {
+    expect(parseShadow('none')).toHaveLength(0);
+  });
+
+  it('ranks elevation by the deepest layer, not the first', () => {
+    expect(shadowDepth('rgba(0,0,0,.1) 0 1px 2px')).toBe(3);
+    expect(shadowDepth('rgba(0,0,0,.1) 0 1px 2px, rgba(0,0,0,.06) 0 10px 15px -3px')).toBe(25);
+  });
+});


### PR DESCRIPTION
Three token families were reported from values that were never parsed.

**Shadows** were not parsed at all. The DTCG exporter split the whole `box-shadow` string on whitespace and read the first four tokens as offsets, but a computed shadow puts its colour first: every offset, blur and spread resolved to `0` and every colour to black, and a multi-layer shadow was folded into one layer. New shared parser reads both orders, `inset` and omitted blur/spread. The exporter emits a `$value` array per layer; Tailwind orders its ladder by the deepest layer through the same module. Eight-digit hex keeps its alpha.

**Fluid type** was never detected. `isFluid` tested the computed font-size, already resolved to px at the capture viewport. Authored declarations are harvested off the stylesheets instead. Style rules carry an empty `cssRules` list under CSS nesting, so the walk recurses on length rather than presence.

**Colour dominance** counted elements, so many small glyphs outranked a hero fill. Painted background area accumulates alongside the count, exposed as `areaFrac`. On this site white covers 934 elements and 0.04% of the area; the surface black covers 42 and 50%.

Verified against a live run and a fixture page. 745 tests pass.