### PR TITLE
normalize pill radii, and name the pages a crawl took

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -719,7 +719,7 @@ program
       // so the summary confirms what was asked for, not just what was extracted.
       const flagBits = activeFlags(opts);
       const flagsLine = flagBits.length ? chalk.dim(`   Flags: ${flagBits.join(' ')}`) : null;
-      const pathBits = pathSummary(paths, result.pages?.length ?? 0);
+      const pathBits = pathSummary(paths, result.pages?.length ?? 0, result.pages?.map((p) => p.url) ?? []);
       const pathsLine = pathBits.length ? chalk.dim(`   Paths: ${pathBits.join(' ')}`) : null;
 
       if (opts.jsonOnly) {

--- a/lib/extractors/spacing.ts
+++ b/lib/extractors/spacing.ts
@@ -1,3 +1,4 @@
+import { normalizeRadiusValues } from '../radius-normalize.js';
 export async function extractSpacing(page) {
   return await page.evaluate(() => {
     const spacings = new Map();
@@ -35,7 +36,7 @@ export async function extractSpacing(page) {
 }
 
 export async function extractBorderRadius(page) {
-  return await page.evaluate(() => {
+  const raw = await page.evaluate(() => {
     const radii = new Map();
 
     document.querySelectorAll("*").forEach((el) => {
@@ -80,6 +81,10 @@ export async function extractBorderRadius(page) {
 
     return { values };
   });
+
+  // Normalized in Node, not in the page: the merge is shared with the formatters
+  // and is worth unit-testing away from a browser.
+  return { values: normalizeRadiusValues(raw.values) };
 }
 
 export async function extractBorders(page) {

--- a/lib/formatters/terminal.ts
+++ b/lib/formatters/terminal.ts
@@ -8,6 +8,7 @@ import type { BrandingResult } from '../types.js';
 
 import chalk from 'chalk';
 import { color } from './theme.js';
+import { formatPageList } from '../run-summary.js';
 import { convertColor, formatColor } from '../colors.js';
 import type { ColorFormat } from '../colors.js';
 
@@ -39,7 +40,7 @@ export function displayResults(data: BrandingResult, options: { colorFormat?: Co
   });
   console.log(chalk.dim('├─') + ' ' + chalk.dim(timeString));
   if (data.pages && data.pages.length > 1) {
-    const paths = data.pages.map(p => new URL(p.url).pathname || '/').join(', ');
+    const paths = formatPageList(data.pages.map(p => p.url));
     console.log(chalk.dim('├─') + ' ' + chalk.dim(`${data.pages.length} pages: ${paths}`));
   }
   console.log(chalk.dim('│'));

--- a/lib/radius-normalize.ts
+++ b/lib/radius-normalize.ts
@@ -27,7 +27,8 @@ export function normalizeRadius(value: string): string {
 
   const parts = raw.split(/\s+/).map((part) => {
     const n = parseFloat(part);
-    return Number.isFinite(n) && n >= PILL_THRESHOLD ? PILL_RADIUS : part;
+    // Infinity is the far end of the same case, not an exception to it.
+    return Number.isNaN(n) || n < PILL_THRESHOLD ? part : PILL_RADIUS;
   });
 
   return parts.every((part) => part === PILL_RADIUS) ? PILL_RADIUS : parts.join(' ');

--- a/lib/radius-normalize.ts
+++ b/lib/radius-normalize.ts
@@ -1,0 +1,71 @@
+/**
+ * Pill radii in computed styles.
+ *
+ * `border-radius: 9999px` and Tailwind's `rounded-full` both resolve to
+ * Chromium's maximum length, which serializes as `3.35544e+07px`. Passed through
+ * verbatim it reaches every output as scientific notation and outranks the real
+ * radius scale, because it sorts as a 33-million-pixel value.
+ */
+
+export const PILL_RADIUS = '9999px';
+
+/** Any authored radius at or above this is a pill, not a scale step. */
+const PILL_THRESHOLD = 9999;
+
+export interface RadiusValue {
+  value: string;
+  count: number;
+  elements: string[];
+  confidence: string;
+  numericValue: number;
+}
+
+/** Collapse pill-sized components to a readable `9999px`. Percentages pass through. */
+export function normalizeRadius(value: string): string {
+  const raw = String(value ?? '').trim();
+  if (!raw || raw.includes('%')) return raw;
+
+  const parts = raw.split(/\s+/).map((part) => {
+    const n = parseFloat(part);
+    return Number.isFinite(n) && n >= PILL_THRESHOLD ? PILL_RADIUS : part;
+  });
+
+  return parts.every((part) => part === PILL_RADIUS) ? PILL_RADIUS : parts.join(' ');
+}
+
+/** Normalize and re-merge: two raw values can collapse to the same one. */
+export function normalizeRadiusValues(values: RadiusValue[]): RadiusValue[] {
+  const merged = new Map<string, RadiusValue & { contexts: Set<string> }>();
+
+  for (const entry of values ?? []) {
+    const value = normalizeRadius(entry.value);
+    const existing = merged.get(value);
+
+    if (existing) {
+      existing.count += entry.count ?? 0;
+      for (const context of entry.elements ?? []) existing.contexts.add(context);
+      continue;
+    }
+
+    merged.set(value, {
+      ...entry,
+      value,
+      count: entry.count ?? 0,
+      contexts: new Set(entry.elements ?? []),
+      elements: [],
+      numericValue: parseFloat(value) || 0,
+    });
+  }
+
+  return [...merged.values()]
+    .map(({ contexts, ...entry }) => ({
+      ...entry,
+      elements: [...contexts].slice(0, 5),
+      confidence: entry.count > 10 ? 'high' : entry.count > 3 ? 'medium' : 'low',
+    }))
+    .sort((a, b) => {
+      if (a.value.includes('%') && !b.value.includes('%')) return 1;
+      if (!a.value.includes('%') && b.value.includes('%')) return -1;
+      return a.numericValue - b.numericValue;
+    });
+}

--- a/lib/run-summary.ts
+++ b/lib/run-summary.ts
@@ -58,13 +58,36 @@ export function activeFlags(opts: RunOpts = {}): string[] {
 }
 
 /**
- * Explicit paths and/or the merged-page count. Explicit paths are positional
- * (not flags) so they would otherwise be invisible; --crawl/--sitemap have no
- * explicit paths but still merge pages, reported by the count alone.
+ * Pathnames of the pages a crawl actually took, capped so a 20-page sitemap run
+ * stays one readable line. Unparseable URLs are kept verbatim rather than
+ * dropped, so the list always accounts for every page.
  */
-export function pathSummary(paths: string[] | undefined, mergedPages = 0): string[] {
+export function formatPageList(urls: (string | undefined)[] = [], max = 6): string {
+  const paths = urls
+    .filter((u): u is string => !!u)
+    .map((u) => {
+      try { return new URL(u).pathname || '/'; } catch { return u; }
+    });
+
+  if (paths.length <= max) return paths.join(', ');
+  return `${paths.slice(0, max).join(', ')}, +${paths.length - max} more`;
+}
+
+/**
+ * Explicit paths and/or the merged pages. Explicit paths are positional (not
+ * flags) so they would otherwise be invisible; --crawl/--sitemap have none, and
+ * a bare count cannot be checked against what the run should have picked.
+ */
+export function pathSummary(
+  paths: string[] | undefined,
+  mergedPages = 0,
+  crawledUrls: (string | undefined)[] = [],
+): string[] {
   const bits: string[] = [];
   if (paths && paths.length) bits.push(...paths);
-  if (mergedPages > 1) bits.push(`(${mergedPages} pages merged)`);
+  if (mergedPages > 1) {
+    const listed = formatPageList(crawledUrls);
+    bits.push(listed ? `(${mergedPages} pages merged: ${listed})` : `(${mergedPages} pages merged)`);
+  }
   return bits;
 }

--- a/test/radius-normalize.test.ts
+++ b/test/radius-normalize.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeRadius, normalizeRadiusValues, PILL_RADIUS } from '../lib/radius-normalize.js';
+
+const entry = (value: string, count: number, elements: string[] = []) => ({
+  value,
+  count,
+  elements,
+  confidence: 'low',
+  numericValue: parseFloat(value) || 0,
+});
+
+test('normalizeRadius: the computed maximum length reads as a pill', () => {
+  assert.equal(normalizeRadius('3.35544e+07px'), PILL_RADIUS);
+  assert.equal(normalizeRadius('33554400px'), PILL_RADIUS);
+  assert.equal(normalizeRadius('9999px'), PILL_RADIUS);
+});
+
+test('normalizeRadius: real scale steps pass through untouched', () => {
+  for (const value of ['0px', '4px', '6px', '128px', '999px', '0.5rem']) {
+    assert.equal(normalizeRadius(value), value);
+  }
+});
+
+test('normalizeRadius: percentages are a different shape and are left alone', () => {
+  assert.equal(normalizeRadius('50%'), '50%');
+  assert.equal(normalizeRadius('50% 50% 0 0'), '50% 50% 0 0');
+});
+
+test('normalizeRadius: a multi-corner radius keeps its shape', () => {
+  assert.equal(normalizeRadius('3.35544e+07px 3.35544e+07px 0px 0px'), '9999px 9999px 0px 0px');
+});
+
+test('normalizeRadius: malformed input degrades to itself rather than throwing', () => {
+  assert.equal(normalizeRadius(''), '');
+  assert.equal(normalizeRadius(undefined as unknown as string), '');
+  assert.equal(normalizeRadius('inherit'), 'inherit');
+});
+
+test('normalizeRadiusValues: values that collapse to the same pill are merged', () => {
+  const out = normalizeRadiusValues([
+    entry('3.35544e+07px', 300, ['a', 'span']),
+    entry('9999px', 89, ['button']),
+    entry('6px', 12, ['card']),
+  ]);
+
+  assert.equal(out.length, 2);
+  const pill = out.find((v) => v.value === PILL_RADIUS)!;
+  assert.equal(pill.count, 389);
+  assert.deepEqual(pill.elements.sort(), ['a', 'button', 'span']);
+  assert.equal(pill.confidence, 'high');
+  assert.equal(pill.numericValue, 9999);
+});
+
+test('normalizeRadiusValues: the pill no longer outranks the real scale by 33 million', () => {
+  const out = normalizeRadiusValues([entry('3.35544e+07px', 300), entry('6px', 12), entry('50%', 4)]);
+  assert.deepEqual(out.map((v) => v.value), ['6px', PILL_RADIUS, '50%']);
+});
+
+test('normalizeRadiusValues: an empty or missing list is not an error', () => {
+  assert.deepEqual(normalizeRadiusValues([]), []);
+  assert.deepEqual(normalizeRadiusValues(undefined as unknown as []), []);
+});

--- a/test/radius-normalize.test.ts
+++ b/test/radius-normalize.test.ts
@@ -16,6 +16,10 @@ test('normalizeRadius: the computed maximum length reads as a pill', () => {
   assert.equal(normalizeRadius('9999px'), PILL_RADIUS);
 });
 
+test('normalizeRadius: a value too large to be finite is still a pill', () => {
+  assert.equal(normalizeRadius('1e400px'), PILL_RADIUS);
+});
+
 test('normalizeRadius: real scale steps pass through untouched', () => {
   for (const value of ['0px', '4px', '6px', '128px', '999px', '0.5rem']) {
     assert.equal(normalizeRadius(value), value);

--- a/test/run-summary.test.ts
+++ b/test/run-summary.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { activeFlags, pathSummary } from '../lib/run-summary.js';
+import { activeFlags, formatPageList, pathSummary } from '../lib/run-summary.js';
 
 /**
  * The closing-summary "what shaped this run" lines (DEM-99): which flags were
@@ -57,4 +57,32 @@ test('pathSummary: crawl/sitemap have no explicit paths, just the merged count',
 test('pathSummary: single page -> nothing (no merge happened)', () => {
   assert.deepEqual(pathSummary(undefined, 1), []);
   assert.deepEqual(pathSummary([], 0), []);
+});
+
+test('formatPageList: a short crawl lists every page', () => {
+  assert.equal(
+    formatPageList(['https://a.com/', 'https://a.com/pricing', 'https://a.com/docs/start']),
+    '/, /pricing, /docs/start',
+  );
+});
+
+test('formatPageList: a long crawl is capped so the summary stays one line', () => {
+  const urls = Array.from({ length: 20 }, (_, i) => `https://a.com/p${i}`);
+  assert.equal(formatPageList(urls), '/p0, /p1, /p2, /p3, /p4, /p5, +14 more');
+});
+
+test('formatPageList: an unparseable URL is kept verbatim, never dropped', () => {
+  // The list has to account for every page, or the count and the list disagree.
+  assert.equal(formatPageList(['https://a.com/x', 'not a url', undefined]), '/x, not a url');
+});
+
+test('pathSummary: a crawl names the pages it took, not just how many', () => {
+  assert.deepEqual(
+    pathSummary(undefined, 3, ['https://a.com/', 'https://a.com/pricing', 'https://a.com/about']),
+    ['(3 pages merged: /, /pricing, /about)'],
+  );
+});
+
+test('pathSummary: the count still stands alone when no URLs are available', () => {
+  assert.deepEqual(pathSummary(undefined, 3), ['(3 pages merged)']);
 });


### PR DESCRIPTION
`rounded-full` resolves to Chromium's maximum length and serialised as `3.35544e+07px`, ranking above the real radius scale. Normalised to `9999px`, with the counts merged when two spellings collapse.

The crawl summary reported a page count and not which pages. It names them now, capped, and the tree listing shares the same formatter. DEM-311, DEM-259.