### PR TITLE
a missing robots.txt is not one we could not read

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -119,6 +119,8 @@ By default a `robots.txt` disallow warns and the run continues. That is right wh
 
 It is not right where nobody is deciding. Set `DEMBRANDT_ENFORCE_ROBOTS=1` in scheduled jobs, containers and any server-side use, and a disallow — or a `robots.txt` that cannot be read at all — skips the target with exit `4` before the browser is launched. Both the CLI and the MCP server honour it.
 
+A site with no `robots.txt` is not a site that refused: a `404` means there are no rules to honour and the run proceeds. `401`, `403`, `429` and any `5xx` are answers we could not read, and those skip.
+
 Exit `4` is a decision by the site, not a failure of the run, so a job that iterates over URLs should count it separately from `2` rather than failing the build:
 
 ```bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -119,7 +119,7 @@ By default a `robots.txt` disallow warns and the run continues. That is right wh
 
 It is not right where nobody is deciding. Set `DEMBRANDT_ENFORCE_ROBOTS=1` in scheduled jobs, containers and any server-side use, and a disallow — or a `robots.txt` that cannot be read at all — skips the target with exit `4` before the browser is launched. Both the CLI and the MCP server honour it.
 
-A site with no `robots.txt` is not a site that refused: a `404` means there are no rules to honour and the run proceeds. `401`, `403`, `429` and any `5xx` are answers we could not read, and those skip.
+A site with no `robots.txt` is not a site that refused: `404` and `410` mean there are no rules to honour and the run proceeds. Every other response we cannot read as rules — a refusal, a rate limit, a bot wall, a `5xx` — skips.
 
 Exit `4` is a decision by the site, not a failure of the run, so a job that iterates over URLs should count it separately from `2` rather than failing the build:
 

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -11,13 +11,14 @@ interface RobotsGroup {
   rules: RobotsRule[];
 }
 
+const REFUSAL_STATUSES = new Set([401, 403, 429]);
+
 export type RobotsResult =
   | { status: "absent"; robotsUrl: string }
   | { status: "unavailable"; robotsUrl: string }
   | { status: "ok"; robotsUrl: string; allowed: boolean; rule: string | null };
 
 export type RobotsRules =
-  /** `absent`: no robots.txt to read (4xx). `unavailable`: it exists but we could not read it. */
   | { status: "absent" }
   | { status: "unavailable" }
   | { status: "ok"; robotsUrl: string; rules: RobotsRule[]; sitemaps: string[] };
@@ -42,9 +43,7 @@ export async function fetchRobotsRules(
       signal: controller.signal,
       headers: { "User-Agent": ROBOTS_AGENT },
     });
-    // RFC 9309: 4xx means there are no rules, 5xx means treat everything as
-    // disallowed. Collapsing the two skips a site that simply has no file.
-    if (res.status >= 400 && res.status < 500 && res.status !== 429) return { status: "absent" };
+    if (res.status >= 400 && res.status < 500 && !REFUSAL_STATUSES.has(res.status)) return { status: "absent" };
     if (!res.ok) return { status: "unavailable" };
     body = await res.text();
     // A bot wall answers 200 with HTML, which parses to no rules and would read

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -12,10 +12,13 @@ interface RobotsGroup {
 }
 
 export type RobotsResult =
+  | { status: "absent"; robotsUrl: string }
   | { status: "unavailable"; robotsUrl: string }
   | { status: "ok"; robotsUrl: string; allowed: boolean; rule: string | null };
 
 export type RobotsRules =
+  /** `absent`: no robots.txt to read (4xx). `unavailable`: it exists but we could not read it. */
+  | { status: "absent" }
   | { status: "unavailable" }
   | { status: "ok"; robotsUrl: string; rules: RobotsRule[]; sitemaps: string[] };
 
@@ -39,6 +42,9 @@ export async function fetchRobotsRules(
       signal: controller.signal,
       headers: { "User-Agent": ROBOTS_AGENT },
     });
+    // RFC 9309: 4xx means there are no rules, 5xx means treat everything as
+    // disallowed. Collapsing the two skips a site that simply has no file.
+    if (res.status >= 400 && res.status < 500 && res.status !== 429) return { status: "absent" };
     if (!res.ok) return { status: "unavailable" };
     body = await res.text();
     // A bot wall answers 200 with HTML, which parses to no rules and would read
@@ -69,6 +75,7 @@ export function robotsVerdict(
   robots: RobotsResult,
   { enforce }: { enforce: boolean },
 ): RobotsVerdict {
+  if (robots.status === 'absent') return { action: 'proceed' };
   if (robots.status === 'unavailable') {
     return enforce ? { action: 'refuse', reason: 'robots.txt could not be read' } : { action: 'proceed' };
   }
@@ -86,7 +93,7 @@ export function evaluatePath(rules: RobotsRule[], path: string): { allowed: bool
 export function checkAgainstRules(targetUrl: string, rules: RobotsRules): RobotsResult {
   const u = new URL(targetUrl);
   if (rules.status !== "ok") {
-    return { status: "unavailable", robotsUrl: `${u.protocol}//${u.host}/robots.txt` };
+    return { status: rules.status, robotsUrl: `${u.protocol}//${u.host}/robots.txt` };
   }
   return { status: "ok", robotsUrl: rules.robotsUrl, ...evaluatePath(rules.rules, u.pathname || "/") };
 }

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -11,7 +11,7 @@ interface RobotsGroup {
   rules: RobotsRule[];
 }
 
-const REFUSAL_STATUSES = new Set([401, 403, 429]);
+const ABSENT_STATUSES = new Set([404, 410]);
 
 export type RobotsResult =
   | { status: "absent"; robotsUrl: string }
@@ -43,7 +43,7 @@ export async function fetchRobotsRules(
       signal: controller.signal,
       headers: { "User-Agent": ROBOTS_AGENT },
     });
-    if (res.status >= 400 && res.status < 500 && !REFUSAL_STATUSES.has(res.status)) return { status: "absent" };
+    if (ABSENT_STATUSES.has(res.status)) return { status: "absent" };
     if (!res.ok) return { status: "unavailable" };
     body = await res.text();
     // A bot wall answers 200 with HTML, which parses to no rules and would read

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -66,6 +66,7 @@ test('fetchRobotsRules: falls back to * when there is no Dembrandt-specific grou
 
 test('fetchRobotsRules: absent on 4xx, unavailable on 5xx or a network failure', async () => {
   assert.deepEqual(await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/')), { status: 'absent' });
+  assert.deepEqual(await withMockFetch('', 410, () => fetchRobotsRules('https://example.com/')), { status: 'absent' });
   assert.deepEqual(await withMockFetch('', 500, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
   assert.deepEqual(await withMockFetch(null, 0, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
 });
@@ -214,7 +215,7 @@ test('a missing robots.txt is not the same as one we could not read', async () =
 });
 
 test('a refusal or a rate limit is unreadable, not absent', async () => {
-  for (const status of [401, 403, 429]) {
+  for (const status of [401, 403, 418, 429]) {
     const refused = await withMockFetch('', status, () => fetchRobotsRules('https://example.com/'));
     assert.equal(refused.status, 'unavailable', `status ${status}`);
     assert.equal(

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -199,9 +199,6 @@ test('checkAgainstRules: evaluates a path against rules already fetched', () => 
 });
 
 test('a missing robots.txt is not the same as one we could not read', async () => {
-  // RFC 9309: 4xx means there are no rules to honour, 5xx means honour all of
-  // them. Collapsing the two makes an enforcing run skip a site that simply has
-  // no file.
   const absent = await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/'));
   assert.equal(absent.status, 'absent');
   assert.deepEqual(robotsVerdict(checkAgainstRules('https://example.com/', absent), { enforce: true }), {
@@ -216,7 +213,13 @@ test('a missing robots.txt is not the same as one we could not read', async () =
   );
 });
 
-test('a rate-limited robots.txt is unreadable, not absent', async () => {
-  const limited = await withMockFetch('', 429, () => fetchRobotsRules('https://example.com/'));
-  assert.equal(limited.status, 'unavailable');
+test('a refusal or a rate limit is unreadable, not absent', async () => {
+  for (const status of [401, 403, 429]) {
+    const refused = await withMockFetch('', status, () => fetchRobotsRules('https://example.com/'));
+    assert.equal(refused.status, 'unavailable', `status ${status}`);
+    assert.equal(
+      robotsVerdict(checkAgainstRules('https://example.com/', refused), { enforce: true }).action,
+      'refuse',
+    );
+  }
 });

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -7,7 +7,7 @@ function withMockFetch<T>(body: string | null, status: number, run: () => Promis
   globalThis.fetch = (async () =>
     body === null
       ? Promise.reject(new Error('network error'))
-      : { ok: status >= 200 && status < 300, text: async () => body }) as unknown as typeof fetch;
+      : { ok: status >= 200 && status < 300, status, text: async () => body }) as unknown as typeof fetch;
   return run().finally(() => {
     globalThis.fetch = original;
   });
@@ -64,8 +64,9 @@ test('fetchRobotsRules: falls back to * when there is no Dembrandt-specific grou
   if (rules.status === 'ok') assert.deepEqual(rules.rules, [{ type: 'disallow', value: '/admin' }]);
 });
 
-test('fetchRobotsRules: unavailable on a non-2xx response or network failure', async () => {
-  assert.deepEqual(await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
+test('fetchRobotsRules: absent on 4xx, unavailable on 5xx or a network failure', async () => {
+  assert.deepEqual(await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/')), { status: 'absent' });
+  assert.deepEqual(await withMockFetch('', 500, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
   assert.deepEqual(await withMockFetch(null, 0, () => fetchRobotsRules('https://example.com/')), { status: 'unavailable' });
 });
 
@@ -195,4 +196,27 @@ test('checkAgainstRules: evaluates a path against rules already fetched', () => 
   });
   assert.equal(checkAgainstRules('https://example.com/pricing', rules).status === 'ok', true);
   assert.equal(checkAgainstRules('https://example.com/x', { status: 'unavailable' }).status, 'unavailable');
+});
+
+test('a missing robots.txt is not the same as one we could not read', async () => {
+  // RFC 9309: 4xx means there are no rules to honour, 5xx means honour all of
+  // them. Collapsing the two makes an enforcing run skip a site that simply has
+  // no file.
+  const absent = await withMockFetch('', 404, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(absent.status, 'absent');
+  assert.deepEqual(robotsVerdict(checkAgainstRules('https://example.com/', absent), { enforce: true }), {
+    action: 'proceed',
+  });
+
+  const unreadable = await withMockFetch('', 503, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(unreadable.status, 'unavailable');
+  assert.equal(
+    robotsVerdict(checkAgainstRules('https://example.com/', unreadable), { enforce: true }).action,
+    'refuse',
+  );
+});
+
+test('a rate-limited robots.txt is unreadable, not absent', async () => {
+  const limited = await withMockFetch('', 429, () => fetchRobotsRules('https://example.com/'));
+  assert.equal(limited.status, 'unavailable');
 });


### PR DESCRIPTION
Enforcement treated every unreadable response as a refusal, 404 included. RFC 9309 separates them: 4xx means there are no rules to honour, 5xx means honour all of them.

A site that simply has no `robots.txt` was skipped by an enforcing run, which is the opposite of what its absence says. `429` stays unreadable, since a rate limit is not an answer.

Found by dry-running the weekly liveness list against the identifying agent before its first scheduled run: of the four sites it would have skipped, one had no file at all.