### PR TITLE
decide robots on the origin we landed on, and match the group we send

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import { mergeResults } from "./lib/merger.js";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { checkAgainstRules, fetchRobotsRules, filterAllowedUrls, robotsVerdict, ROBOTS_AGENT, type RobotsRules } from "./lib/robots.js";
+import { checkAgainstRules, fetchRobotsRules, filterAllowedUrls, robotsAgentFor, robotsVerdict, type RobotsRules } from "./lib/robots.js";
 import { EXIT, classifyError } from "./lib/exit-codes.js";
 import { activeFlags, pathSummary } from "./lib/run-summary.js";
 import { consumeCloudHint } from "./lib/cli-state.js";
@@ -45,11 +45,6 @@ function sameOrigin(a: string, b: string): boolean {
 function sitemapsFrom(rules: RobotsRules, targetUrl: string): string[] {
   if (rules.status !== "ok" || !sameOrigin(rules.robotsUrl, targetUrl)) return [];
   return rules.sitemaps;
-}
-
-/** A run that names itself can be allowed or refused by name in robots.txt. */
-function identifiesAsBot(userAgent: string | undefined): boolean {
-  return !!userAgent && userAgent.toLowerCase().includes("dembrandt");
 }
 
 /**
@@ -146,7 +141,7 @@ program
     // they have the right to fetch, so there the robots decision has to bind.
     const enforceRobots = process.env.DEMBRANDT_ENFORCE_ROBOTS === "1";
     // Only the group matching the User-Agent we actually send applies to us.
-    const robotsAgent = identifiesAsBot(opts.userAgent) ? ROBOTS_AGENT : "*";
+    const robotsAgent = robotsAgentFor(opts.userAgent);
 
     // One fetch per origin for the whole run: the entry check, the sitemap
     // directives and the crawl filter all read the same file.
@@ -283,8 +278,40 @@ program
             _version: version,
           });
 
-          if (entryRobotsWarning && result.meta) {
-            result.meta.robotsWarnings = [entryRobotsWarning];
+          // A redirect can land on another origin, whose robots.txt is a
+          // different file and has not been consulted for this page yet.
+          const landedElsewhere = !sameOrigin(url, result.url);
+          const landingRobotsRules = landedElsewhere
+            ? await fetchRobotsRules(result.url, { agent: robotsAgent }).catch(
+                () => ({ status: "unavailable" }) as RobotsRules,
+              )
+            : entryRobotsRules;
+
+          let redirectRobotsWarning = null;
+          if (landedElsewhere) {
+            const verdict = robotsVerdict(checkAgainstRules(result.url, landingRobotsRules), {
+              enforce: enforceRobots,
+            });
+            if (verdict.action === "refuse") {
+              spinner.fail(
+                `${verdict.reason}. Skipping ${result.url}, redirected from ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).`
+              );
+              process.exit(EXIT.ROBOTS_DENIED);
+            }
+            if (verdict.action === "warn") {
+              redirectRobotsWarning = `robots.txt disallows ${result.url} (rule: "${verdict.rule}")`;
+              if (!opts.jsonOnly) {
+                spinner.warn(
+                  chalk.hex("#FFB86C")(`${verdict.reason}. Proceeding anyway — respect the site's terms.`)
+                );
+                spinner.start("Continuing...");
+              }
+            }
+          }
+
+          const robotsWarnings = [entryRobotsWarning, redirectRobotsWarning].filter(Boolean);
+          if (robotsWarnings.length > 0 && result.meta) {
+            result.meta.robotsWarnings = robotsWarnings;
           }
 
           // Build list of additional URLs to extract
@@ -313,12 +340,9 @@ program
           delete result._discoveredLinks;
 
           if (additionalUrls.length > 0) {
-            // A redirect can land on a different origin, whose robots.txt is a
-            // different file; reuse the entry rules only when the origin holds.
-            const robotsRules = sameOrigin(url, result.url)
-              ? entryRobotsRules
-              : await fetchRobotsRules(result.url, { agent: robotsAgent });
-            const { allowed, disallowed } = filterAllowedUrls(additionalUrls, robotsRules);
+            const { allowed, disallowed } = filterAllowedUrls(additionalUrls, landingRobotsRules, {
+              enforce: enforceRobots,
+            });
             if (disallowed.length > 0) {
               if (!opts.jsonOnly) {
                 spinner.warn(

--- a/index.ts
+++ b/index.ts
@@ -296,6 +296,8 @@ program
               spinner.fail(
                 `${verdict.reason}. Skipping ${result.url}, redirected from ${url} (DEMBRANDT_ENFORCE_ROBOTS=1).`
               );
+              // process.exit skips the finally that owns the browser.
+              if (browser) await browser.close();
               process.exit(EXIT.ROBOTS_DENIED);
             }
             if (verdict.action === "warn") {

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -84,6 +84,11 @@ export function robotsVerdict(
   return enforce ? { action: 'refuse', reason } : { action: 'warn', reason, rule: robots.rule };
 }
 
+/** A run that names itself can be allowed or refused by name in robots.txt. */
+export function robotsAgentFor(userAgent: string | undefined): string {
+  return userAgent && userAgent.toLowerCase().includes("dembrandt") ? ROBOTS_AGENT : "*";
+}
+
 export function evaluatePath(rules: RobotsRule[], path: string): { allowed: boolean; rule: string | null } {
   return evaluate(rules, path);
 }
@@ -106,13 +111,18 @@ export async function checkRobotsTxt(
 
 /**
  * Split discovered crawl URLs into those robots.txt allows and those it
- * doesn't, using an already-fetched rule set. Unavailable robots.txt allows
- * everything through, matching checkRobotsTxt's fail-open behaviour.
+ * doesn't, using an already-fetched rule set. Follows the same truth table as
+ * robotsVerdict: an unreadable robots.txt allows everything through unless the
+ * run enforces, and an absent one always does.
  */
 export function filterAllowedUrls(
   urls: string[],
   robotsRules: RobotsRules,
+  { enforce = false }: { enforce?: boolean } = {},
 ): { allowed: string[]; disallowed: { url: string; rule: string | null }[] } {
+  if (robotsRules.status === "unavailable" && enforce) {
+    return { allowed: [], disallowed: urls.map((url) => ({ url, rule: null })) };
+  }
   if (robotsRules.status !== "ok") return { allowed: urls, disallowed: [] };
   const allowed: string[] = [];
   const disallowed: { url: string; rule: string | null }[] = [];

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -23,7 +23,7 @@ import { mergeResults } from "./lib/merger.js";
 import { additionalPages, discoveryBudget, extractOptions, isMultiPage, launchArgs } from "./lib/mcp/options.js";
 import type { Extraction, ExtractionRequest } from "./lib/mcp/options.js";
 import { JobQueue, resolveExtraction } from "./lib/mcp/jobs.js";
-import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from "./lib/robots.js";
+import { checkRobotsTxt, fetchRobotsRules, filterAllowedUrls, robotsAgentFor, robotsVerdict } from "./lib/robots.js";
 
 const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
@@ -75,9 +75,12 @@ async function runExtraction(url: string, options: ExtractionRequest = {}) {
 
   // Checked before the fetch, and before the browser: an enforcing run has to be
   // able to not make the request, and the warning is only honest if it precedes it.
-  const entryRobots = await checkRobotsTxt(url).catch(() => null);
+  const enforceRobots = process.env.DEMBRANDT_ENFORCE_ROBOTS === "1";
+  // Only the group matching the User-Agent we actually send applies to us.
+  const robotsAgent = robotsAgentFor(options.userAgent);
+  const entryRobots = await checkRobotsTxt(url, { agent: robotsAgent }).catch(() => null);
   const verdict = entryRobots
-    ? robotsVerdict(entryRobots, { enforce: process.env.DEMBRANDT_ENFORCE_ROBOTS === "1" })
+    ? robotsVerdict(entryRobots, { enforce: enforceRobots })
     : { action: "proceed" as const };
 
   if (verdict.action === "refuse") {
@@ -124,8 +127,8 @@ async function runExtraction(url: string, options: ExtractionRequest = {}) {
     delete first._discoveredLinks;
 
     if (extraUrls.length > 0) {
-      const robotsRules = await fetchRobotsRules(first.url);
-      const { allowed, disallowed } = filterAllowedUrls(extraUrls, robotsRules);
+      const robotsRules = await fetchRobotsRules(first.url, { agent: robotsAgent });
+      const { allowed, disallowed } = filterAllowedUrls(extraUrls, robotsRules, { enforce: enforceRobots });
       if (disallowed.length > 0) {
         extraUrls = allowed;
         if (first.meta) {

--- a/test/mcp-robots.test.ts
+++ b/test/mcp-robots.test.ts
@@ -1,0 +1,93 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+/**
+ * The MCP server has to match the robots.txt group that governs the User-Agent
+ * it sends, exactly as the CLI does. Reading the `*` group while announcing
+ * ourselves means a site can refuse us by name with no effect, which is a
+ * refusal read as permission.
+ */
+
+const SERVER = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'mcp-server.js');
+
+const ROBOTS = 'User-agent: *\nAllow: /\n\nUser-agent: Dembrandt\nDisallow: /\n';
+
+const PAGE = `<!doctype html>
+<html><head><meta charset="utf-8"><title>MCP fixture</title><style>
+  :root { --brand-ink: #1d4ed8; }
+  body { margin: 0; font-family: Georgia, serif; font-size: 16px; line-height: 1.5;
+         color: #202124; background: #ffffff; }
+  h1 { font-size: 32px; font-weight: 700; letter-spacing: -0.5px; }
+  .cta { background: var(--brand-ink); color: #ffffff; border-radius: 8px;
+         padding: 16px 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); border: 0; }
+  .card { border-radius: 8px; padding: 24px; box-shadow: 0 8px 24px rgba(0,0,0,0.15); }
+</style></head>
+<body>
+  <header><h1>MCP fixture</h1></header>
+  <main>
+    <p>Body copy so the body font and size are measured on real text.</p>
+    <div class="card"><p>Card copy.</p><button class="cta">Primary action</button></div>
+  </main>
+</body></html>`;
+
+const NAMED_UA = 'Mozilla/5.0 (X11; Linux x86_64) Chrome/136.0.0.0 Dembrandt/test (+https://dembrandt.com/bot)';
+const PLAIN_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+let server: Server;
+let origin: string;
+let client: Client;
+
+async function getTokens(userAgent: string): Promise<string> {
+  const result = (await client.callTool({
+    name: 'get_design_tokens',
+    arguments: { url: origin, sync: true, userAgent },
+  })) as { content: Array<{ type: string; text: string }> };
+  return result.content.map((c) => c.text).join('\n');
+}
+
+before(async () => {
+  server = createServer((req, res) => {
+    if (req.url === '/robots.txt') {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(ROBOTS);
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(PAGE);
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'server did not bind a port');
+  origin = `http://127.0.0.1:${address.port}`;
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER],
+    env: { ...process.env, DEMBRANDT_ENFORCE_ROBOTS: '1' } as Record<string, string>,
+  });
+  client = new Client({ name: 'robots-smoke', version: '1' });
+  await client.connect(transport);
+});
+
+after(async () => {
+  await client?.close();
+  server?.close();
+});
+
+test('a run that names itself is refused by the group naming it', { timeout: 120_000 }, async () => {
+  const text = await getTokens(NAMED_UA);
+  assert.match(text, /Skipping/);
+  assert.match(text, /DEMBRANDT_ENFORCE_ROBOTS=1/);
+});
+
+test('the same site under an unnamed run reads the * group and proceeds', { timeout: 180_000 }, async () => {
+  const text = await getTokens(PLAIN_UA);
+  assert.doesNotMatch(text, /Skipping/);
+  const result = JSON.parse(text);
+  assert.ok(result.typography.styles.length > 0, 'nothing was extracted');
+});

--- a/test/robots-redirect-e2e.test.ts
+++ b/test/robots-redirect-e2e.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { after, before, test } from 'node:test';
+
+/**
+ * A redirect to another origin lands on a robots.txt the entry check never
+ * read. Only the real CLI can catch that wiring: the entry URL is allowed, and
+ * the decision that matters is taken after navigation.
+ */
+
+const run = promisify(execFile);
+const indexJs = fileURLToPath(new URL('../index.js', import.meta.url));
+
+const PAGE = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Landing fixture</title><style>
+  :root { --brand-ink: #1d4ed8; }
+  body { margin: 0; font-family: Georgia, serif; font-size: 16px; line-height: 1.5;
+         color: #202124; background: #ffffff; }
+  h1 { font-size: 32px; font-weight: 700; letter-spacing: -0.5px; }
+  .cta { background: var(--brand-ink); color: #ffffff; border-radius: 8px;
+         padding: 16px 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); border: 0; }
+  .card { border-radius: 8px; padding: 24px; box-shadow: 0 8px 24px rgba(0,0,0,0.15); }
+  @media (min-width: 768px) { .card { padding: 32px; } }
+</style></head>
+<body>
+  <header><h1>Landing fixture</h1></header>
+  <main>
+    <p>Body copy so the body font and size are measured on real text.</p>
+    <div class="card"><p>Card copy.</p><button class="cta">Primary action</button></div>
+  </main>
+</body></html>`;
+
+let landing: Server;
+let entry: Server;
+let landingOrigin: string;
+let entryOrigin: string;
+let workdir: string;
+
+before(async () => {
+  landing = createServer((req, res) => {
+    if (req.url === '/robots.txt') {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('User-agent: *\nDisallow: /\n');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(PAGE);
+  });
+
+  entry = createServer((req, res) => {
+    // No robots.txt of its own: the entry origin reserves nothing, so the run
+    // gets past the entry check and the landing origin is the only refusal.
+    if (req.url === '/robots.txt') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(302, { location: landingOrigin + '/' });
+    res.end();
+  });
+
+  await new Promise<void>(resolve => landing.listen(0, '127.0.0.1', resolve));
+  await new Promise<void>(resolve => entry.listen(0, '127.0.0.1', resolve));
+  const l = landing.address();
+  const e = entry.address();
+  assert.ok(l && typeof l === 'object' && e && typeof e === 'object', 'servers did not bind');
+  landingOrigin = `http://127.0.0.1:${l.port}`;
+  entryOrigin = `http://127.0.0.1:${e.port}`;
+  workdir = mkdtempSync(join(tmpdir(), 'dembrandt-robots-e2e-'));
+});
+
+after(() => {
+  landing?.close();
+  entry?.close();
+  if (workdir) rmSync(workdir, { recursive: true, force: true });
+});
+
+test('an enforcing run refuses the origin it was redirected to', { timeout: 180_000 }, async () => {
+  const err = await run('node', [indexJs, entryOrigin, '--json-only'], {
+    cwd: workdir,
+    encoding: 'utf8',
+    timeout: 170_000,
+    env: { ...process.env, DEMBRANDT_ENFORCE_ROBOTS: '1', DEMBRANDT_NO_HINTS: '1' },
+  }).then(() => null, (e) => e);
+
+  assert.ok(err, 'the run should not have succeeded');
+  assert.equal(err.code, 4);
+  assert.match(err.stderr, /redirected from/);
+});
+
+test('the same redirect only warns when nobody is enforcing', { timeout: 180_000 }, async () => {
+  const { stdout } = await run('node', [indexJs, entryOrigin, '--json-only'], {
+    cwd: workdir,
+    encoding: 'utf8',
+    timeout: 170_000,
+    maxBuffer: 8 * 1024 * 1024,
+    env: { ...process.env, DEMBRANDT_NO_HINTS: '1' },
+  });
+
+  const result = JSON.parse(stdout);
+  assert.equal(new URL(result.url).port, new URL(landingOrigin).port);
+  assert.match(result.meta.robotsWarnings.join(' '), /robots\.txt disallows/);
+});

--- a/test/robots.test.ts
+++ b/test/robots.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { checkAgainstRules, checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls, robotsVerdict } from '../lib/robots.js';
+import { checkAgainstRules, checkRobotsTxt, evaluatePath, fetchRobotsRules, filterAllowedUrls, robotsAgentFor, robotsVerdict } from '../lib/robots.js';
 
 function withMockFetch<T>(body: string | null, status: number, run: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
@@ -222,5 +222,46 @@ test('a refusal or a rate limit is unreadable, not absent', async () => {
       robotsVerdict(checkAgainstRules('https://example.com/', refused), { enforce: true }).action,
       'refuse',
     );
+  }
+});
+
+test('robotsAgentFor: the group we match follows the User-Agent we send', () => {
+  assert.equal(robotsAgentFor(undefined), '*');
+  assert.equal(robotsAgentFor('Mozilla/5.0 (X11) Chrome/136.0.0.0 Safari/537.36'), '*');
+  assert.equal(robotsAgentFor('Mozilla/5.0 Chrome/136 Dembrandt/0.32.1 (+https://dembrandt.com/bot)'), 'Dembrandt');
+  assert.equal(robotsAgentFor('custom dembrandt runner'), 'Dembrandt');
+});
+
+test('filterAllowedUrls: an unreadable robots.txt allows nothing when the run enforces', () => {
+  const urls = ['https://example.com/a', 'https://example.com/b'];
+
+  assert.deepEqual(filterAllowedUrls(urls, { status: 'unavailable' }, { enforce: true }), {
+    allowed: [],
+    disallowed: [{ url: urls[0], rule: null }, { url: urls[1], rule: null }],
+  });
+  assert.deepEqual(filterAllowedUrls(urls, { status: 'unavailable' }, { enforce: false }), {
+    allowed: urls,
+    disallowed: [],
+  });
+  // The default is the advisory posture, so an omitted option never enforces.
+  assert.deepEqual(filterAllowedUrls(urls, { status: 'unavailable' }), { allowed: urls, disallowed: [] });
+  assert.deepEqual(filterAllowedUrls(urls, { status: 'absent' }, { enforce: true }), {
+    allowed: urls,
+    disallowed: [],
+  });
+});
+
+test('filterAllowedUrls and robotsVerdict answer the same question the same way', () => {
+  const url = 'https://example.com/x';
+  for (const enforce of [true, false]) {
+    for (const rules of [{ status: 'absent' } as const, { status: 'unavailable' } as const]) {
+      const verdict = robotsVerdict(checkAgainstRules(url, rules), { enforce });
+      const { allowed } = filterAllowedUrls([url], rules, { enforce });
+      assert.equal(
+        allowed.length === 1,
+        verdict.action !== 'refuse',
+        `${rules.status} under enforce=${enforce}`,
+      );
+    }
   }
 });


### PR DESCRIPTION
Two holes in the same path, both from #202, both the shape where a refusal reads as permission.

A redirect can land on another origin. Its robots.txt is a different file, and until now nothing consulted it for the page we actually extracted, so a site could disallow the path we were on and never be heard. The decision now runs after navigation, on the URL we landed on. The crawl filter had the same gap from the other side: it allowed every discovered page through whenever robots.txt was unreadable, including under DEMBRANDT_ENFORCE_ROBOTS=1, which is the one setting that exists to say no. It now follows the same truth table as the entry check.

The MCP server always matched the star group, even when the browser announced itself. That is the bug #202 fixed in the CLI, still standing in the surface with no tests. The group selection moved into lib/robots.ts so both callers read it from one place, and the agent parameter has no default that can quietly be wrong.

Tested with two local origins and a real browser: an enforcing run exits 4 on the origin it was redirected to, and warns instead when nobody is enforcing. The MCP pair drives the real server over stdio, one run refused by name and one allowed under the star group, so the group selection is proved to change the outcome rather than merely to exist. Both new tests fail on main. Which other paths deserve the same treatment before I trust this one?