### PR TITLE
robots: apply the group that governs us, and bind it in unattended runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,10 @@
-name: Nightly Liveness
+name: Weekly Liveness
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    # Weekly, not nightly: the engine does not regress in a day, and a daily
+    # scheduled fetch of third-party sites is a pattern their logs notice.
+    - cron: "0 3 * * 3"
   workflow_dispatch:
 
 permissions:
@@ -57,6 +59,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: nightly-liveness-${{ matrix.chunk }}
+          name: weekly-liveness-${{ matrix.chunk }}
           path: test/liveness-report.json
           retention-days: 30

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -48,7 +48,10 @@ jobs:
 
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The browser cache does not cover `--with-deps`, which installs ~21MB of
+    # font packages from apt on every run; a slow mirror alone has spent 10
+    # minutes there.
+    timeout-minutes: 16
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -106,11 +106,31 @@ A pipeline can branch on the exit code; "design drifted" and "extraction broke" 
 | `1` | Drift detected (`--compare`) |
 | `2` | Extraction failure (`EXTRACTION_FAILED`, `BROWSER_UNAVAILABLE`) |
 | `3` | Cloud sync failed under `--key`; the extraction itself succeeded |
+| `4` | Skipped: robots.txt refused the target, under `DEMBRANDT_ENFORCE_ROBOTS=1` |
 | `67` | Navigation/connection timeout (`NAVIGATION_TIMEOUT`), retryable, try `--slow` |
 
 With `--json-only`, a failure also prints a machine-readable `{ "error": { "code", "message" } }` to stdout.
 
 `3` exists so a pipeline can tell "this run was not recorded" apart from "the extractor is broken". Passing `--key` states an intent, and a run that could not meet it has not done what was asked, even though its output is valid: the payload was over the size limit, the key was rejected, or the API was unreachable. Reporting success there means drift tracking stops recording and nothing ever says so.
+
+## Unattended runs: `DEMBRANDT_ENFORCE_ROBOTS=1`
+
+By default a `robots.txt` disallow warns and the run continues. That is right when a person runs the CLI against a site they are responsible for: the tool has no standing to overrule them, and the warning is information rather than a gate.
+
+It is not right where nobody is deciding. Set `DEMBRANDT_ENFORCE_ROBOTS=1` in scheduled jobs, containers and any server-side use, and a disallow — or a `robots.txt` that cannot be read at all — skips the target with exit `4` before the browser is launched. Both the CLI and the MCP server honour it.
+
+Exit `4` is a decision by the site, not a failure of the run, so a job that iterates over URLs should count it separately from `2` rather than failing the build:
+
+```bash
+dembrandt "$url" --json-only || code=$?
+case "${code:-0}" in
+  0) ;;
+  4) echo "skipped by robots.txt: $url" ;;
+  *) failed=1 ;;
+esac
+```
+
+The group that applies is the one matching the User-Agent actually sent. A run that names itself (`--user-agent` containing `Dembrandt`) is matched against a `Dembrandt` group; anything else is matched against `*`, because that is the group governing it.
 
 **Rate limiting is not a sync failure.** Exceeding the account quota (20/hour, 200/day, 500/week) still warns and exits `0`, because hitting a quota is the system working as designed rather than a fault to fix, and a snapshot job should not turn a deploy pipeline red for it. A rejected key, an oversized payload or an unreachable API are the opposite: they need someone to act, and nobody acts on what nobody sees.
 

--- a/index.ts
+++ b/index.ts
@@ -150,7 +150,7 @@ program
 
     // One fetch per origin for the whole run: the entry check, the sitemap
     // directives and the crawl filter all read the same file.
-    let entryRobotsRules = await fetchRobotsRules(url, { agent: robotsAgent }).catch(
+    const entryRobotsRules = await fetchRobotsRules(url, { agent: robotsAgent }).catch(
       () => ({ status: "unavailable" }) as RobotsRules,
     );
 

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, robotsVerdict, ROBOTS_AGENT } from "./lib/robots.js";
+import { checkAgainstRules, fetchRobotsRules, filterAllowedUrls, robotsVerdict, ROBOTS_AGENT, type RobotsRules } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
@@ -36,6 +36,16 @@ import { guardWarnings, voiceNeedsOutputFile } from "./lib/cli-guards.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
+
+function sameOrigin(a: string, b: string): boolean {
+  try { return new URL(a).origin === new URL(b).origin; } catch { return false; }
+}
+
+/** robots.txt Sitemap: directives, but only for the origin they were read from. */
+function sitemapsFrom(rules: RobotsRules, targetUrl: string): string[] {
+  if (rules.status !== "ok" || !sameOrigin(rules.robotsUrl, targetUrl)) return [];
+  return rules.sitemaps;
+}
 
 /** A run that names itself can be allowed or refused by name in robots.txt. */
 function identifiesAsBot(userAgent: string | undefined): boolean {
@@ -138,9 +148,15 @@ program
     // Only the group matching the User-Agent we actually send applies to us.
     const robotsAgent = identifiesAsBot(opts.userAgent) ? ROBOTS_AGENT : "*";
 
+    // One fetch per origin for the whole run: the entry check, the sitemap
+    // directives and the crawl filter all read the same file.
+    let entryRobotsRules = await fetchRobotsRules(url, { agent: robotsAgent }).catch(
+      () => ({ status: "unavailable" }) as RobotsRules,
+    );
+
     let entryRobotsWarning = null;
     try {
-      const robots = await checkRobotsTxt(url, { agent: robotsAgent });
+      const robots = checkAgainstRules(url, entryRobotsRules);
       const verdict = robotsVerdict(robots, { enforce: enforceRobots });
 
       if (verdict.action === "refuse") {
@@ -286,9 +302,9 @@ program
             if (!opts.jsonOnly) spinner.start("Fetching sitemap...");
             const max = crawlN ? crawlN - 1 : 20;
             sitemapMax = max;
-            additionalUrls = await parseSitemap(result.url, max);
+            additionalUrls = await parseSitemap(result.url, max, sitemapsFrom(entryRobotsRules, result.url));
             if (additionalUrls.length === 0 && result.url !== url) {
-              additionalUrls = await parseSitemap(url, max);
+              additionalUrls = await parseSitemap(url, max, sitemapsFrom(entryRobotsRules, url));
             }
           } else if (isAutoCrawl) {
             additionalUrls = result._discoveredLinks || [];
@@ -297,7 +313,11 @@ program
           delete result._discoveredLinks;
 
           if (additionalUrls.length > 0) {
-            const robotsRules = await fetchRobotsRules(result.url, { agent: robotsAgent });
+            // A redirect can land on a different origin, whose robots.txt is a
+            // different file; reuse the entry rules only when the origin holds.
+            const robotsRules = sameOrigin(url, result.url)
+              ? entryRobotsRules
+              : await fetchRobotsRules(result.url, { agent: robotsAgent });
             const { allowed, disallowed } = filterAllowedUrls(additionalUrls, robotsRules);
             if (disallowed.length > 0) {
               if (!opts.jsonOnly) {

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls } from "./lib/robots.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, ROBOTS_AGENT } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
@@ -36,6 +36,15 @@ import { guardWarnings, voiceNeedsOutputFile } from "./lib/cli-guards.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
+
+/**
+ * A run that names itself in its User-Agent is addressable by the site: it can
+ * be allowed or refused by name in robots.txt, and blocked cleanly at the edge.
+ * Used to pick which robots.txt group actually governs the run.
+ */
+function identifiesAsBot(userAgent: string | undefined): boolean {
+  return !!userAgent && userAgent.toLowerCase().includes("dembrandt");
+}
 
 /**
  * ora options for a spinner on the given stream. The spinner animates only on
@@ -127,9 +136,28 @@ program
 
     const spinner = ora({ text: "Starting extraction...", ...spinnerOptions(opts.jsonOnly) }).start();
 
+    // Unattended runs (scheduled CI, any hosted path) have no user deciding what
+    // they have the right to fetch, so there the robots decision has to bind.
+    const enforceRobots = process.env.DEMBRANDT_ENFORCE_ROBOTS === "1";
+    // Only the group matching the User-Agent we actually send applies to us.
+    const robotsAgent = identifiesAsBot(opts.userAgent) ? ROBOTS_AGENT : "*";
+
     let entryRobotsWarning = null;
     try {
-      const robots = await checkRobotsTxt(url);
+      const robots = await checkRobotsTxt(url, { agent: robotsAgent });
+      const refused =
+        (robots.status === "ok" && robots.allowed === false) ||
+        (enforceRobots && robots.status === "unavailable");
+
+      if (enforceRobots && refused) {
+        const why =
+          robots.status === "ok"
+            ? `robots.txt disallows this path (rule: "${robots.rule}")`
+            : "robots.txt could not be read";
+        spinner.fail(`${why}. Skipping ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).`);
+        process.exit(EXIT.ROBOTS_DENIED);
+      }
+
       if (robots.status === "ok" && robots.allowed === false) {
         entryRobotsWarning = `robots.txt disallows ${url} (rule: "${robots.rule}")`;
         spinner.warn(
@@ -281,7 +309,7 @@ program
           delete result._discoveredLinks;
 
           if (additionalUrls.length > 0) {
-            const robotsRules = await fetchRobotsRules(result.url);
+            const robotsRules = await fetchRobotsRules(result.url, { agent: robotsAgent });
             const { allowed, disallowed } = filterAllowedUrls(additionalUrls, robotsRules);
             if (disallowed.length > 0) {
               if (!opts.jsonOnly) {

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, ROBOTS_AGENT } from "./lib/robots.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, robotsVerdict, ROBOTS_AGENT } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
@@ -141,25 +141,17 @@ program
     let entryRobotsWarning = null;
     try {
       const robots = await checkRobotsTxt(url, { agent: robotsAgent });
-      const refused =
-        (robots.status === "ok" && robots.allowed === false) ||
-        (enforceRobots && robots.status === "unavailable");
+      const verdict = robotsVerdict(robots, { enforce: enforceRobots });
 
-      if (enforceRobots && refused) {
-        const why =
-          robots.status === "ok"
-            ? `robots.txt disallows this path (rule: "${robots.rule}")`
-            : "robots.txt could not be read";
-        spinner.fail(`${why}. Skipping ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).`);
+      if (verdict.action === "refuse") {
+        spinner.fail(`${verdict.reason}. Skipping ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).`);
         process.exit(EXIT.ROBOTS_DENIED);
       }
 
-      if (robots.status === "ok" && robots.allowed === false) {
-        entryRobotsWarning = `robots.txt disallows ${url} (rule: "${robots.rule}")`;
+      if (verdict.action === "warn") {
+        entryRobotsWarning = `robots.txt disallows ${url} (rule: "${verdict.rule}")`;
         spinner.warn(
-          chalk.hex("#FFB86C")(
-            `robots.txt disallows this path (rule: "${robots.rule}"). Proceeding anyway — respect the site's terms.`
-          )
+          chalk.hex("#FFB86C")(`${verdict.reason}. Proceeding anyway — respect the site's terms.`)
         );
         spinner.start("Starting extraction...");
       }

--- a/index.ts
+++ b/index.ts
@@ -37,11 +37,7 @@ import { guardWarnings, voiceNeedsOutputFile } from "./lib/cli-guards.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
 
-/**
- * A run that names itself in its User-Agent is addressable by the site: it can
- * be allowed or refused by name in robots.txt, and blocked cleanly at the edge.
- * Used to pick which robots.txt group actually governs the run.
- */
+/** A run that names itself can be allowed or refused by name in robots.txt. */
 function identifiesAsBot(userAgent: string | undefined): boolean {
   return !!userAgent && userAgent.toLowerCase().includes("dembrandt");
 }

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -114,8 +114,11 @@ const FETCH_OPTS = {
  * Discover sitemap URLs by checking robots.txt first, then common paths.
  * Returns the first sitemap XML that responds successfully.
  */
-async function findSitemapUrls(origin) {
-  // 1. Check robots.txt for Sitemap: directives
+async function findSitemapUrls(origin, knownSitemaps: string[] = []) {
+  // 1. Sitemap: directives. The caller has usually already read robots.txt for
+  // the same origin, so re-reading it is a second request for one file.
+  if (knownSitemaps.length > 0) return knownSitemaps;
+
   try {
     const res = await fetch(`${origin}/robots.txt`, {
       ...FETCH_OPTS,
@@ -162,13 +165,14 @@ async function fetchSitemap(url) {
  *
  * @param {string} baseUrl - The starting URL (should be post-redirect)
  * @param {number} maxPages - Maximum number of URLs to return
+ * @param {string[]} knownSitemaps - Sitemap: directives already read from robots.txt
  * @returns {Promise<string[]>} List of URLs from sitemap (excluding homepage)
  */
-export async function parseSitemap(baseUrl, maxPages) {
+export async function parseSitemap(baseUrl, maxPages, knownSitemaps: string[] = []) {
   const base = new URL(baseUrl);
 
   // Find and fetch sitemap(s)
-  const candidates = await findSitemapUrls(base.origin);
+  const candidates = await findSitemapUrls(base.origin, knownSitemaps);
   let xml = '';
   for (const candidate of candidates) {
     xml = await fetchSitemap(candidate);

--- a/lib/exit-codes.ts
+++ b/lib/exit-codes.ts
@@ -3,6 +3,7 @@
  * drifted" (review the diff) from "extraction broke" (retry / investigate):
  *   0  success / stable      1  drift detected (--compare)
  *   2  extraction failure    3  cloud sync failed (--key; extraction itself is fine)
+ *   4  skipped: robots.txt refused the target (DEMBRANDT_ENFORCE_ROBOTS=1)
  *   67 navigation/connection timeout (retryable, try --slow)
  *
  * Kept in its own module (not index.ts, which runs the CLI on import) so the
@@ -11,7 +12,7 @@
  * changing one is a breaking change to the gate.
  */
 
-export const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, TIMEOUT: 67 } as const;
+export const EXIT = { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, ROBOTS_DENIED: 4, TIMEOUT: 67 } as const;
 
 /** Stable failure code surfaced to CI alongside the numeric exit. */
 export type ErrorCode = "NAVIGATION_TIMEOUT" | "EXTRACTION_FAILED";

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -1,4 +1,9 @@
-const UA = "Dembrandt";
+/**
+ * The token a site would use to address us in robots.txt. Only the group that
+ * matches the User-Agent we actually send applies to us, so callers that browse
+ * as a plain browser must match "*" instead of this name.
+ */
+export const ROBOTS_AGENT = "Dembrandt";
 
 interface RobotsRule {
   type: "allow" | "disallow";
@@ -24,7 +29,7 @@ export type RobotsRules =
  */
 export async function fetchRobotsRules(
   targetUrl: string,
-  { timeoutMs = 5000 }: { timeoutMs?: number } = {},
+  { timeoutMs = 5000, agent = "*" }: { timeoutMs?: number; agent?: string } = {},
 ): Promise<RobotsRules> {
   const u = new URL(targetUrl);
   const robotsUrl = `${u.protocol}//${u.host}/robots.txt`;
@@ -36,10 +41,14 @@ export async function fetchRobotsRules(
   try {
     const res = await fetch(robotsUrl, {
       signal: controller.signal,
-      headers: { "User-Agent": UA },
+      headers: { "User-Agent": ROBOTS_AGENT },
     });
     if (!res.ok) return { status: "unavailable" };
     body = await res.text();
+    // A bot wall or SPA fallback answers 200 with HTML. Parsed as robots.txt it
+    // yields no rules, which would read as "nothing is disallowed" — the exact
+    // inversion of what the site is saying.
+    if (looksLikeHtml(body)) return { status: "unavailable" };
   } catch {
     return { status: "unavailable" };
   } finally {
@@ -47,7 +56,7 @@ export async function fetchRobotsRules(
   }
 
   const groups = parseRobots(body);
-  const rules = matchGroup(groups, UA) || matchGroup(groups, "*") || [];
+  const rules = matchGroup(groups, agent) || matchGroup(groups, "*") || [];
   return { status: "ok", robotsUrl, rules };
 }
 
@@ -57,7 +66,7 @@ export function evaluatePath(rules: RobotsRule[], path: string): { allowed: bool
 
 export async function checkRobotsTxt(
   targetUrl: string,
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; agent?: string } = {},
 ): Promise<RobotsResult> {
   const u = new URL(targetUrl);
   const rules = await fetchRobotsRules(targetUrl, opts);
@@ -124,6 +133,10 @@ function parseRobots(text: string): RobotsGroup[] {
     }
   }
   return groups;
+}
+
+function looksLikeHtml(body: string): boolean {
+  return /^\s*(<!doctype html|<html|<head|<body)/i.test(body);
 }
 
 function matchGroup(groups: RobotsGroup[], agent: string): RobotsRule[] | null {

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -55,6 +55,29 @@ export async function fetchRobotsRules(
   return { status: "ok", robotsUrl, rules };
 }
 
+export type RobotsVerdict =
+  | { action: 'proceed' }
+  | { action: 'warn'; reason: string; rule: string | null }
+  | { action: 'refuse'; reason: string };
+
+/**
+ * What a run should do with a robots result. Enforcing runs refuse a disallow
+ * and an unreadable robots.txt; a user-driven run is warned and proceeds,
+ * because it is the user, not the tool, who knows what they may fetch.
+ */
+export function robotsVerdict(
+  robots: RobotsResult,
+  { enforce }: { enforce: boolean },
+): RobotsVerdict {
+  if (robots.status === 'unavailable') {
+    return enforce ? { action: 'refuse', reason: 'robots.txt could not be read' } : { action: 'proceed' };
+  }
+  if (robots.allowed) return { action: 'proceed' };
+
+  const reason = `robots.txt disallows this path (rule: "${robots.rule}")`;
+  return enforce ? { action: 'refuse', reason } : { action: 'warn', reason, rule: robots.rule };
+}
+
 export function evaluatePath(rules: RobotsRule[], path: string): { allowed: boolean; rule: string | null } {
   return evaluate(rules, path);
 }

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -17,7 +17,7 @@ export type RobotsResult =
 
 export type RobotsRules =
   | { status: "unavailable" }
-  | { status: "ok"; robotsUrl: string; rules: RobotsRule[] };
+  | { status: "ok"; robotsUrl: string; rules: RobotsRule[]; sitemaps: string[] };
 
 /**
  * Fetch and parse robots.txt for the target's origin once, so a multi-page
@@ -52,7 +52,7 @@ export async function fetchRobotsRules(
 
   const groups = parseRobots(body);
   const rules = matchGroup(groups, agent) || matchGroup(groups, "*") || [];
-  return { status: "ok", robotsUrl, rules };
+  return { status: "ok", robotsUrl, rules, sitemaps: parseSitemapDirectives(body) };
 }
 
 export type RobotsVerdict =
@@ -82,16 +82,20 @@ export function evaluatePath(rules: RobotsRule[], path: string): { allowed: bool
   return evaluate(rules, path);
 }
 
+/** Evaluate a target against rules already fetched for its origin. */
+export function checkAgainstRules(targetUrl: string, rules: RobotsRules): RobotsResult {
+  const u = new URL(targetUrl);
+  if (rules.status !== "ok") {
+    return { status: "unavailable", robotsUrl: `${u.protocol}//${u.host}/robots.txt` };
+  }
+  return { status: "ok", robotsUrl: rules.robotsUrl, ...evaluatePath(rules.rules, u.pathname || "/") };
+}
+
 export async function checkRobotsTxt(
   targetUrl: string,
   opts: { timeoutMs?: number; agent?: string } = {},
 ): Promise<RobotsResult> {
-  const u = new URL(targetUrl);
-  const rules = await fetchRobotsRules(targetUrl, opts);
-  if (rules.status === "unavailable") {
-    return { status: "unavailable", robotsUrl: `${u.protocol}//${u.host}/robots.txt` };
-  }
-  return { status: "ok", robotsUrl: rules.robotsUrl, ...evaluatePath(rules.rules, u.pathname || "/") };
+  return checkAgainstRules(targetUrl, await fetchRobotsRules(targetUrl, opts));
 }
 
 /**
@@ -151,6 +155,13 @@ function parseRobots(text: string): RobotsGroup[] {
     }
   }
   return groups;
+}
+
+/** `Sitemap:` directives are global, not scoped to a user-agent group. */
+function parseSitemapDirectives(body: string): string[] {
+  return [...body.matchAll(/^\s*sitemap:\s*(\S+)/gim)]
+    .map(m => m[1].trim())
+    .filter(u => /^https?:\/\//i.test(u));
 }
 
 function looksLikeHtml(body: string): boolean {

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -1,8 +1,4 @@
-/**
- * The token a site would use to address us in robots.txt. Only the group that
- * matches the User-Agent we actually send applies to us, so callers that browse
- * as a plain browser must match "*" instead of this name.
- */
+/** The name a site addresses us by. Only applies when we send it (see `agent`). */
 export const ROBOTS_AGENT = "Dembrandt";
 
 interface RobotsRule {
@@ -45,9 +41,8 @@ export async function fetchRobotsRules(
     });
     if (!res.ok) return { status: "unavailable" };
     body = await res.text();
-    // A bot wall or SPA fallback answers 200 with HTML. Parsed as robots.txt it
-    // yields no rules, which would read as "nothing is disallowed" — the exact
-    // inversion of what the site is saying.
+    // A bot wall answers 200 with HTML, which parses to no rules and would read
+    // as "nothing disallowed" — the inversion of what the site is saying.
     if (looksLikeHtml(body)) return { status: "unavailable" };
   } catch {
     return { status: "unavailable" };

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -23,7 +23,7 @@ import { mergeResults } from "./lib/merger.js";
 import { additionalPages, discoveryBudget, extractOptions, isMultiPage, launchArgs } from "./lib/mcp/options.js";
 import type { Extraction, ExtractionRequest } from "./lib/mcp/options.js";
 import { JobQueue, resolveExtraction } from "./lib/mcp/jobs.js";
-import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls } from "./lib/robots.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from "./lib/robots.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -72,6 +72,18 @@ const nullSpinner = {
  */
 async function runExtraction(url: string, options: ExtractionRequest = {}) {
   if (!/^https?:\/\//i.test(url)) url = "https://" + url;
+
+  // Checked before the fetch, and before the browser: an enforcing run has to be
+  // able to not make the request, and the warning is only honest if it precedes it.
+  const entryRobots = await checkRobotsTxt(url).catch(() => null);
+  const verdict = entryRobots
+    ? robotsVerdict(entryRobots, { enforce: process.env.DEMBRANDT_ENFORCE_ROBOTS === "1" })
+    : { action: "proceed" as const };
+
+  if (verdict.action === "refuse") {
+    return { ok: false, error: `${verdict.reason}. Skipping ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).` };
+  }
+
   let browser;
   let chromium;
   try {
@@ -99,9 +111,8 @@ async function runExtraction(url: string, options: ExtractionRequest = {}) {
       discoverLinks: discoveryBudget(options),
     });
 
-    const entryRobots = await checkRobotsTxt(url).catch(() => null);
-    if (entryRobots?.status === "ok" && entryRobots.allowed === false && first.meta) {
-      first.meta.robotsWarnings = [`robots.txt disallows ${url} (rule: "${entryRobots.rule}")`];
+    if (verdict.action === "warn" && first.meta) {
+      first.meta.robotsWarnings = [`robots.txt disallows ${url} (rule: "${verdict.rule}")`];
     }
 
     if (!isMultiPage(options)) {

--- a/test/exit-codes.test.ts
+++ b/test/exit-codes.test.ts
@@ -10,7 +10,7 @@ import { EXIT, classifyError } from '../lib/exit-codes.js';
  */
 
 test('EXIT codes hold their documented values', () => {
-  assert.deepEqual(EXIT, { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, TIMEOUT: 67 });
+  assert.deepEqual(EXIT, { OK: 0, DRIFT: 1, RUNTIME: 2, SYNC_FAILED: 3, ROBOTS_DENIED: 4, TIMEOUT: 67 });
 });
 
 test('drift exit is distinct from every failure exit', () => {
@@ -18,6 +18,7 @@ test('drift exit is distinct from every failure exit', () => {
   // apart from "extraction broke". DRIFT must never collide with a failure code.
   assert.notEqual(EXIT.DRIFT, EXIT.RUNTIME);
   assert.notEqual(EXIT.DRIFT, EXIT.TIMEOUT);
+  assert.notEqual(EXIT.DRIFT, EXIT.ROBOTS_DENIED);
   assert.notEqual(EXIT.DRIFT, EXIT.OK);
   assert.notEqual(EXIT.DRIFT, EXIT.SYNC_FAILED);
 });

--- a/test/liveness.mjs
+++ b/test/liveness.mjs
@@ -10,6 +10,12 @@
  * AND zero text styles AND no degraded stamps (runs-but-extracts-nothing).
  * The run fails when more than 25% of sites fail. Summary JSON goes to
  * test/liveness-report.json for the CI artifact.
+ *
+ * Unattended runs are the tool acting on its own behalf, not a user's, so this
+ * harness names itself in the User-Agent and treats robots.txt as binding. A
+ * site that refuses is skipped, not failed: it is a decision by the site, not a
+ * regression in the engine, and it is the signal that the site belongs off the
+ * list.
  */
 import { spawn } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
@@ -20,11 +26,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const sitesFile = process.argv[2] ?? "sites-smoke.json";
 const sites = JSON.parse(await readFile(resolve(__dirname, sitesFile), "utf-8"));
+const { version } = JSON.parse(await readFile(resolve(ROOT, "package.json"), "utf-8"));
+
+const SKIPPED_BY_ROBOTS = 4;
+const BOT_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+  `Chrome/136.0.0.0 Safari/537.36 Dembrandt/${version} (+https://dembrandt.com/bot)`;
 
 function runSite(site) {
   return new Promise((done) => {
-    const args = [resolve(ROOT, "dist/index.js"), site, "--json-only", "--no-sandbox"];
-    const p = spawn(process.execPath, args, { env: { ...process.env, DEMBRANDT_NO_HINTS: "1" } });
+    const args = [
+      resolve(ROOT, "dist/index.js"), site,
+      "--json-only", "--no-sandbox", "--user-agent", BOT_UA,
+    ];
+    const p = spawn(process.execPath, args, {
+      env: { ...process.env, DEMBRANDT_NO_HINTS: "1", DEMBRANDT_ENFORCE_ROBOTS: "1" },
+    });
     let out = "";
     p.stdout.on("data", (d) => { out += d; });
     p.stderr.on("data", () => {});
@@ -39,9 +56,10 @@ function runSite(site) {
         styles = j.typography?.styles?.length ?? 0;
         degraded = (j.meta?.degraded?.length ?? 0) + (j.meta?.errors?.length ?? 0);
       } catch { /* unparseable output counts via the empty rule below */ }
+      const skipped = code === SKIPPED_BY_ROBOTS;
       const empty = colors === 0 && styles === 0 && degraded === 0;
       const ok = code === 0 && !empty;
-      done({ site, code, colors, styles, degraded, ok });
+      done({ site, code, colors, styles, degraded, ok, skipped });
     });
   });
 }
@@ -50,15 +68,38 @@ const results = [];
 for (const site of sites) {
   const r = await runSite(site);
   results.push(r);
-  console.log(`${r.ok ? "ok  " : "FAIL"} ${r.site} exit=${r.code} colors=${r.colors} styles=${r.styles}${r.degraded ? ` degraded=${r.degraded}` : ""}`);
+  const label = r.skipped ? "skip" : r.ok ? "ok  " : "FAIL";
+  const detail = r.skipped ? "robots.txt refused" : `colors=${r.colors} styles=${r.styles}${r.degraded ? ` degraded=${r.degraded}` : ""}`;
+  console.log(`${label} ${r.site} exit=${r.code} ${detail}`);
 }
 
-const failed = results.filter((r) => !r.ok).length;
-const report = { generatedFor: sitesFile, total: results.length, failed, results };
+const skipped = results.filter((r) => r.skipped);
+const attempted = results.filter((r) => !r.skipped);
+const failed = attempted.filter((r) => !r.ok).length;
+const report = {
+  generatedFor: sitesFile,
+  total: results.length,
+  attempted: attempted.length,
+  skipped: skipped.length,
+  failed,
+  results,
+};
 await writeFile(resolve(__dirname, "liveness-report.json"), JSON.stringify(report, null, 2));
 
-if (failed / results.length > 0.25) {
-  console.error(`\n${failed}/${results.length} sites failed — engine regression`);
+if (skipped.length > 0) {
+  console.log(`\n${skipped.length} site(s) skipped by robots.txt: ${skipped.map((r) => r.site).join(", ")}`);
+  console.log("A site that refuses an identified run belongs off test/sites.json.");
+}
+
+// Every site refusing us is a list problem, not an engine regression, but it
+// leaves nothing measured — say so rather than reporting a pass.
+if (attempted.length === 0) {
+  console.error("\nNo sites were attempted — every target refused the run");
   process.exit(1);
 }
-console.log(`\n${results.length - failed}/${results.length} sites live`);
+
+if (failed / attempted.length > 0.25) {
+  console.error(`\n${failed}/${attempted.length} sites failed — engine regression`);
+  process.exit(1);
+}
+console.log(`\n${attempted.length - failed}/${attempted.length} sites live`);

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls } from '../lib/robots.js';
+import { checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from '../lib/robots.js';
 
 function withMockFetch<T>(body: string | null, status: number, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
@@ -135,4 +135,32 @@ test('checkRobotsTxt: forwards the agent to the group match', async () => {
     allowed: false,
     rule: '/admin',
   });
+});
+
+test('robotsVerdict: a user-driven run is warned and proceeds, an enforcing run refuses', () => {
+  const disallowed = { status: 'ok', robotsUrl: 'https://example.com/robots.txt', allowed: false, rule: '/' } as const;
+
+  assert.deepEqual(robotsVerdict(disallowed, { enforce: false }), {
+    action: 'warn',
+    reason: 'robots.txt disallows this path (rule: "/")',
+    rule: '/',
+  });
+  assert.equal(robotsVerdict(disallowed, { enforce: true }).action, 'refuse');
+});
+
+test('robotsVerdict: an unreadable robots.txt fails open for a user and closed when enforcing', () => {
+  const unavailable = { status: 'unavailable', robotsUrl: 'https://example.com/robots.txt' } as const;
+
+  assert.deepEqual(robotsVerdict(unavailable, { enforce: false }), { action: 'proceed' });
+  assert.deepEqual(robotsVerdict(unavailable, { enforce: true }), {
+    action: 'refuse',
+    reason: 'robots.txt could not be read',
+  });
+});
+
+test('robotsVerdict: an allowed path proceeds either way', () => {
+  const allowed = { status: 'ok', robotsUrl: 'https://example.com/robots.txt', allowed: true, rule: null } as const;
+
+  assert.deepEqual(robotsVerdict(allowed, { enforce: false }), { action: 'proceed' });
+  assert.deepEqual(robotsVerdict(allowed, { enforce: true }), { action: 'proceed' });
 });

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -49,7 +49,8 @@ test('evaluatePath: wildcard and end-anchor patterns match correctly', () => {
 
 test('fetchRobotsRules: parses the matching user-agent group', async () => {
   const body = 'User-agent: Dembrandt\nDisallow: /private\n\nUser-agent: *\nDisallow: /\n';
-  const rules = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
+  const rules = await withMockFetch(body, 200, () =>
+    fetchRobotsRules('https://example.com/', { agent: 'Dembrandt' }));
   assert.equal(rules.status, 'ok');
   if (rules.status === 'ok') {
     assert.deepEqual(rules.rules, [{ type: 'disallow', value: '/private' }]);
@@ -95,4 +96,45 @@ test('filterAllowedUrls: a malformed URL is passed through rather than dropped',
   const { allowed, disallowed } = filterAllowedUrls(['not a url'], rules);
   assert.deepEqual(allowed, ['not a url']);
   assert.deepEqual(disallowed, []);
+});
+
+test('fetchRobotsRules: an HTML body is treated as unavailable, not as an empty rule set', async () => {
+  // Bot walls answer 200 with HTML; parsed as robots.txt it would read as
+  // "nothing disallowed" — the inversion of what the site is saying.
+  const body = '<!DOCTYPE html>\n<html><body>Access denied</body></html>';
+  const result = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(result.status, 'unavailable');
+});
+
+test('fetchRobotsRules: matches the group for the requested agent', async () => {
+  const body = 'User-agent: Dembrandt\nDisallow: /named\n\nUser-agent: *\nDisallow: /everyone\n';
+  const named = await withMockFetch(body, 200, () =>
+    fetchRobotsRules('https://example.com/', { agent: 'Dembrandt' }));
+  assert.deepEqual(named, {
+    status: 'ok',
+    robotsUrl: 'https://example.com/robots.txt',
+    rules: [{ type: 'disallow', value: '/named' }],
+  });
+});
+
+test('fetchRobotsRules: an unnamed run falls under the wildcard group, not the Dembrandt one', async () => {
+  const body = 'User-agent: Dembrandt\nAllow: /\n\nUser-agent: *\nDisallow: /\n';
+  const result = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
+  assert.deepEqual(result, {
+    status: 'ok',
+    robotsUrl: 'https://example.com/robots.txt',
+    rules: [{ type: 'disallow', value: '/' }],
+  });
+});
+
+test('checkRobotsTxt: forwards the agent to the group match', async () => {
+  const body = 'User-agent: Dembrandt\nDisallow: /admin\n\nUser-agent: *\nAllow: /\n';
+  const result = await withMockFetch(body, 200, () =>
+    checkRobotsTxt('https://example.com/admin', { agent: 'Dembrandt' }));
+  assert.deepEqual(result, {
+    status: 'ok',
+    robotsUrl: 'https://example.com/robots.txt',
+    allowed: false,
+    rule: '/admin',
+  });
 });

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -99,8 +99,6 @@ test('filterAllowedUrls: a malformed URL is passed through rather than dropped',
 });
 
 test('fetchRobotsRules: an HTML body is treated as unavailable, not as an empty rule set', async () => {
-  // Bot walls answer 200 with HTML; parsed as robots.txt it would read as
-  // "nothing disallowed" — the inversion of what the site is saying.
   const body = '<!DOCTYPE html>\n<html><body>Access denied</body></html>';
   const result = await withMockFetch(body, 200, () => fetchRobotsRules('https://example.com/'));
   assert.equal(result.status, 'unavailable');

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from '../lib/robots.js';
+import { checkAgainstRules, checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from '../lib/robots.js';
 
 function withMockFetch<T>(body: string | null, status: number, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
@@ -76,7 +76,7 @@ test('checkRobotsTxt: evaluates the target path against the fetched rules', asyn
 });
 
 test('filterAllowedUrls: splits urls by robots decision', () => {
-  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', rules: [{ type: 'disallow' as const, value: '/admin' }] };
+  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', sitemaps: [], rules: [{ type: 'disallow' as const, value: '/admin' }] };
   const { allowed, disallowed } = filterAllowedUrls(
     ['https://example.com/pricing', 'https://example.com/admin/users'],
     rules,
@@ -92,7 +92,7 @@ test('filterAllowedUrls: an unavailable robots.txt allows everything through', (
 });
 
 test('filterAllowedUrls: a malformed URL is passed through rather than dropped', () => {
-  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', rules: [] };
+  const rules = { status: 'ok' as const, robotsUrl: 'https://example.com/robots.txt', sitemaps: [], rules: [] };
   const { allowed, disallowed } = filterAllowedUrls(['not a url'], rules);
   assert.deepEqual(allowed, ['not a url']);
   assert.deepEqual(disallowed, []);
@@ -111,6 +111,7 @@ test('fetchRobotsRules: matches the group for the requested agent', async () => 
   assert.deepEqual(named, {
     status: 'ok',
     robotsUrl: 'https://example.com/robots.txt',
+    sitemaps: [],
     rules: [{ type: 'disallow', value: '/named' }],
   });
 });
@@ -121,6 +122,7 @@ test('fetchRobotsRules: an unnamed run falls under the wildcard group, not the D
   assert.deepEqual(result, {
     status: 'ok',
     robotsUrl: 'https://example.com/robots.txt',
+    sitemaps: [],
     rules: [{ type: 'disallow', value: '/' }],
   });
 });
@@ -163,4 +165,34 @@ test('robotsVerdict: an allowed path proceeds either way', () => {
 
   assert.deepEqual(robotsVerdict(allowed, { enforce: false }), { action: 'proceed' });
   assert.deepEqual(robotsVerdict(allowed, { enforce: true }), { action: 'proceed' });
+});
+
+test('fetchRobotsRules: Sitemap directives come back with the rules, not a second fetch', () => {
+  const body = 'Sitemap: https://example.com/sitemap.xml\nUser-agent: *\nDisallow: /admin\nSitemap: /relative-is-not-a-url\n';
+  return withMockFetch(body, 200, async () => {
+    const rules = await fetchRobotsRules('https://example.com/');
+    assert.equal(rules.status, 'ok');
+    if (rules.status === 'ok') {
+      assert.deepEqual(rules.sitemaps, ['https://example.com/sitemap.xml']);
+      assert.deepEqual(rules.rules, [{ type: 'disallow', value: '/admin' }]);
+    }
+  });
+});
+
+test('checkAgainstRules: evaluates a path against rules already fetched', () => {
+  const rules = {
+    status: 'ok' as const,
+    robotsUrl: 'https://example.com/robots.txt',
+    sitemaps: [],
+    rules: [{ type: 'disallow' as const, value: '/admin' }],
+  };
+
+  assert.deepEqual(checkAgainstRules('https://example.com/admin/users', rules), {
+    status: 'ok',
+    robotsUrl: 'https://example.com/robots.txt',
+    allowed: false,
+    rule: '/admin',
+  });
+  assert.equal(checkAgainstRules('https://example.com/pricing', rules).status === 'ok', true);
+  assert.equal(checkAgainstRules('https://example.com/x', { status: 'unavailable' }).status, 'unavailable');
 });

--- a/test/sites.json
+++ b/test/sites.json
@@ -1,6 +1,5 @@
 [
   "dembrandt.com",
-
   "stripe.com",
   "linear.app",
   "vercel.com",
@@ -10,51 +9,22 @@
   "figma.com",
   "notion.so",
   "slack.com",
-
-  "apple.com",
-  "nike.com",
-  "coca-cola.com",
-  "mcdonalds.com",
+  "framer.com",
+  "webflow.com",
+  "squarespace.com",
+  "wordpress.com",
+  "salesforce.com",
+  "ibm.com",
+  "sap.com",
   "ikea.com",
   "lego.com",
   "spotify.com",
-  "netflix.com",
   "airbnb.com",
-  "uber.com",
-
-  "tesla.com",
-  "bmwgroup.com",
-  "louisvuitton.com",
-  "rolex.com",
-
-  "salesforce.com",
-  "oracle.com",
-  "ibm.com",
-  "sap.com",
-
-  "bbc.com",
-  "nytimes.com",
-  "lemonde.fr",
-  "spiegel.de",
-
-  "amazon.co.jp",
-  "flipkart.com",
-  "mercadolibre.com",
-  "aliexpress.com",
-
   "gov.uk",
   "usa.gov",
   "canada.ca",
-
-  "wordpress.com",
-  "squarespace.com",
-  "webflow.com",
-  "framer.com",
-
   "developer.mozilla.org",
   "stackoverflow.com",
-
-  "craigslist.org",
   "wikipedia.org",
   "dribbble.com"
 ]


### PR DESCRIPTION
The robots check matched the `Dembrandt` group while the browser sent plain Chrome, so a site could allow or disallow us by name with no effect. Group now follows the User-Agent actually sent.

Every refusal read as permission: an unreachable robots.txt was fail-open, and a bot wall answering 200 with HTML parsed into zero rules. HTML bodies are now unavailable.

`DEMBRANDT_ENFORCE_ROBOTS=1` makes a disallow, or an unreadable file, skip the target with exit 4. CLI and MCP both honour it. Fail-open stays the default where a person runs the tool themselves.

robots.txt is now read once per origin, not three times per `--sitemap` run.

Site list 48 to 28, nightly to weekly, smoke timeout raised. DEM-291.