### PR TITLE
read the family that rendered the text, surface mono, stop role names winning primary

### DIFF
--- a/lib/extractors/colors.ts
+++ b/lib/extractors/colors.ts
@@ -143,6 +143,15 @@ export async function extractColors(page) {
       return diff > 180 ? 360 - diff : diff;
     }
 
+    // "primary" qualified by a rendering role names a slot on a surface — the
+    // text on the primary button, a border — not the brand primary itself.
+    const ROLE_QUALIFIED_PRIMARY =
+      /(?:foreground|fg|text|ink|label|caption|border|outline|ring|divider|icon|placeholder|muted|hover|active|disabled)[-_ ]?primary|primary[-_ ]?(?:foreground|fg|text|ink|label|border|outline|ring|icon|content|hover|active|disabled)/;
+
+    function isRoleQualified(context) {
+      return ROLE_QUALIFIED_PRIMARY.test(context);
+    }
+
     function isValidColorValue(value) {
       if (!value) return false;
       if (value.includes("calc(") || value.includes("clamp(") || value.includes("var(")) {
@@ -361,7 +370,7 @@ export async function extractColors(page) {
         }
       });
 
-      if (context.includes("primary") || el.matches('[class*="primary"]')) {
+      if ((context.includes("primary") || el.matches('[class*="primary"]')) && !isRoleQualified(context)) {
         const candidate = bgColor !== "rgba(0, 0, 0, 0)" && bgColor !== "transparent" ? bgColor : textColor;
         if (colorAlpha(candidate) >= 0.7 && colorLightness(candidate) <= 0.95) semanticColors.primary = candidate;
       }

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -143,6 +143,16 @@ export function filterFontUrls(urls: string[]): string[] {
 
 export async function extractTypography(page) {
   const data = await page.evaluate(() => {
+    const glyphlessFamilies = new Set<string>();
+    const coversLatinLetters = (range: string) =>
+      range.split(',').some((part) => {
+        const m = /^\s*u\+([0-9a-f]+)(?:-([0-9a-f]+))?/i.exec(part.trim());
+        if (!m) return true; // wildcards and unparseable ranges: assume coverage
+        const start = parseInt(m[1], 16);
+        const end = m[2] ? parseInt(m[2], 16) : start;
+        return start <= 0x41 && end >= 0x5a; // A-Z
+      });
+
     const seen = new Map();
     const variationSettings: string[] = [];
     const featureSettings: string[] = [];
@@ -218,6 +228,12 @@ export async function extractTypography(page) {
               if (!isThirdParty && (isSameOrigin || src.includes('url(')) && !sources.customFonts.includes(family)) {
                 sources.customFonts.push(family);
               }
+              // A face restricted to digits (tabular-numeral fonts are declared this
+              // way) renders no letters, so the browser falls through to the next
+              // family for text. Such a family must not be reported as the family.
+              const range = rule.style.getPropertyValue('unicode-range');
+              if (range && !coversLatinLetters(range)) glyphlessFamilies.add(family.toLowerCase());
+
               const familyLower = family.toLowerCase();
               if (
                 familyLower.includes('variable') ||
@@ -254,7 +270,8 @@ export async function extractTypography(page) {
 
     const els = document.querySelectorAll(`
       h1,h2,h3,h4,h5,h6,p,span,a,button,[role="button"],.btn,.button,
-      .hero,[class*="title"],[class*="heading"],[class*="text"],nav a
+      .hero,[class*="title"],[class*="heading"],[class*="text"],nav a,
+      code,pre,kbd,samp
     `);
 
     els.forEach((el) => {
@@ -264,8 +281,11 @@ export async function extractTypography(page) {
       const size = parseFloat(s.fontSize);
       const weight = parseInt(s.fontWeight) || 400;
       const fontFamilies = s.fontFamily.split(",").map(f => f.replace(/['"]/g, "").trim());
-      const family = fontFamilies[0];
-      const fallbacks = fontFamilies.slice(1).filter(f => f && f !== 'sans-serif' && f !== 'serif' && f !== 'monospace');
+      const rendered = fontFamilies.findIndex(f => !glyphlessFamilies.has(f.toLowerCase()));
+      const familyIndex = rendered === -1 ? 0 : rendered;
+      const family = fontFamilies[familyIndex];
+      const fallbacks = fontFamilies.filter((_, i) => i !== familyIndex)
+        .filter(f => f && f !== 'sans-serif' && f !== 'serif' && f !== 'monospace');
       const letterSpacing = s.letterSpacing;
       const textTransform = s.textTransform;
       const lineHeight = s.lineHeight;
@@ -280,7 +300,11 @@ export async function extractTypography(page) {
       let context = "body";
       const className = typeof el.className === 'string' ? el.className : ((el as any).className.baseVal || '');
       const headingMatch = el.tagName.match(/^H([1-6])$/);
-      if (
+      if (["CODE", "PRE", "KBD", "SAMP"].includes(el.tagName)) {
+        // Its own role: a mono face is part of the system but is not body copy,
+        // and letting it compete for "body" moves the body token.
+        context = "mono";
+      } else if (
         el.tagName === "BUTTON" ||
         el.getAttribute("role") === "button" ||
         className.includes("btn")

--- a/lib/extractors/typography.ts
+++ b/lib/extractors/typography.ts
@@ -143,7 +143,10 @@ export function filterFontUrls(urls: string[]): string[] {
 
 export async function extractTypography(page) {
   const data = await page.evaluate(() => {
-    const glyphlessFamilies = new Set<string>();
+    // A family is split across faces by subset (latin, cyrillic, greek), so it
+    // renders letters if ANY of its faces covers A-Z, not if every one does.
+    const rangedFamilies = new Set<string>();
+    const latinFamilies = new Set<string>();
     const coversLatinLetters = (range: string) =>
       range.split(',').some((part) => {
         const m = /^\s*u\+([0-9a-f]+)(?:-([0-9a-f]+))?/i.exec(part.trim());
@@ -223,6 +226,7 @@ export async function extractTypography(page) {
               }
               const family = (rule.style.getPropertyValue('font-family') || '').replace(/['"]/g, '').trim();
               if (!family) continue;
+              const familyKey = family.toLowerCase();
               const isThirdParty = thirdPartyHosts.some(h => src.includes(h));
               const isSameOrigin = src.includes(pageHost) || src.startsWith('/') || src.startsWith('./') || (!src.includes('http') && src.includes('url('));
               if (!isThirdParty && (isSameOrigin || src.includes('url(')) && !sources.customFonts.includes(family)) {
@@ -232,9 +236,14 @@ export async function extractTypography(page) {
               // way) renders no letters, so the browser falls through to the next
               // family for text. Such a family must not be reported as the family.
               const range = rule.style.getPropertyValue('unicode-range');
-              if (range && !coversLatinLetters(range)) glyphlessFamilies.add(family.toLowerCase());
+              if (range) {
+                rangedFamilies.add(familyKey);
+                if (coversLatinLetters(range)) latinFamilies.add(familyKey);
+              } else {
+                latinFamilies.add(familyKey);
+              }
 
-              const familyLower = family.toLowerCase();
+              const familyLower = familyKey;
               if (
                 familyLower.includes('variable') ||
                 familyLower.includes(' vf') ||
@@ -281,7 +290,11 @@ export async function extractTypography(page) {
       const size = parseFloat(s.fontSize);
       const weight = parseInt(s.fontWeight) || 400;
       const fontFamilies = s.fontFamily.split(",").map(f => f.replace(/['"]/g, "").trim());
-      const rendered = fontFamilies.findIndex(f => !glyphlessFamilies.has(f.toLowerCase()));
+      const glyphless = (f: string) => {
+        const key = f.toLowerCase();
+        return rangedFamilies.has(key) && !latinFamilies.has(key);
+      };
+      const rendered = fontFamilies.findIndex(f => !glyphless(f));
       const familyIndex = rendered === -1 ? 0 : rendered;
       const family = fontFamilies[familyIndex];
       const fallbacks = fontFamilies.filter((_, i) => i !== familyIndex)

--- a/test/typography-family-fixture.test.ts
+++ b/test/typography-family-fixture.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { chromium, type Browser, type Page } from 'playwright';
+import { extractTypography } from '../lib/extractors/typography.js';
+import { extractColors } from '../lib/extractors/colors.js';
+import type { TypographyStyle } from '../lib/types.js';
+
+// Both subjects read the CSSOM against a live document, so they are invisible
+// to a pure unit test: the font stack has to be resolved by a real browser and
+// the class names have to reach a real cascade.
+
+const FIXTURE =
+  `<!doctype html><html><head><style>` +
+  // A numerals-only face, declared the way tabular-figure fonts are.
+  `@font-face { font-family: 'NumeralsOnly'; src: url(data:font/woff2;base64,AA) format('woff2'); unicode-range: U+30-39; }` +
+  `@font-face { font-family: 'BrandSans'; src: url(data:font/woff2;base64,AA) format('woff2'); }` +
+  `body { font-family: 'NumeralsOnly', 'BrandSans', sans-serif; }` +
+  `code, pre { font-family: 'BrandMono', monospace; font-size: 14px; }` +
+  `.brand-primary { background: #00dc82; color: #fff; }` +
+  // Transparent background, so the old code fell through to the text colour.
+  `.foreground-primary { color: rgb(18, 23, 21); background: transparent; }` +
+  `</style></head><body>` +
+  `<h1>A heading rendered in the brand sans</h1>` +
+  `<p>Body copy long enough for the extractor to keep it as a real style entry.</p>` +
+  `<pre><code>const monospaced = "code sample";</code></pre>` +
+  `<button class="brand-primary" style="width:200px;height:48px">Call to action</button>` +
+  `<div class="foreground-primary" style="width:900px;height:500px">Text on a light surface</div>` +
+  `</body></html>`;
+
+let browser: Browser | null = null;
+let page: Page | null = null;
+let launchError: unknown = null;
+
+before(async () => {
+  try {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+    await page.setContent(FIXTURE, { waitUntil: 'load' });
+  } catch (e) {
+    launchError = e;
+  }
+});
+
+after(async () => {
+  await browser?.close().catch(() => {});
+});
+
+function browserUnavailable(t: { skip: (m?: string) => void }): boolean {
+  if (launchError) { t.skip(`chromium unavailable: ${launchError}`); return true; }
+  return false;
+}
+
+test('a numerals-only face is not reported as the family that rendered the text', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+
+  for (const style of styles) {
+    assert.notEqual(style.family, 'NumeralsOnly', `NumeralsOnly reported for ${style.context}`);
+  }
+  assert.ok(
+    styles.some((s) => s.family === 'BrandSans'),
+    `expected BrandSans, got ${JSON.stringify(styles.map((s) => s.family))}`,
+  );
+});
+
+test('the family that was skipped is still listed as a fallback, not lost', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  const sans = styles.find((s) => s.family === 'BrandSans');
+  assert.ok(sans);
+  assert.ok(sans.fallbacks?.includes('NumeralsOnly'));
+});
+
+test('a mono face used only in code blocks is extracted, under its own context', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  const mono = styles.find((s) => s.family === 'BrandMono');
+  assert.ok(mono, `expected BrandMono, got ${JSON.stringify(styles.map((s) => s.family))}`);
+  assert.equal(mono.context, 'mono');
+});
+
+test('a role-qualified name does not win semantic.primary', async (t) => {
+  if (browserUnavailable(t)) return;
+  const { semantic } = await extractColors(page!);
+
+  // `.foreground-primary` names the text on a surface, not the brand primary,
+  // and it comes last in the DOM, where last-write-wins used to hand it the slot.
+  assert.notEqual(semantic.primary, 'rgb(18, 23, 21)');
+  assert.equal(semantic.primary, 'rgb(0, 220, 130)');
+});

--- a/test/typography-family-fixture.test.ts
+++ b/test/typography-family-fixture.test.ts
@@ -14,6 +14,10 @@ const FIXTURE =
   // A numerals-only face, declared the way tabular-figure fonts are.
   `@font-face { font-family: 'NumeralsOnly'; src: url(data:font/woff2;base64,AA) format('woff2'); unicode-range: U+30-39; }` +
   `@font-face { font-family: 'BrandSans'; src: url(data:font/woff2;base64,AA) format('woff2'); }` +
+  // Split across subsets the way a font loader emits it: one face has no Latin,
+  // and the family still renders letters through the other.
+  `@font-face { font-family: 'BrandMono'; src: url(data:font/woff2;base64,AA) format('woff2'); unicode-range: U+0460-052F; }` +
+  `@font-face { font-family: 'BrandMono'; src: url(data:font/woff2;base64,AA) format('woff2'); unicode-range: U+0000-00FF; }` +
   `body { font-family: 'NumeralsOnly', 'BrandSans', sans-serif; }` +
   `code, pre { font-family: 'BrandMono', monospace; font-size: 14px; }` +
   `.brand-primary { background: #00dc82; color: #fff; }` +
@@ -69,6 +73,12 @@ test('the family that was skipped is still listed as a fallback, not lost', asyn
   const sans = styles.find((s) => s.family === 'BrandSans');
   assert.ok(sans);
   assert.ok(sans.fallbacks?.includes('NumeralsOnly'));
+});
+
+test('a family is glyphless only when none of its subsets covers letters', async (t) => {
+  if (browserUnavailable(t)) return;
+  const styles = (await extractTypography(page!)).styles as TypographyStyle[];
+  assert.ok(styles.some((s) => s.family === 'BrandMono'), 'a subsetted family must not be skipped');
 });
 
 test('a mono face used only in code blocks is extracted, under its own context', async (t) => {


### PR DESCRIPTION
A numerals-only face is declared with a `unicode-range` covering digits, renders no letters, and was still reported as the family. The family is now the first in the stack that can cover A-Z; the skipped one stays in `fallbacks`.

`code`, `pre`, `kbd` and `samp` were not in the element selector, so a mono family used only in code blocks never appeared. Added under a `mono` context.

`foreground-primary` and `text-primary` could claim `semantic.primary`, last write winning. Role-qualified names are excluded.

Fixture tests for each; all three fail without the fix. Chroma threshold in the neutral-primary rescue is untouched, see DEM-311.