### PR TITLE
stop publishing the compiled test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     }
   },
   "files": [
-    "dist/"
+    "dist/",
+    "!dist/test/"
   ],
   "scripts": {
     "start": "node dist/index.js",


### PR DESCRIPTION
`files: ["dist/"]` took the whole build output, so every install carried 172 compiled test files and their fixtures.

```
tarball     536 KB -> 356 KB
installed   3.4 MB -> 1.9 MB
dist/test   172 files -> 0
```

The fixtures are extraction snapshots of third-party sites, redistributed inside the package rather than as the `examples/` files that carry a rationale.

`.npmignore` already excludes `test/` and `*.test.js`; the `files` allowlist wins over it, which is why neither rule applied.

Verified by packing and installing into a clean directory: the CLI reports its version and the MCP server completes an initialize handshake from the installed package. Related: DEM-215.