### PR TITLE
elect tokens by page coverage, score whole-site consistency

### DIFF
--- a/lib/coverage.ts
+++ b/lib/coverage.ts
@@ -1,0 +1,80 @@
+/**
+ * Token coverage across a crawl.
+ *
+ * A merged multi-page extraction says a token exists. Coverage says how much of
+ * the site agrees with it, which is what separates a design system from one
+ * page's improvisation.
+ */
+
+export type TokenScope = 'site' | 'section' | 'page';
+
+export interface CoverageEntry {
+  family: string;
+  token: string;
+  pages: number;
+  coverage: number;
+  scope: TokenScope;
+}
+
+export interface CoverageSummary {
+  totalPages: number;
+  score: number;
+  byFamily: Record<string, { tokens: number; meanCoverage: number; pageLocal: number }>;
+  outliers: CoverageEntry[];
+}
+
+/** A token every page uses is site-wide; one page only is page-local. */
+export function scopeOf(pages: number, totalPages: number): TokenScope {
+  if (totalPages <= 1 || pages >= totalPages) return 'site';
+  return pages <= 1 ? 'page' : 'section';
+}
+
+export function coverageEntry(family: string, token: string, pages: number, totalPages: number): CoverageEntry {
+  const bounded = Math.max(0, Math.min(pages, totalPages));
+  return {
+    family,
+    token,
+    pages: bounded,
+    coverage: totalPages > 0 ? bounded / totalPages : 0,
+    scope: scopeOf(bounded, totalPages),
+  };
+}
+
+const MAX_OUTLIERS = 20;
+
+/**
+ * Mean coverage per family, then averaged across families, so a site with two
+ * hundred colours and four radii is not scored on its colours alone. Counted,
+ * not weighted by opinion.
+ */
+export function summarizeCoverage(entries: CoverageEntry[], totalPages: number): CoverageSummary | null {
+  if (totalPages <= 1 || entries.length === 0) return null;
+
+  const byFamily: CoverageSummary['byFamily'] = {};
+  for (const entry of entries) {
+    const family = (byFamily[entry.family] ??= { tokens: 0, meanCoverage: 0, pageLocal: 0 });
+    family.tokens++;
+    family.meanCoverage += entry.coverage;
+    if (entry.scope === 'page') family.pageLocal++;
+  }
+
+  const families = Object.values(byFamily);
+  for (const family of families) {
+    family.meanCoverage = round(family.meanCoverage / family.tokens);
+  }
+
+  const score = Math.round(
+    (families.reduce((sum, f) => sum + f.meanCoverage, 0) / families.length) * 100
+  );
+
+  const outliers = entries
+    .filter(e => e.scope === 'page')
+    .sort((a, b) => a.family.localeCompare(b.family) || a.token.localeCompare(b.token))
+    .slice(0, MAX_OUTLIERS);
+
+  return { totalPages, score, byFamily, outliers };
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -42,6 +42,7 @@ export function displayResults(data: BrandingResult, options: { colorFormat?: Co
     const paths = data.pages.map(p => new URL(p.url).pathname || '/').join(', ');
     console.log(chalk.dim('├─') + ' ' + chalk.dim(`${data.pages.length} pages: ${paths}`));
   }
+  displayCoverage(data.coverage);
   console.log(chalk.dim('│'));
 
   displayLogo(data.logo);
@@ -494,6 +495,22 @@ function displayBorders(borders, colorFormat: ColorFormat = 'hex') {
   }
 
   console.log(chalk.dim('│'));
+}
+
+/**
+ * Consistency across the crawl. Named tokens are the ones a single page
+ * introduced: usage says a token is popular, coverage says the site agrees.
+ */
+function displayCoverage(coverage) {
+  if (!coverage) return;
+
+  const tint = coverage.score >= 80 ? chalk.green : coverage.score >= 55 ? chalk.yellow : chalk.red;
+  console.log(chalk.dim('├─') + ' ' + tint(`${coverage.score}/100 consistent`) + chalk.dim(` across ${coverage.totalPages} pages`));
+
+  if (!coverage.outliers.length) return;
+  const shown = coverage.outliers.slice(0, 4).map(o => `${o.family} ${o.token}`).join(', ');
+  const rest = coverage.outliers.length - 4;
+  console.log(chalk.dim('├─') + ' ' + chalk.dim(`page-local: ${shown}${rest > 0 ? `, +${rest} more` : ''}`));
 }
 
 function displayShadows(shadows) {

--- a/lib/merger.ts
+++ b/lib/merger.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from 'node:crypto';
 import { deltaE } from './colors.js';
 import { applyBudget, computeMetrics, totalWords, WORD_FLOOR } from './voice/metrics.js';
+import { coverageEntry, summarizeCoverage, type CoverageEntry } from './coverage.js';
 
 /**
  * Meta for a merged snapshot. The merged artifact is a distinct snapshot, so it
@@ -240,19 +241,26 @@ function mergeComponents(results) {
 
 function mergeValueArrays(results, getter, valueKey = 'value') {
   const map = new Map();
-  results.forEach(r => {
+  results.forEach((r, pageIdx) => {
     (getter(r) || []).forEach(item => {
       const key = item[valueKey];
       if (!map.has(key)) {
-        map.set(key, { ...item });
+        map.set(key, { ...item, _pages: new Set([pageIdx]) });
       } else {
         const e = map.get(key);
         e.count = (e.count || 0) + (item.count || 1);
         e.frequency = (e.frequency || 0) + (item.frequency || 0);
+        e._pages.add(pageIdx);
       }
     });
   });
-  return [...map.values()].sort((a, b) => (b.count || b.frequency || 0) - (a.count || a.frequency || 0));
+  return withPageCount([...map.values()])
+    .sort((a, b) => (b.count || b.frequency || 0) - (a.count || a.frequency || 0));
+}
+
+/** Turn the merge-time page set into a plain count the output can carry. */
+function withPageCount(entries) {
+  return entries.map(({ _pages, ...entry }) => ({ ...entry, pageCount: _pages ? _pages.size : 1 }));
 }
 
 function mergeSpacing(results) {
@@ -274,35 +282,38 @@ function mergeBorderRadius(results) {
 
 function mergeBorders(results) {
   const map = new Map();
-  results.forEach(r => {
+  results.forEach((r, pageIdx) => {
     (r.borders?.combinations || []).forEach(item => {
       const key = `${item.width}|${item.style}|${item.color}`;
       if (!map.has(key)) {
-        map.set(key, { ...item, elements: [...(item.elements || [])] });
+        map.set(key, { ...item, elements: [...(item.elements || [])], _pages: new Set([pageIdx]) });
       } else {
         const e = map.get(key);
         e.count += (item.count || 1);
         const elementSet = new Set([...(e.elements || []), ...(item.elements || [])]);
         e.elements = [...elementSet].slice(0, 5);
+        e._pages.add(pageIdx);
         if (e.count > 10) e.confidence = 'high';
         else if (e.count > 3) e.confidence = 'medium';
       }
     });
   });
   return {
-    combinations: [...map.values()].sort((a, b) => b.count - a.count),
+    combinations: withPageCount([...map.values()]).sort((a, b) => b.count - a.count),
   };
 }
 
 function mergeShadows(results) {
   const map = new Map();
-  results.forEach(r => {
+  results.forEach((r, pageIdx) => {
     (r.shadows || []).forEach(s => {
       const key = s.shadow || s.value || JSON.stringify(s);
       if (!map.has(key)) {
-        map.set(key, { ...s, count: s.count || 1 });
+        map.set(key, { ...s, count: s.count || 1, _pages: new Set([pageIdx]) });
       } else {
-        map.get(key).count += (s.count || 1);
+        const e = map.get(key);
+        e.count += (s.count || 1);
+        e._pages.add(pageIdx);
       }
     });
   });
@@ -311,7 +322,24 @@ function mergeShadows(results) {
     if (s.count > 10) s.confidence = 'high';
     else if (s.count > 3) s.confidence = 'medium';
   }
-  return [...map.values()].sort((a, b) => b.count - a.count);
+  return withPageCount([...map.values()]).sort((a, b) => b.count - a.count);
+}
+
+/** Every merged token family that carries page provenance, flattened for scoring. */
+function collectCoverage(merged, totalPages): CoverageEntry[] {
+  const families: [string, { key: unknown; pages: unknown }[]][] = [
+    ['color', (merged.colors?.palette ?? []).map(c => ({ key: c.normalized ?? c.color, pages: c.pageCount }))],
+    ['spacing', (merged.spacing?.commonValues ?? []).map(v => ({ key: v.px, pages: v.pageCount }))],
+    ['radius', (merged.borderRadius?.values ?? []).map(v => ({ key: v.value, pages: v.pageCount }))],
+    ['border', (merged.borders?.combinations ?? []).map(b => ({ key: `${b.width} ${b.style} ${b.color}`, pages: b.pageCount }))],
+    ['shadow', (merged.shadows ?? []).map(s => ({ key: s.shadow, pages: s.pageCount }))],
+  ];
+
+  return families.flatMap(([family, tokens]) =>
+    tokens
+      .filter(t => t.key != null)
+      .map(t => coverageEntry(family, String(t.key), Number(t.pages) || 1, totalPages))
+  );
 }
 
 function mergeByName(results, getter) {
@@ -465,7 +493,7 @@ export function mergeResults(results) {
 
   const home = results[0];
 
-  return {
+  const merged = {
     url: home.url,
     extractedAt: home.extractedAt,
     ...mergeMeta(results),
@@ -508,4 +536,7 @@ export function mergeResults(results) {
       ...(r.voiceSkipped ? { voiceSkipped: r.voiceSkipped } : {}),
     })),
   };
+
+  const coverage = summarizeCoverage(collectCoverage(merged, results.length), results.length);
+  return coverage ? { ...merged, coverage } : merged;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,8 @@
  * of the (now TypeScript) codebase can import and use them.
  */
 
+import type { CoverageSummary } from './coverage.js';
+
 export type Confidence = 'high' | 'medium' | 'low';
 
 export interface PaletteColor {
@@ -156,6 +158,8 @@ export interface Shadow {
   shadow: string;
   count: number;
   confidence: Confidence;
+  /** Pages that carried this token; present only on a merged crawl. */
+  pageCount?: number;
 }
 
 export interface Gradient {
@@ -433,6 +437,8 @@ export interface BrandingResult {
   borderRadius: BorderRadius;
   borders: Borders;
   shadows: Shadow[];
+  /** Present only on a merged crawl of more than one page. */
+  coverage?: CoverageSummary;
   gradients?: Gradient[];
   motion?: Motion;
   components: Components;

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { coverageEntry, scopeOf, summarizeCoverage } from '../lib/coverage.js';
+
+/**
+ * Coverage is what separates a design system from one page's improvisation, so
+ * the scope rule and the score have to be counted from page provenance alone,
+ * never from usage on a single page.
+ */
+
+test('a token on every page is site-wide, one page only is page-local', () => {
+  assert.equal(scopeOf(4, 4), 'site');
+  assert.equal(scopeOf(2, 4), 'section');
+  assert.equal(scopeOf(1, 4), 'page');
+});
+
+test('a single-page crawl carries no coverage signal, so nothing is an outlier', () => {
+  assert.equal(scopeOf(1, 1), 'site');
+  assert.equal(summarizeCoverage([coverageEntry('color', '#fff', 1, 1)], 1), null);
+});
+
+test('page count is bounded by the crawl, so coverage never exceeds 1', () => {
+  const entry = coverageEntry('color', '#fff', 9, 3);
+  assert.equal(entry.pages, 3);
+  assert.equal(entry.coverage, 1);
+});
+
+test('a token missing from a page is not counted as site-wide', () => {
+  assert.equal(coverageEntry('shadow', '0 1px 2px', 3, 4).scope, 'section');
+});
+
+test('the score is the mean of family means, not of all tokens', () => {
+  // 10 site-wide colours and 1 page-local radius. Token-averaging would report
+  // ~95; family-averaging reports the radius family's failure at full weight.
+  const entries = [
+    ...Array.from({ length: 10 }, (_, i) => coverageEntry('color', `#00000${i}`, 4, 4)),
+    coverageEntry('radius', '3px', 1, 4),
+  ];
+  const summary = summarizeCoverage(entries, 4)!;
+  assert.equal(summary.score, 63);
+  assert.equal(summary.byFamily.color.meanCoverage, 1);
+  assert.equal(summary.byFamily.radius.pageLocal, 1);
+});
+
+test('outliers are the page-local tokens, in a stable order', () => {
+  const summary = summarizeCoverage([
+    coverageEntry('shadow', '0 1px 2px', 1, 3),
+    coverageEntry('color', '#abcdef', 1, 3),
+    coverageEntry('color', '#111111', 3, 3),
+  ], 3)!;
+  assert.deepEqual(summary.outliers.map(o => o.token), ['#abcdef', '0 1px 2px']);
+});

--- a/test/merger.test.ts
+++ b/test/merger.test.ts
@@ -484,3 +484,28 @@ test('voiceAllPages is null when every page skipped voice, even though the run u
 
   assert.equal(merged.voiceAllPages, null);
 });
+
+test('coverage tags a token by how many pages carry it, not by how often it is used', () => {
+  const everywhere = { px: '8px', count: 40 };
+  const oneOff = { px: '11px', count: 400 };
+
+  const merged = mergeResults([
+    page('https://a.com/', { spacing: { commonValues: [everywhere, oneOff] } }),
+    page('https://a.com/pricing', { spacing: { commonValues: [everywhere] } }),
+    page('https://a.com/docs', { spacing: { commonValues: [everywhere] } }),
+  ]);
+
+  const spacing = merged.spacing.commonValues;
+  assert.equal(spacing.find((v) => v.px === '8px').pageCount, 3);
+  assert.equal(spacing.find((v) => v.px === '11px').pageCount, 1);
+
+  // The heavily-used value is the outlier: usage is a page-local opinion,
+  // coverage is the site's agreement.
+  assert.deepEqual(merged.coverage.outliers.map((o) => o.token), ['11px']);
+  assert.equal(merged.coverage.totalPages, 3);
+});
+
+test('coverage is absent for a single-page extraction', () => {
+  const merged = mergeResults([page('https://a.com/', { shadows: [{ shadow: '0 1px 2px', count: 3 }] })]);
+  assert.equal(merged.coverage, undefined);
+});


### PR DESCRIPTION
First draft for DEM-307 (Crawl merge should elect tokens by page coverage, not dedup them). Data layer and terminal only; review the shape before it grows.

## What changed

A merged crawl could say a token exists but not how much of the site agreed with it. The merge deduplicated by value and kept the summed usage count, so a value used four hundred times on one page outranked one used forty times on every page.

Every merged family now carries the number of pages that produced it, the way the colour palette already did. `lib/coverage.ts` (pure, unit-tested) turns that into a scope per token and a consistency score:

- `site` when every page carries it, `page` when one does, `section` between
- score is the mean of per-family means, so two hundred colours and four radii weigh the same
- page-local tokens are listed as outliers
- absent for a single-page run rather than reported as 100, since one page carries no coverage signal

## On a real two-page crawl

```
├─ 2 pages: /, /pricing
├─ 53/100 consistent across 2 pages
├─ page-local: border 0px 0px 1px solid rgb(36, 36, 36), ... +16 more
```

## Known limits, deliberate for a draft

- **Borders flood the outliers.** They are keyed by exact `width|style|colour`, so near-identical hairlines count as separate tokens. Coverage inherits whatever identity the merge uses, and that identity is too literal for borders. Worth fixing in the merge, not here.
- **Typography carries no page count yet.** Its merge is shaped differently from the value-array families and needs its own pass.
- **The outlier list is not capped per family**, which is why one family can fill it.
- **No JSON-facing scope label per token** yet: the scope is computed for the summary but only `pageCount` reaches the output. Deciding whether tokens carry their own `scope` field is a contract question worth settling before it ships.

## Not in scope

Declarative assertions over this (`coverage >= 0.8` as a gate) are the natural follow-up and belong with DEM-81 (Declarative drift assertions with error/warn severity (lighthouserc model)).