### PR TITLE
stop shipping the extractor scratch set in every extraction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -418,11 +418,6 @@ program
         }
       }
 
-      // Strip raw colors unless --raw-colors flag is set
-      if (!opts.rawColors && result.colors && result.colors.rawColors) {
-        delete result.colors.rawColors;
-      }
-
       // Pull the internal payload off the result before it can reach stdout or
       // the normal saved output, and write it to its own sidecar.
       const teachData = (result as any)._teach;

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1495,9 +1495,7 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
     if (options.includeRawColors) {
       result.colors.rawColors = colors._raw || [];
     }
-    // `_raw` is the extractor's own scratch set, published as `rawColors` only
-    // when asked for. Stripping it here rather than in the CLI keeps every
-    // consumer — MCP, library, saved JSON — on the same result shape.
+    // Internal scratch set; `rawColors` above is its published form.
     delete (result.colors as { _raw?: unknown })._raw;
 
     if (options.discoverLinks) {

--- a/lib/extractors/index.ts
+++ b/lib/extractors/index.ts
@@ -1495,6 +1495,10 @@ export async function extractBranding(url: string, spinner: Spinner, browser: Br
     if (options.includeRawColors) {
       result.colors.rawColors = colors._raw || [];
     }
+    // `_raw` is the extractor's own scratch set, published as `rawColors` only
+    // when asked for. Stripping it here rather than in the CLI keeps every
+    // consumer — MCP, library, saved JSON — on the same result shape.
+    delete (result.colors as { _raw?: unknown })._raw;
 
     if (options.discoverLinks) {
       try {

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -16,10 +16,7 @@ const TRANSIENT_KEYS = ['_discoveredLinks', '_extractedUrls', '_pageResults'] as
 /**
  * Remove internal crawl/merge fields that must never be persisted, even if a raw
  * crawl object is fed in. Returns a shallow copy; the input is untouched.
- *
- * `colors._raw` is the same category one level down: the extractor's scratch set,
- * published as `colors.rawColors` only under --raw-colors. Every snapshot saved
- * before it was stripped at the producer still carries it, so ingest drops it too.
+ * `colors._raw` is the same category one level down.
  */
 export function stripTransient<T extends BrandingResult>(result: T): T {
   const clean = { ...result } as T & Record<string, unknown>;

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -9,17 +9,28 @@
  * need these — they live in core so every consumer shares one implementation
  * instead of each repo re-deriving it.
  */
-import type { BrandingResult } from './types.js';
+import type { BrandingResult, Colors } from './types.js';
 
 const TRANSIENT_KEYS = ['_discoveredLinks', '_extractedUrls', '_pageResults'] as const;
 
 /**
  * Remove internal crawl/merge fields that must never be persisted, even if a raw
  * crawl object is fed in. Returns a shallow copy; the input is untouched.
+ *
+ * `colors._raw` is the same category one level down: the extractor's scratch set,
+ * published as `colors.rawColors` only under --raw-colors. Every snapshot saved
+ * before it was stripped at the producer still carries it, so ingest drops it too.
  */
 export function stripTransient<T extends BrandingResult>(result: T): T {
   const clean = { ...result } as T & Record<string, unknown>;
   for (const key of TRANSIENT_KEYS) delete clean[key];
+
+  const colors: Colors | undefined = clean.colors;
+  if (colors && '_raw' in colors) {
+    const { _raw, ...rest } = colors;
+    (clean as Record<string, unknown>).colors = rest;
+  }
+
   return clean;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,10 +62,7 @@ export interface Colors {
   cssVariables: Record<string, string | CssVariable>;
   /** Pre-filter colour set, published only under --raw-colors. */
   rawColors?: PaletteColor[];
-  /**
-   * Internal scratch set behind `rawColors`. Stripped at the producer and again
-   * at ingest; declared only so both strips are typed. Never persisted.
-   */
+  /** Internal scratch set behind `rawColors`. Never persisted. */
   _raw?: PaletteColor[];
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,7 +60,13 @@ export interface Colors {
    * ones carry a CssVariable object, so consumers must handle both.
    */
   cssVariables: Record<string, string | CssVariable>;
+  /** Pre-filter colour set, published only under --raw-colors. */
   rawColors?: PaletteColor[];
+  /**
+   * Internal scratch set behind `rawColors`. Stripped at the producer and again
+   * at ingest; declared only so both strips are typed. Never persisted.
+   */
+  _raw?: PaletteColor[];
 }
 
 export interface TypographyStyle {

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -35,6 +35,25 @@ test('stripTransient removes internal crawl fields and does not mutate input', (
   assert.deepStrictEqual((input as any)._discoveredLinks, [1]);
 });
 
+test('stripTransient drops the extractor scratch set nested under colors', () => {
+  // Every snapshot saved before the producer stripped it carries colors._raw,
+  // so ingest has to drop it too or stored extractions keep the leak forever.
+  const input: any = {
+    ...base,
+    colors: { semantic: {}, palette: [{ normalized: '#fff' }], cssVariables: [], _raw: [1, 2, 3] },
+  };
+  const out: any = stripTransient(input);
+  assert.strictEqual('_raw' in out.colors, false);
+  assert.deepStrictEqual(out.colors.palette, [{ normalized: '#fff' }]);
+  // input untouched
+  assert.deepStrictEqual(input.colors._raw, [1, 2, 3]);
+});
+
+test('stripTransient leaves rawColors alone: it is published output, not scratch', () => {
+  const input: any = { ...base, colors: { semantic: {}, palette: [], cssVariables: [], rawColors: [1] } };
+  assert.deepStrictEqual(stripTransient(input).colors.rawColors, [1]);
+});
+
 test('normalizeExtraction canonicalizes loose unions for diffing', () => {
   const out: any = normalizeExtraction({ ...base, _pageResults: [9] } as any);
   assert.strictEqual(out.typography.styles[0].weight, 700);        // string -> number

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -36,8 +36,7 @@ test('stripTransient removes internal crawl fields and does not mutate input', (
 });
 
 test('stripTransient drops the extractor scratch set nested under colors', () => {
-  // Every snapshot saved before the producer stripped it carries colors._raw,
-  // so ingest has to drop it too or stored extractions keep the leak forever.
+  // Snapshots saved before the producer stripped it still carry colors._raw.
   const input: any = {
     ...base,
     colors: { semantic: {}, palette: [{ normalized: '#fff' }], cssVariables: [], _raw: [1, 2, 3] },


### PR DESCRIPTION
The `--raw-colors` flag copies `colors._raw` to `colors.rawColors`. `_raw` itself shipped in every result regardless, so the gated data has been in the default output since at least 0.17.0.

Stripped at the producer, so MCP, the library and saved JSON get one shape. `stripTransient` drops it at ingest too: every stored snapshot still carries it.